### PR TITLE
Support child dict on secrets engine's configuration

### DIFF
--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -826,6 +826,16 @@ func (v *vault) configureSecretEngines() error {
 				if !ok {
 					return fmt.Errorf("error finding sub config data name for secret engine")
 				}
+
+				// config data can have child dict. But it will cause `json: unsupported type: map[interface {}]interface {}`
+				// So check and replace by `map[string]interface{}` before use it.
+				for k, v := range subConfigData {
+					switch val := v.(type) {
+					case map[interface{}]interface{}:
+						subConfigData[k] = cast.ToStringMap(val)
+					}
+				}
+
 				configPath := fmt.Sprintf("%s/%s/%s", path, configOption, name)
 				_, err = v.cl.Logical().Write(configPath, subConfigData)
 


### PR DESCRIPTION
Sorry, is me again...
On SSH secret engine config. There have a `default_extensions` to contain some child config.
Example:
```
type: ssh
path: ssh-client-signer
description: SSH Client Key Signing.
configuration:
  config:
    - name: ca
      generate_signing_key: "true"
  roles:
    - name: infra
      allow_user_certificates: "true"
      default_extensions:
        permit-pty: ""
        permit-port-forwarding: ""
        permit-agent-forwarding: ""
      allowed_users: "*"
      key_type: "ca"
      default_user: "ubuntu,admin,ec2-user"
      ttl: "1h"
```
But it cause error `json: unsupported type: map[interface {}]interface {}`.

So have to check and replace by `map[string]interface{}` before use it.