### PR TITLE
Set secrets to bank-vaults's environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,18 @@ auth:
       token_max_ttl: 30m
       secret_id_num_uses: 40
 
+# Pass secret to environment variables. Please reference below `my-mysql` part for usage.
+# `env` is environment variable name
+# `secretName` is secret's name.
+# `secretKey` is secret's data key.
+secretEnvsConfig:
+  - env: ROOT_USERNAME
+    secretName: mysql-login
+    secretKey: user
+  - env: ROOT_PASSWORD
+    secretName: mysql-login
+    secretKey: password
+
 # Allows configuring Secrets Engines in Vault (KV, Database and SSH is tested,
 # but the config is free form so probably more is supported).
 # See https://www.vaultproject.io/docs/secrets/index.html for more information.
@@ -235,8 +247,8 @@ secrets:
           plugin_name: "mysql-database-plugin"
           connection_url: "{{username}}:{{password}}@tcp(127.0.0.1:3306)/"
           allowed_roles: [pipeline]
-          username: "${env "ROOT_USERNAME"}" # Example how to read environment variables
-          password: "${env "ROOT_PASSWORD"}"
+          username: "${env `ROOT_USERNAME`}" # Example how to read environment variables
+          password: "${env `ROOT_PASSWORD`}"
       roles:
         - name: pipeline
           db_name: my-mysql

--- a/README.md
+++ b/README.md
@@ -209,13 +209,17 @@ auth:
 # `env` is environment variable name
 # `secretName` is secret's name.
 # `secretKey` is secret's data key.
-secretEnvsConfig:
-  - env: ROOT_USERNAME
-    secretName: mysql-login
-    secretKey: user
-  - env: ROOT_PASSWORD
-    secretName: mysql-login
-    secretKey: password
+envsConfig:
+  - name: ROOT_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: mysql-login
+        key: user
+  - name: ROOT_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: mysql-login
+        key: password
 
 # Allows configuring Secrets Engines in Vault (KV, Database and SSH is tested,
 # but the config is free form so probably more is supported).

--- a/operator/deploy/cr-credentialFromSecret.yaml
+++ b/operator/deploy/cr-credentialFromSecret.yaml
@@ -1,0 +1,86 @@
+apiVersion: "vault.banzaicloud.com/v1alpha1"
+kind: "Vault"
+metadata:
+  name: "vault"
+spec:
+  size: 1
+  image: vault:0.11.0
+  bankVaultsImage: banzaicloud/bank-vaults:latest
+
+  # Support for custom Vault (and sidecar) pod annotations
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9102"
+
+  # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
+  serviceAccount: vault-operator
+
+  # Describe where you would like to store the Vault unseal keys and root token.
+  unsealConfig:
+    kubernetes:
+      secretNamespace: default
+
+  # Pass secret to bank-vaults environment variables.
+  envsConfig:
+  - name: MYSQL_001_USER
+    valueFrom:
+      secretKeyRef:
+        name: mysql-001-credential
+        key: user
+  - name: MYSQL_001_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: mysql-001-credential
+        key: password
+
+  # A YAML representation of a final vault config file.
+  # See https://www.vaultproject.io/docs/configuration/ for more information.
+  config:
+    storage:
+      file:
+        path: "/vault/file"
+    listener:
+      tcp:
+        address: "0.0.0.0:8200"
+        # Uncommenting the following line and deleting tls_cert_file and tls_key_file disables TLS
+        # tls_disable: true
+        tls_cert_file: /vault/tls/server.crt
+        tls_key_file: /vault/tls/server.key
+    telemetry:
+      statsd_address: localhost:9125
+    ui: true
+
+  # See: https://github.com/banzaicloud/bank-vaults#example-external-vault-configuration for more details.
+  externalConfig:
+    policies:
+    - name: allow_secrets
+      rules: path "secret/*" {
+              capabilities = ["create", "read", "update", "delete", "list"]
+            }
+    auth:
+    - type: kubernetes
+      roles:
+        # Allow every pod in the default namespace to use the secret kv store
+        - name: default
+          bound_service_account_names: default
+          bound_service_account_namespaces: default
+          policies: allow_secrets
+          ttl: 1h
+
+    secrets:
+    - type: database
+      description: MySQL Database secret engine.
+      configuration:
+        config:
+        - name: my-mysql
+          plugin_name: "mysql-database-plugin"
+          connection_url: "{{username}}:{{password}}@tcp(127.0.0.1:3306)/"
+          allowed_roles: [pipeline]
+          username: "${env `MYSQL_001_USER`}" # Example how to read environment variables
+          password: "${env `MYSQL_001_PASSWORD`}"
+        roles:
+        - name: pipeline
+          db_name: my-mysql
+          creation_statements: "GRANT ALL ON *.* TO '{{name}}'@'%' IDENTIFIED BY '{{password}}';"
+          default_ttl: "10m"
+          max_ttl: "24h"

