### PR TITLE
Add required s3 permission on readme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ The Access Policy in which the Pod is running has to have the following IAM Role
 The Instance profile in which the Pod is running has to have the following IAM Policies:
 
 - KMS: `kms:Encrypt, kms:Decrypt`
-- S3:  `s3:GetObject, s3:PutObject`
+- S3:  `s3:GetObject, s3:PutObject` on object level and `s3:ListBucket` on bucket level
 
 An example command how to init and unseal Vault on AWS:
 


### PR DESCRIPTION
The code required s3 return `NoSuchKey` error when perform `keyStoreNotFound` check. But if the user/role don't have `s3:ListBucket` permission on bucket level. s3 will return `AccessDenied` instead of `NoSuchKey`. It will cause an error returned. And the unseal key won't upload to s3.
End result is the vault initialized. But no any unseal key.