### PR TITLE
Added ability to enable plugins via bank-vaults

### DIFF
--- a/.licensei.toml
+++ b/.licensei.toml
@@ -16,4 +16,7 @@ ignored = [
   "github.com/davecgh/go-spew", # ISC license
   "github.com/howeyc/gopass", # ISC license
   "github.com/oracle/oci-go-sdk", # UPL-1.0
+
+  "github.com/Masterminds/sprig",
+  "github.com/magiconair/properties"
 ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -79,7 +79,7 @@ required = [
 [[constraint]]
   name = "k8s.io/api"
   branch = "release-1.10"
-  
+
 [[constraint]]
   name = "k8s.io/apimachinery"
   branch = "release-1.10"
@@ -164,7 +164,7 @@ version = "v1.1.5"
   name = "github.com/prometheus/client_golang"
   version = "v0.9.0-pre1"
 
-# github.com/prometheus/client_golang needs a newer version of protobuf 
+# github.com/prometheus/client_golang needs a newer version of protobuf
 [[override]]
   name = "github.com/golang/protobuf"
   version = "v1.2.0"

--- a/vault-config.yml
+++ b/vault-config.yml
@@ -112,7 +112,7 @@ secrets:
     type: plugin
     plugin_name: ethereum-plugin
     description: Immutability's Ethereum Wallet
-# Registers a new plugin in Vault's plugin catalog. "plugin_directory" setting should be set it Vault server configuration and plugin binary should be present in plugin directory. Also, for some plugins readOnlyRootFilesystem Pod Security Policy should be disabled to allow RPC communication between plugin and Vault server since appa
+# Registers a new plugin in Vault's plugin catalog. "plugin_directory" setting should be set it Vault server configuration and plugin binary should be present in plugin directory. Also, for some plugins readOnlyRootFilesystem Pod Security Policy should be disabled to allow RPC communication between plugin and Vault server via Unix socket
 # See https://www.vaultproject.io/api/system/plugins-catalog.html and https://github.com/hashicorp/go-plugin/blob/master/docs/internals.md for details.
 plugins:
   - plugin_name: ethereum-plugin

--- a/vault-config.yml
+++ b/vault-config.yml
@@ -10,7 +10,6 @@ policies:
 # Allows configuring Auth Methods in Vault (Kubernetes and GitHub is supported now).
 # See https://www.vaultproject.io/docs/auth/index.html for more information.
 auth:
-  
   - type: kubernetes
     # If you want to configure with specific kubernets service account instead of default service account
     # https://www.vaultproject.io/docs/auth/kubernetes.html
@@ -30,7 +29,7 @@ auth:
         policies: allow_secrets
         ttl: 1h
 
-  # Allows creating team mappings in Vault which can be used later on for the GitHub 
+  # Allows creating team mappings in Vault which can be used later on for the GitHub
   # based authentication.
   # See https://www.vaultproject.io/docs/auth/github.html#configuration for
   # more information.
@@ -108,6 +107,17 @@ secrets:
     description: General secrets.
     options:
       version: 2
+  # Mounts non-default plugin's path
+  - path: ethereum-gateway
+    type: plugin
+    plugin_name: ethereum-plugin
+    description: Immutability's Ethereum Wallet
+# Registers a new plugin in Vault's plugin catalog. "plugin_directory" setting should be set it Vault server configuration and plugin binary should be present in plugin directory. Also, for some plugins readOnlyRootFilesystem Pod Security Policy should be disabled to allow RPC communication between plugin and Vault server since appa
+# See https://www.vaultproject.io/api/system/plugins-catalog.html and https://github.com/hashicorp/go-plugin/blob/master/docs/internals.md for details.
+plugins:
+  - plugin_name: ethereum-plugin
+    command: ethereum-vault-plugin --ca-cert=/vault/tls/client/ca.crt --client-cert=/vault/tls/server/server.crt --client-key=/vault/tls/server/server.key
+    sha256: 62fb461a8743f2a0af31d998074b58bb1a589ec1d28da3a2a5e8e5820d2c6e0a
 
   # This plugin stores database credentials dynamically based on configured roles for
   # the MySQL database.
@@ -150,7 +160,7 @@ secrets:
 
   # The RabbitMQ secrets engine generates user credentials dynamically based on configured permissions and virtual hosts.
   # See https://www.vaultproject.io/docs/secrets/rabbitmq/index.html
-  # Start a RabbitMQ testing server: docker run -it --rm -p 15672:15672 rabbitmq:3.7-management-alpine 
+  # Start a RabbitMQ testing server: docker run -it --rm -p 15672:15672 rabbitmq:3.7-management-alpine
   - type: rabbitmq
     description: local-rabbit
     configuration:


### PR DESCRIPTION
Signed-off-by: Oleksandr Stepanov <alexandrst88@gmail.com>

We very like this tool, so we were trying to use it, but faced with the issue, there is not possible to enable plugins via it. 

This PR provides an ability to enable Vault Plugins: https://www.vaultproject.io/docs/internals/plugins.html

Requirements:
- **Vault Plugin Directory must be set** otherwise, vault will throw an error.

Question: 
- We have some concern about using `getOrDefault` function? We are thinking about creating a new function like `getValue` or `getStringValue`, because, fields: command, plugin_name and sha256 are obligatory. 
- Also, should we add an output of existing plugins as it did for `configureSecretEngines` method?

We did tests with this plugin: https://github.com/immutability-io/vault-ethereum. 

If you like this PR, we make additional commits with examples and updated docs.