--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -61,6 +61,7 @@ type VaultSpec struct {
 	ExternalConfig    map[string]interface{} `json:"externalConfig"`
 	UnsealConfig      UnsealConfig           `json:"unsealConfig"`
 	CredentialsConfig CredentialsConfig      `json:"credentialsConfig"`
+	SecretEnvsConfig  []SecretEnvConfig      `json:"secretEnvsConfig"`
 	SecurityContext   v1.PodSecurityContext  `json:"securityContext,omitempty"`
 	// This option gives us the option to workaround current StatefulSet limitations around updates
 	// See: https://github.com/kubernetes/kubernetes/issues/67250
@@ -348,4 +349,11 @@ type CredentialsConfig struct {
 	Env        string `json:"env"`
 	Path       string `json:"path"`
 	SecretName string `json:"secretName"`
+}
+
+// CredentialsConfig configuration for a credentials file provided as a secret
+type SecretEnvConfig struct {
+	Env        string `json:"env"`
+	SecretName string `json:"secretName"`
+	SecretKey  string `json:"secretKey"`
 }

--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -61,7 +61,7 @@ type VaultSpec struct {
 	ExternalConfig    map[string]interface{} `json:"externalConfig"`
 	UnsealConfig      UnsealConfig           `json:"unsealConfig"`
 	CredentialsConfig CredentialsConfig      `json:"credentialsConfig"`
-	SecretEnvsConfig  []SecretEnvConfig      `json:"secretEnvsConfig"`
+	EnvsConfig        []v1.EnvVar            `json:"envsConfig"`
 	SecurityContext   v1.PodSecurityContext  `json:"securityContext,omitempty"`
 	// This option gives us the option to workaround current StatefulSet limitations around updates
 	// See: https://github.com/kubernetes/kubernetes/issues/67250
@@ -349,11 +349,4 @@ type CredentialsConfig struct {
 	Env        string `json:"env"`
 	Path       string `json:"path"`
 	SecretName string `json:"secretName"`
-}
-
-// SecretEnvConfig configuration for set environment variable from secret
-type SecretEnvConfig struct {
-	Env        string `json:"env"`
-	SecretName string `json:"secretName"`
-	SecretKey  string `json:"secretKey"`
 }

--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -351,7 +351,7 @@ type CredentialsConfig struct {
 	SecretName string `json:"secretName"`
 }
 
-// CredentialsConfig configuration for a credentials file provided as a secret
+// SecretEnvConfig configuration for set environment variable from secret
 type SecretEnvConfig struct {
 	Env        string `json:"env"`
 	SecretName string `json:"secretName"`

--- a/operator/pkg/stub/handler.go
+++ b/operator/pkg/stub/handler.go
@@ -654,16 +654,8 @@ func withCredentialsVolumeMount(v *v1alpha1.Vault, volumeMounts []v1.VolumeMount
 }
 
 func withSecretEnv(v *v1alpha1.Vault, envs []v1.EnvVar) []v1.EnvVar {
-	for _, secret := range v.Spec.SecretEnvsConfig {
-		envs = append(envs, v1.EnvVar{
-			Name: secret.Env,
-			ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{Name: secret.SecretName},
-					Key:                  secret.SecretKey,
-				},
-			},
-		})
+	for _, env := range v.Spec.EnvsConfig {
+		envs = append(envs, env)
 	}
 
 	return envs


### PR DESCRIPTION
Add config for set secrets to bank-vaults's environment variables. Use case can reference readme example's `my-mysql` username and password.