### PR TITLE
Add Security Context to Vault CR

### DIFF
--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"k8s.io/api/core/v1"
 	"reflect"
 
 	"github.com/spf13/cast"
@@ -60,6 +61,7 @@ type VaultSpec struct {
 	ExternalConfig    map[string]interface{} `json:"externalConfig"`
 	UnsealConfig      UnsealConfig           `json:"unsealConfig"`
 	CredentialsConfig CredentialsConfig      `json:"credentialsConfig"`
+	SecurityContext   v1.PodSecurityContext  `json:"securityContext,omitempty"`
 	// This option gives us the option to workaround current StatefulSet limitations around updates
 	// See: https://github.com/kubernetes/kubernetes/issues/67250
 	// TODO: Should be removed once the ParallelPodManagement policy supports the broken update.

--- a/operator/pkg/stub/handler.go
+++ b/operator/pkg/stub/handler.go
@@ -482,13 +482,21 @@ func statefulSetForVault(v *v1alpha1.Vault) (*appsv1.StatefulSet, error) {
 							}},
 						},
 					}),
-					Volumes: volumes,
+					Volumes:         volumes,
+					SecurityContext: withSecurityContext(v),
 				},
 			},
 		},
 	}
 	addOwnerRefToObject(dep, owner)
 	return dep, nil
+}
+
+func withSecurityContext(v *v1alpha1.Vault) *v1.PodSecurityContext {
+	if v.Spec.SecurityContext.Size() == 0 {
+		return nil
+	}
+	return &v.Spec.SecurityContext
 }
 
 func withSupportUpgradeParams(v *v1alpha1.Vault, params []string) []string {


### PR DESCRIPTION
This fixes #187 

**Edit:**
This allows users to customize the `securityContext` of the Vault Statefulset.

```yaml
apiVersion: "vault.banzaicloud.com/v1alpha1"
kind: "Vault"
metadata:
  name: "vault"
spec:
  size: 1
  image: vault:0.11.0
  bankVaultsImage: banzaicloud/bank-vaults:latest
  
  securityContext:
    runAsUser: 100
    fsGroup: 100
```