### PR TITLE
cross account support for aws auth

### DIFF
--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -359,7 +359,7 @@ func (v *vault) Configure() error {
 			}
 			crossaccountrole, err := cast.ToSliceE(authMethod["crossaccountrole"])
 			if err != nil {
-				return
+				return nil
 			}
 			err = v.configureAWSCrossAccountRoles(crossaccountrole)
 			if err != nil {

--- a/vault-config.yml
+++ b/vault-config.yml
@@ -47,11 +47,20 @@ auth:
       access_key: VKIAJBRHKH6EVTTNXDHA
       secret_key: vCtSM8ZUEQ3mOFVlYPBQkf2sO6F/W7a5TVzrl3Oj
       iam_server_id_header_value: vault-dev.example.com # consider setting this to the Vault server's DNS name 
+    crossaccountrole:
+    # Add cross account number and role to assume in the cross account
+    # https://www.vaultproject.io/api/auth/aws/index.html#create-sts-role
+    - sts_account: 12345671234
+      sts_role_arn: arn:aws:iam::12345671234:role/crossaccountrole
     roles:
     # Add roles for AWS instances or principals
     # See https://www.vaultproject.io/api/auth/aws/index.html#create-role
     - name: dev-role-iam
       bound_iam_principal_arn: arn:aws:iam::123456789012:role/dev-vault
+      policies: allow_secrets
+      period: 1h
+    - name: cross-account-role
+      bound_iam_principal_arn: arn:aws:iam::12345671234:role/crossaccountrole
       policies: allow_secrets
       period: 1h
 


### PR DESCRIPTION
Added support for cross-account access under AWS auth config. Ref #139.