### PR TITLE
etcd size for quorum fault tolerance

### DIFF
--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -113,7 +113,7 @@ func (spec *VaultSpec) GetEtcdVersion() string {
 
 // GetEtcdSize returns the number of etcd pods to use
 func (spec *VaultSpec) GetEtcdSize() int32 {
-	if spec.EtcdSize == "" || spec.EtcdSize < 1 {
+	if spec.EtcdSize < 1 {
 		return 3
 	}
 	// check if size given is even. If even, subtract 1. Reasoning: Because of raft consensus protocol,

--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -63,6 +63,7 @@ type VaultSpec struct {
 	// TODO: Should be removed once the ParallelPodManagement policy supports the broken update.
 	SupportUpgrade bool   `json:"supportUpgrade"`
 	EtcdVersion    string `json:"etcdVersion"`
+	EtcdSize       int32  `json:"etcdSize"`
 }
 
 // HAStorageTypes is the set of storage backends supporting High Availability
@@ -108,6 +109,13 @@ func (spec *VaultSpec) GetEtcdVersion() string {
 		return "3.1.15"
 	}
 	return spec.EtcdVersion
+}
+
+func (spec *VaultSpec) GetEtcdSize() int32 {
+	if spec.EtcdSize == "" {
+		return 3
+	}
+	return spec.EtcdSize
 }
 
 // HasStorageHAEnabled detects if the ha_enabled field is set to true in Vault's storage stanza

--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -63,7 +63,7 @@ type VaultSpec struct {
 	// TODO: Should be removed once the ParallelPodManagement policy supports the broken update.
 	SupportUpgrade bool   `json:"supportUpgrade"`
 	EtcdVersion    string `json:"etcdVersion"`
-	EtcdSize       int32  `json:"etcdSize"`
+	EtcdSize       int    `json:"etcdSize"`
 }
 
 // HAStorageTypes is the set of storage backends supporting High Availability
@@ -112,7 +112,7 @@ func (spec *VaultSpec) GetEtcdVersion() string {
 }
 
 // GetEtcdSize returns the number of etcd pods to use
-func (spec *VaultSpec) GetEtcdSize() int32 {
+func (spec *VaultSpec) GetEtcdSize() int {
 	if spec.EtcdSize < 1 {
 		return 3
 	}

--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -111,9 +111,16 @@ func (spec *VaultSpec) GetEtcdVersion() string {
 	return spec.EtcdVersion
 }
 
+// GetEtcdSize returns the number of etcd pods to use
 func (spec *VaultSpec) GetEtcdSize() int32 {
-	if spec.EtcdSize == "" {
+	if spec.EtcdSize == "" || spec.EtcdSize < 1 {
 		return 3
+	}
+	// check if size given is even. If even, subtract 1. Reasoning: Because of raft consensus protocol,
+	// an odd-size cluster tolerates the same number of failures as an even-size cluster but with fewer nodes
+	// See https://github.com/etcd-io/etcd/blob/master/Documentation/faq.md#what-is-failure-tolerance
+	if spec.EtcdSize%2 == 0 {
+		return spec.EtcdSize - 1
 	}
 	return spec.EtcdSize
 }

--- a/operator/pkg/stub/handler.go
+++ b/operator/pkg/stub/handler.go
@@ -605,7 +605,7 @@ func etcdForVault(v *v1alpha1.Vault) (*etcdV1beta2.EtcdCluster, error) {
 	etcdCluster.Name = etcdName
 	etcdCluster.Namespace = v.Namespace
 	etcdCluster.Labels = labelsForVault(v.Name)
-	etcdCluster.Spec.Size = 3
+	etcdCluster.Spec.Size = v.Spec.GetEtcdSize()
 	etcdCluster.Spec.Version = v.Spec.GetEtcdVersion()
 	etcdCluster.Spec.TLS = &etcdV1beta2.TLSPolicy{
 		Static: &etcdV1beta2.StaticTLS{


### PR DESCRIPTION
If etcd is chosen as a back end, the size is hard coded to 3
https://github.com/banzaicloud/bank-vaults/blob/master/operator/pkg/stub/handler.go#L608

This might cause issues if quorum is lost https://github.com/coreos/etcd-operator/issues/1972, having a size of 3 only tolerates the failure of 1 etcd pod.

Added support in the spec for etcd size

 