### PR TITLE
Support StatefuleSet upgrade with workaround

### DIFF
--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -13,11 +13,15 @@ import (
 const cfgUnsealPeriod = "unseal-period"
 const cfgInit = "init"
 const cfgOnce = "once"
+const cfgStepDownActive = "step-down-active"
+const cfgActiveNodeAddress = "active-node-address"
 
 type unsealCfg struct {
-	unsealPeriod time.Duration
-	proceedInit  bool
-	runOnce      bool
+	unsealPeriod      time.Duration
+	proceedInit       bool
+	runOnce           bool
+	stepDownActive    bool
+	activeNodeAddress string
 }
 
 var unsealConfig unsealCfg
@@ -37,9 +41,17 @@ from one of the followings:
 		appConfig.BindPFlag(cfgOnce, cmd.PersistentFlags().Lookup(cfgOnce))
 		appConfig.BindPFlag(cfgInitRootToken, cmd.PersistentFlags().Lookup(cfgInitRootToken))
 		appConfig.BindPFlag(cfgStoreRootToken, cmd.PersistentFlags().Lookup(cfgStoreRootToken))
+		appConfig.BindPFlag(cfgStepDownActive, cmd.PersistentFlags().Lookup(cfgStepDownActive))
+		appConfig.BindPFlag(cfgActiveNodeAddress, cmd.PersistentFlags().Lookup(cfgActiveNodeAddress))
 		unsealConfig.unsealPeriod = appConfig.GetDuration(cfgUnsealPeriod)
 		unsealConfig.proceedInit = appConfig.GetBool(cfgInit)
 		unsealConfig.runOnce = appConfig.GetBool(cfgOnce)
+		unsealConfig.stepDownActive = appConfig.GetBool(cfgStepDownActive)
+		unsealConfig.activeNodeAddress = appConfig.GetString(cfgActiveNodeAddress)
+
+		if unsealConfig.stepDownActive && unsealConfig.activeNodeAddress == "" {
+			logrus.Fatalf("'%s' should be also set if '%s' is enabled", cfgActiveNodeAddress, cfgStepDownActive)
+		}
 
 		store, err := kvStoreForConfig(appConfig)
 
@@ -102,6 +114,14 @@ from one of the followings:
 				}
 
 				logrus.Infof("successfully unsealed vault")
+
+				if unsealConfig.stepDownActive {
+					err = v.StepDownActive(unsealConfig.activeNodeAddress)
+					if err != nil {
+						logrus.Warnf("failed to tell active instance to step down: %s", err.Error())
+					}
+				}
+
 				exitIfNecessary(0)
 			}()
 
@@ -123,6 +143,8 @@ func init() {
 	unsealCmd.PersistentFlags().Bool(cfgOnce, false, "Run unseal only once")
 	unsealCmd.PersistentFlags().String(cfgInitRootToken, "", "root token for the new vault cluster (only if -init=true)")
 	unsealCmd.PersistentFlags().Bool(cfgStoreRootToken, true, "should the root token be stored in the key store (only if -init=true)")
+	unsealCmd.PersistentFlags().Bool(cfgStepDownActive, false, "should the active node be asked to step down")
+	unsealCmd.PersistentFlags().String(cfgActiveNodeAddress, "", "the address of the active Vault node")
 
 	rootCmd.AddCommand(unsealCmd)
 }

--- a/operator/deploy/cr-etcd-ha.yaml
+++ b/operator/deploy/cr-etcd-ha.yaml
@@ -7,6 +7,11 @@ spec:
   image: vault:0.11.0
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
+  # This option gives us the option to workaround current StatefulSet limitations around updates
+  # See: https://github.com/kubernetes/kubernetes/issues/67250
+  # By default it is false.
+  supportUpgrade: true
+
   # Describe where you would like to store the Vault unseal keys and root token.
   unsealConfig:
     kubernetes:

--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -44,6 +44,10 @@ type VaultSpec struct {
 	ExternalConfig    map[string]interface{} `json:"externalConfig"`
 	UnsealConfig      UnsealConfig           `json:"unsealConfig"`
 	CredentialsConfig CredentialsConfig      `json:"credentialsConfig"`
+	// This option gives us the option to workaround current StatefulSet limitations around updates
+	// See: https://github.com/kubernetes/kubernetes/issues/67250
+	// TODO: Should be removed once the ParallelPodManagement policy supports the broken update.
+	SupportUpgrade bool `json:"supportUpgrade"`
 }
 
 // HAStorageTypes is the set of storage backends supporting High Availability


### PR DESCRIPTION
This feature gives us the option to workaround current **StatefulSet limitations** around updates
See: https://github.com/kubernetes/kubernetes/issues/67250
By default it is set to **false**.

Fixes: #154 