### PR TITLE
Operator: optional Vault TLS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,8 @@ jobs:
           environment:
             VAULT_ADDR: http://localhost:8200
             VAULT_TOKEN: 227e1cce-6bf7-30bb-2d2a-acc854318caf
-      - run:
-          name: Install Operator SDK
-          command:
-              go get github.com/operator-framework/operator-sdk/commands/operator-sdk
       - setup_remote_docker
       - run:
           name: Build Vault Operator
           command: |
-              cd operator
-              operator-sdk build banzaicloud/vault-operator
+              go build ./operator/cmd/vault-operator

--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -26,6 +26,8 @@ spec:
     listener:
       tcp:
         address: "0.0.0.0:8200"
+        # Uncommenting the following line and deleting tls_cert_file and tls_key_file disables TLS
+        # tls_disable: true
         tls_cert_file: /vault/tls/server.crt
         tls_key_file: /vault/tls/server.key
     ui: true

--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -89,6 +89,17 @@ func (spec *VaultSpec) HasStorageHAEnabled() bool {
 	return storageType == "consul" || cast.ToBool(storageSpecs["ha_enabled"])
 }
 
+// GetTLSDisable returns if Vault's TLS is disabled
+func (spec *VaultSpec) GetTLSDisable() bool {
+	listener := spec.getListener()
+	tcpSpecs := cast.ToStringMap(listener["tcp"])
+	return cast.ToBool(tcpSpecs["tls_disable"])
+}
+
+func (spec *VaultSpec) getListener() map[string]interface{} {
+	return cast.ToStringMap(spec.Config["listener"])
+}
+
 // GetBankVaultsImage returns the bank-vaults image to use
 func (spec *VaultSpec) GetBankVaultsImage() string {
 	if spec.BankVaultsImage == "" {


### PR DESCRIPTION
If someone defines posts a Vault CRD with the following configuration block all operator related Vault instances will drop TLS support and will not generate any certificates for Vault:
```yaml
  config:
    listener:
      tcp:
        address: "0.0.0.0:8200"
        tls_disable: true
```