### PR TITLE
Add Approle Auth backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,17 @@ auth:
       bonifaido:
         groups: developers
         policies: allow_secrets
+  # Allows machines/apps to authenticate with Vault-defined roles.
+  # See https://www.vaultproject.io/docs/auth/approle.html for more information
+  - type: approle
+    roles:
+    - name: default
+      policies: allow_secrets
+      secret_id_ttl: 10m
+      token_num_uses: 10
+      token_ttl: 20m
+      token_max_ttl: 30m
+      secret_id_num_uses: 40
 
 # Allows configuring Secrets Engines in Vault (KV, Database and SSH is tested,
 # but the config is free form so probably more is supported).

--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -488,7 +488,7 @@ func (v *vault) Configure() error {
 				}
 			}
 		case "approle":
-			roles := authMethod["roles"].([]interface{})
+			roles, err := cast.ToSliceE(authMethod["roles"])
 			if err != nil {
 				return fmt.Errorf("error finding role block for approle: %s", err.Error())
 			}


### PR DESCRIPTION
This PR adds support for Approle Authentication Backend.

An example config:
```yaml
auth:
- type: approle # https://www.vaultproject.io/docs/auth/approle.html
  roles:
  - name: default
    policies: allow_secrets,allow_certs
    secret_id_ttl: 10m
    token_num_uses: 10
    token_ttl: 20m
    token_max_ttl: 30m
    secret_id_num_uses: 40
```

```bash 
$ vault read auth/approle/role/default/

Key                   Value                          
bind_secret_id        true                           
bound_cidr_list       null                           
local_secret_ids      false                          
period                0                              
policies              ["allow_certs","allow_secrets"]
secret_id_bound_cidrs null                           
secret_id_num_uses    40                             
secret_id_ttl         600                            
token_bound_cidrs     null                           
token_max_ttl         1800                           
token_num_uses        10                             
token_ttl             1200
```