### PR TITLE
Add ability to use existing etcd cluster

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -40,3 +40,8 @@ kubectl apply -f operator/deploy/cr-etcd-ha.yaml
 ```
 
 From now on, if you deploy a Vault CRD into the cluster which has an [Etcd Storage Backend](https://www.vaultproject.io/docs/configuration/storage/etcd.html) defined in its configuration the Vault operator will create an EtcdCluster CRD for the Vault instance, and the etcd-operator will orchestrate the etcd cluster. After the etcd cluster is ready the Vault instance can connect to it and will start up. If the Vault CRD is deleted from the cluster the etcd cluster will be GCd as well. You have to make sure you define backup and restore for the etcd cluster to prevent data loss, this part is not handled by the Vault operator, see [this](https://github.com/coreos/etcd-operator#backup-and-restore-an-etcd-cluster) document for more details.
+
+## Use existing etcd
+
+If you want to use an existing etcd. You can set `etcdSize` vault to < 0. Then it won't create a new etcd.
+And all config under etcd storage will not be override.

--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -116,6 +116,11 @@ func (spec *VaultSpec) GetEtcdVersion() string {
 
 // GetEtcdSize returns the number of etcd pods to use
 func (spec *VaultSpec) GetEtcdSize() int {
+	// Default value of EctdSize is 0. So if < 0 will assume use existing etcd
+	if spec.EtcdSize < 0 {
+		return -1
+	}
+
 	if spec.EtcdSize < 1 {
 		return 3
 	}

--- a/operator/pkg/stub/handler.go
+++ b/operator/pkg/stub/handler.go
@@ -65,7 +65,8 @@ func (h *Handler) Handle(ctx types.Context, event types.Event) error {
 		}
 
 		// check if we need to create an etcd cluster
-		if v.Spec.GetStorageType() == "etcd" {
+		// if etcd size is < 0. Will not create etcd cluster
+		if v.Spec.GetStorageType() == "etcd" && v.Spec.GetEtcdSize() > 0 {
 
 			etcdCluster, err := etcdForVault(v)
 			if err != nil {
@@ -326,7 +327,9 @@ func statefulSetForVault(v *v1alpha1.Vault) (*appsv1.StatefulSet, error) {
 	volumeMounts = withAuditLogVolumeMount(v, volumeMounts)
 
 	// TODO Configure Vault to wait for etcd in an init container in this case
-	if v.Spec.GetStorageType() == "etcd" {
+	// If etcd size is < 0 means not create new etcd cluster
+	// No need to override etcd config, and use user input value
+	if v.Spec.GetStorageType() == "etcd" && v.Spec.GetEtcdSize() > 0 {
 
 		// Overwrite Vault config with the generated TLS certificate's settings
 		etcdStorage := v.Spec.GetStorage()


### PR DESCRIPTION
I have a special case. Which have to use existing etcd as vault's backend storage. 
So use EtcdSize < 0 to let operator not create new etcd cluster. And not override any setting under etcd storage section.