### PR TITLE
Configurer needs to check if Vault is active before configuring

### DIFF
--- a/cmd/bank-vaults/configure.go
+++ b/cmd/bank-vaults/configure.go
@@ -143,13 +143,29 @@ var configureCmd = &cobra.Command{
 						continue
 					}
 
-					// If vault is not sealed, we stop here and wait another unsealPeriod
+					// If vault is sealed, we stop here and wait another unsealPeriod
 					if sealed {
 						logrus.Infof("vault is sealed, waiting %s before trying again...", unsealConfig.unsealPeriod)
 						time.Sleep(unsealConfig.unsealPeriod)
 						continue
 					}
-					logrus.Infof("vault is not sealed, configuring...")
+
+					logrus.Infof("checking if vault is active...")
+					active, err := v.Active()
+					if err != nil {
+						logrus.Errorf("error checking if vault is active: %s, waiting %s before trying again...", err.Error(), 5*time.Second)
+						time.Sleep(5 * time.Second)
+						continue
+					}
+
+					// If vault is not active, we stop here and wait another 5 seconds
+					if !active {
+						logrus.Infof("vault is not active, waiting %s before trying again...", 5*time.Second)
+						time.Sleep(5 * time.Second)
+						continue
+					}
+
+					logrus.Infof("vault is unsealed and active, configuring...")
 
 					if err = v.Configure(); err != nil {
 						logrus.Errorf("error configuring vault: %s", err.Error())


### PR DESCRIPTION
This solves a race condition when Vault hasn't mounted the auth backends/secret engines before configuring but is mounting them during configuration.