### PR TITLE
Add etcdAnnotations field to Vault CR to annotate etcdcluster

### DIFF
--- a/operator/deploy/cr-etcd-ha.yaml
+++ b/operator/deploy/cr-etcd-ha.yaml
@@ -12,6 +12,12 @@ spec:
   # By default it is false.
   supportUpgrade: true
 
+  # This option allows you to annotate the ETCD Cluster that Vault Operator creates.
+  # It's specifically to annotate the ETCD Cluster as 'clusterwide' for a cluster wide
+  # ETCD Operator, however it can be used to set any arbitrary annotations on the ETCD Cluster.
+  # etcdAnnotations:
+  #   etcd.database.coreos.com/scope: clusterwide
+  
   # Describe where you would like to store the Vault unseal keys and root token.
   unsealConfig:
     kubernetes:

--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -65,11 +65,12 @@ type VaultSpec struct {
 	// This option gives us the option to workaround current StatefulSet limitations around updates
 	// See: https://github.com/kubernetes/kubernetes/issues/67250
 	// TODO: Should be removed once the ParallelPodManagement policy supports the broken update.
-	SupportUpgrade  bool   `json:"supportUpgrade"`
-	EtcdVersion     string `json:"etcdVersion"`
-	EtcdSize        int    `json:"etcdSize"`
-	ServiceType     string `json:"serviceType"`
-	PodAntiAffinity string `json:"podAntiAffinity"`
+	SupportUpgrade  bool              `json:"supportUpgrade"`
+	EtcdVersion     string            `json:"etcdVersion"`
+	EtcdSize        int               `json:"etcdSize"`
+	EtcdAnnotations map[string]string `json:"etcdAnnotations,omitempty"`
+	ServiceType     string            `json:"serviceType"`
+	PodAntiAffinity string            `json:"podAntiAffinity"`
 }
 
 // HAStorageTypes is the set of storage backends supporting High Availability

--- a/operator/pkg/stub/handler.go
+++ b/operator/pkg/stub/handler.go
@@ -664,6 +664,7 @@ func etcdForVault(v *v1alpha1.Vault) (*etcdV1beta2.EtcdCluster, error) {
 	etcdCluster := &etcdV1beta2.EtcdCluster{}
 	etcdCluster.APIVersion = etcdV1beta2.SchemeGroupVersion.String()
 	etcdCluster.Kind = etcdV1beta2.EtcdClusterResourceKind
+	etcdCluster.Annotations = v.Spec.EtcdAnnotations
 	etcdCluster.Name = etcdName
 	etcdCluster.Namespace = v.Namespace
 	etcdCluster.Labels = labelsForVault(v.Name)


### PR DESCRIPTION
This allows users to add `spec.etcdAnnotations` to the Vault Custom Resource object which is used to annotate the `etcdcluster` Custom Resource accordingly.

This is specifically for the `etcd.database.coreos.com/scope=clusterwide` annotation, however CoreOS allows for arbitrary annotations to the object so I figured I'd carry on with that and allow full passthrough of annotations.

Example usage:
```yaml
apiVersion: vault.banzaicloud.com/v1alpha1
kind: Vault
labels:
  version: latest
  group: security
  app: vault
metadata:
  name: vault
spec:
  size: 3
  image: vault:0.11.0
  bankVaultsImage: banzaicloud/bank-vaults:latest
  securityContext:
    runAsUser: 100
  supportUpgrade: true
  etcdAnnotations:
    etcd.database.coreos.com/scope: clusterwide
  unsealConfig:
    kubernetes:
      secretNamespace: default
...
```

This means that you can have a Cluster Wide ETCD Operator in one namespace, and then create an `etcdcluster` in a different namespace and have it automatically annotated.