### PR TITLE
operator: add generic fluentd logging sidecar

### DIFF
--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -53,6 +53,7 @@ type VaultSpec struct {
 	Image             string                 `json:"image"`
 	BankVaultsImage   string                 `json:"bankVaultsImage"`
 	StatsDImage       string                 `json:"statsdImage"`
+	FluentDImage      string                 `json:"fluentdImage"`
 	Annotations       map[string]string      `json:"annotations"`
 	Config            map[string]interface{} `json:"config"`
 	ExternalConfig    map[string]interface{} `json:"externalConfig"`
@@ -171,6 +172,22 @@ func (spec *VaultSpec) GetAnnotations() map[string]string {
 	spec.Annotations["prometheus.io/path"] = "/metrics"
 	spec.Annotations["prometheus.io/port"] = "9102"
 	return spec.Annotations
+}
+
+// GetFluentDImage returns the StatsD image to use
+func (spec *VaultSpec) GetFluentDImage() string {
+	if spec.FluentDImage == "" {
+		return "fluent/fluentd:v0.12-onbuild"
+	}
+	return spec.FluentDImage
+}
+
+// GetFluentDEnable returns true if fluentd sidecar is to be deployed
+func (spec *VaultSpec) GetFluentDEnable() bool {
+	if spec.FluentDImage == "" {
+		return false
+	}
+	return true
 }
 
 // ConfigJSON returns the Config field as a JSON string

--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -183,7 +183,7 @@ func (spec *VaultSpec) GetFluentDImage() string {
 	return spec.FluentDImage
 }
 
-// GetFluentDEnable returns true if fluentd sidecar is to be deployed
+// IsFluentDEnabled returns true if fluentd sidecar is to be deployed
 func (spec *VaultSpec) IsFluentDEnabled() bool {
 	// zero value for bool is false
 	return spec.FluentDEnabled

--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -53,6 +53,7 @@ type VaultSpec struct {
 	Image             string                 `json:"image"`
 	BankVaultsImage   string                 `json:"bankVaultsImage"`
 	StatsDImage       string                 `json:"statsdImage"`
+	FluentDEnabled    bool                   `json:"fluentdEnabled"`
 	FluentDImage      string                 `json:"fluentdImage"`
 	Annotations       map[string]string      `json:"annotations"`
 	Config            map[string]interface{} `json:"config"`
@@ -174,20 +175,18 @@ func (spec *VaultSpec) GetAnnotations() map[string]string {
 	return spec.Annotations
 }
 
-// GetFluentDImage returns the StatsD image to use
+// GetFluentDImage returns the FluentD image to use
 func (spec *VaultSpec) GetFluentDImage() string {
 	if spec.FluentDImage == "" {
-		return "fluent/fluentd:v0.12-onbuild"
+		return "fluent/fluentd:stable"
 	}
 	return spec.FluentDImage
 }
 
 // GetFluentDEnable returns true if fluentd sidecar is to be deployed
-func (spec *VaultSpec) GetFluentDEnable() bool {
-	if spec.FluentDImage == "" {
-		return false
-	}
-	return true
+func (spec *VaultSpec) IsFluentDEnabled() bool {
+	// zero value for bool is false
+	return spec.FluentDEnabled
 }
 
 // ConfigJSON returns the Config field as a JSON string

--- a/operator/pkg/stub/handler.go
+++ b/operator/pkg/stub/handler.go
@@ -477,7 +477,7 @@ func statefulSetForVault(v *v1alpha1.Vault) (*appsv1.StatefulSet, error) {
 								Name:      "statsd-mapping",
 								MountPath: "/tmp/",
 							}},
-						},					
+						},
 					}),
 					Volumes: volumes,
 				},
@@ -788,32 +788,6 @@ func configMapForStatsD(v *v1alpha1.Vault) *v1.ConfigMap {
 			Labels:    ls,
 		},
 		Data: map[string]string{"statsd-mapping.conf": `mappings:
-    - match: vault.route.*.*
-      name: "vault_route"
-      labels:
-        method: "$1"
-        path: "$2"`},
-	}
-	addOwnerRefToObject(cm, asOwner(v))
-	return cm
-}
-
-func configMapForFluentD(v *v1alpha1.Vault) *v1.ConfigMap {
-	ls := labelsForVault(v.Name)
-	cm := &v1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ConfigMap",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      v.Name + "-fluentd-mapping",
-			Namespace: v.Namespace,
-			Labels:    ls,
-		},
-		//
-		//TODO: CHANGE MAPPINGS
-		//
-		Data: map[string]string{"fluentd-mapping.conf": `mappings:
     - match: vault.route.*.*
       name: "vault_route"
       labels:

--- a/operator/pkg/stub/handler.go
+++ b/operator/pkg/stub/handler.go
@@ -555,7 +555,7 @@ func withTLSVolumeMount(v *v1alpha1.Vault, volumeMounts []v1.VolumeMount) []v1.V
 }
 
 func withAuditLogVolume(v *v1alpha1.Vault, volumes []v1.Volume) []v1.Volume {
-	if v.Spec.GetFluentDEnable() {
+	if v.Spec.IsFluentDEnabled() {
 		volumes = append(volumes, v1.Volume{
 			Name: "vault-auditlogs",
 			VolumeSource: v1.VolumeSource{
@@ -567,7 +567,7 @@ func withAuditLogVolume(v *v1alpha1.Vault, volumes []v1.Volume) []v1.Volume {
 }
 
 func withAuditLogVolumeMount(v *v1alpha1.Vault, volumeMounts []v1.VolumeMount) []v1.VolumeMount {
-	if v.Spec.GetFluentDEnable() {
+	if v.Spec.IsFluentDEnabled() {
 		volumeMounts = append(volumeMounts, v1.VolumeMount{
 			Name:      "vault-auditlogs",
 			MountPath: "/tmp/",
@@ -577,7 +577,7 @@ func withAuditLogVolumeMount(v *v1alpha1.Vault, volumeMounts []v1.VolumeMount) [
 }
 
 func withAuditLogContainer(v *v1alpha1.Vault, owner string, containers []v1.Container) []v1.Container {
-	if v.Spec.GetFluentDEnable() {
+	if v.Spec.IsFluentDEnabled() {
 		containers = append(containers, v1.Container{
 			Image:           v.Spec.GetFluentDImage(),
 			ImagePullPolicy: v1.PullAlways,


### PR DESCRIPTION
Hello,

Here are some additions to the operator to allow a generic fluentd sidecar container. This was brought up in this issue https://github.com/banzaicloud/bank-vaults/issues/163 . We plan on using this sidecar to handle audit logging.

Everything related to this is purely optional and disabled by default.

Please let me know if you have any questions.

