### PR TITLE
Add missing PFlag lookup

### DIFF
--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -30,6 +30,7 @@ This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		appConfig.BindPFlag(cfgUnsealPeriod, cmd.PersistentFlags().Lookup(cfgUnsealPeriod))
+		appConfig.BindPFlag(cfgInit, cmd.PersistentFlags().Lookup(cfgInit))
 		appConfig.BindPFlag(cfgInitRootToken, cmd.PersistentFlags().Lookup(cfgInitRootToken))
 		appConfig.BindPFlag(cfgStoreRootToken, cmd.PersistentFlags().Lookup(cfgStoreRootToken))
 		unsealConfig.unsealPeriod = appConfig.GetDuration(cfgUnsealPeriod)


### PR DESCRIPTION
Without PFlag lookup `--init` command-line parameter has no effect