### PR TITLE
Added mysql to HA storage type's

### DIFF
--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -72,6 +72,7 @@ var HAStorageTypes = map[string]bool{
 	"dynamodb":  true,
 	"etcd":      true,
 	"gcs":       true,
+	"mysql":     true,
 	"spanner":   true,
 	"zookeeper": true,
 }


### PR DESCRIPTION
As of vault 0.11.0 MySQL storage supports HA.

https://github.com/hashicorp/vault/blob/master/CHANGELOG.md#0110-august-28th-2018

The code isn't tested, can someone test it?