### PR TITLE
Update to Vault 1.0.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -408,7 +408,7 @@
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
-  digest = "1:dbef1dda9aa352f3e62bcaa87be4e33d5e1736416aec983a7868d219249e919d"
+  digest = "1:855a0cb08277efb9b18fee68f6f94259775df36350276257df8c96e9d51dbaaf"
   name = "github.com/hashicorp/vault"
   packages = [
     "api",
@@ -420,8 +420,8 @@
     "helper/strutil",
   ]
   pruneopts = "NUT"
-  revision = "87492f9258e0227f3717e3883c6a8be5716bf564"
-  version = "v0.11.0"
+  revision = "c19cef14891751a23eaa9b41fd456d1f99e7e856"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -596,6 +596,17 @@
   pruneopts = "NUT"
   revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
   version = "v1.1.0"
+
+[[projects]]
+  digest = "1:1d920dce8e11bfff65b5709e883a8ece131b63a5bc4b2cd404f9ef7eb445f73f"
+  name = "github.com/pierrec/lz4"
+  packages = [
+    ".",
+    "internal/xxh32",
+  ]
+  pruneopts = "NUT"
+  revision = "635575b42742856941dbc767b44905bb9ba083f6"
+  version = "v2.0.7"
 
 [[projects]]
   digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -408,7 +408,8 @@
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
-  digest = "1:855a0cb08277efb9b18fee68f6f94259775df36350276257df8c96e9d51dbaaf"
+  branch = "api-list-plugins-backward-fix"
+  digest = "1:1e45ee6ab49aa5b4e6107d56cefae7d5e890962c748fa40b9e92c4fb2b55406d"
   name = "github.com/hashicorp/vault"
   packages = [
     "api",
@@ -420,8 +421,8 @@
     "helper/strutil",
   ]
   pruneopts = "NUT"
-  revision = "c19cef14891751a23eaa9b41fd456d1f99e7e856"
-  version = "v1.0.0"
+  revision = "ad8da7e156f011d5b0b9361e7dae3754a79f8379"
+  source = "github.com/banzaicloud/vault"
 
 [[projects]]
   branch = "master"
@@ -1216,6 +1217,7 @@
     "github.com/gin-gonic/gin",
     "github.com/golang/glog",
     "github.com/hashicorp/vault/api",
+    "github.com/hashicorp/vault/helper/consts",
     "github.com/mitchellh/mapstructure",
     "github.com/operator-framework/operator-sdk/pkg/sdk",
     "github.com/operator-framework/operator-sdk/pkg/sdk/action",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,7 +33,10 @@ required = [
 
 [[constraint]]
   name = "github.com/hashicorp/vault"
-  version = "1.0.0"
+  source = "github.com/banzaicloud/vault"
+  branch = "api-list-plugins-backward-fix"
+  # Use our own branch until https://github.com/hashicorp/vault/pull/5913 is resolved.
+  # version = "1.0.0"
 
 [[constraint]]
   name = "github.com/Masterminds/sprig"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,7 +33,7 @@ required = [
 
 [[constraint]]
   name = "github.com/hashicorp/vault"
-  version = "0.11.0"
+  version = "1.0.0"
 
 [[constraint]]
   name = "github.com/Masterminds/sprig"

--- a/README.md
+++ b/README.md
@@ -318,12 +318,16 @@ secrets:
         generate_lease: true
         ttl: 30m
 
-# Registers a new plugin in Vault's plugin catalog. "plugin_directory" setting should be set it Vault server configuration and plugin binary should be present in plugin directory. Also, for some plugins readOnlyRootFilesystem Pod Security Policy should be disabled to allow RPC communication between plugin and Vault server via Unix socket
-# See https://www.vaultproject.io/api/system/plugins-catalog.html and https://github.com/hashicorp/go-plugin/blob/master/docs/internals.md for details.
+# Registers a new plugin in Vault's plugin catalog. "plugin_directory" setting should be set it Vault server configuration
+# and plugin binary should be present in plugin directory. Also, for some plugins readOnlyRootFilesystem Pod Security Policy
+# should be disabled to allow RPC communication between plugin and Vault server via Unix socket
+# See https://www.vaultproject.io/api/system/plugins-catalog.html and
+#     https://github.com/hashicorp/go-plugin/blob/master/docs/internals.md for details.
 plugins:
   - plugin_name: ethereum-plugin
     command: ethereum-vault-plugin --ca-cert=/vault/tls/client/ca.crt --client-cert=/vault/tls/server/server.crt --client-key=/vault/tls/server/server.key
     sha256: 62fb461a8743f2a0af31d998074b58bb1a589ec1d28da3a2a5e8e5820d2c6e0a
+    type: secret
 ```
 
 ## The Go library

--- a/operator/deploy/cr-aws.yaml
+++ b/operator/deploy/cr-aws.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 2
-  image: vault:0.11.0
+  image: vault:1.0.0
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
   # Insted of credentialsConfig one can use IAM instance profiles, or kube2iam for example:

--- a/operator/deploy/cr-azure.yaml
+++ b/operator/deploy/cr-azure.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 2
-  image: vault:0.11.0
+  image: vault:1.0.0
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
   # Describe where you would like to store the Vault unseal keys and root token

--- a/operator/deploy/cr-credentialFromSecret.yaml
+++ b/operator/deploy/cr-credentialFromSecret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:0.11.0
+  image: vault:1.0.0
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
   # Support for custom Vault (and sidecar) pod annotations

--- a/operator/deploy/cr-etcd-ha.yaml
+++ b/operator/deploy/cr-etcd-ha.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 2
-  image: vault:0.11.0
+  image: vault:1.0.0
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
   # This option gives us the option to workaround current StatefulSet limitations around updates

--- a/operator/deploy/cr-gcs-ha.yaml
+++ b/operator/deploy/cr-gcs-ha.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 2
-  image: vault:0.11.0
+  image: vault:1.0.0
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
   # Describe where you would like to store the Vault unseal keys and root token

--- a/operator/deploy/cr-podAntiAffinity.yaml
+++ b/operator/deploy/cr-podAntiAffinity.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 3
-  image: vault:0.11.0
+  image: vault:1.0.0
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
   # Set use which node label for pod anti-affinity. Prevent all vault put on same AZ.

--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "vault"
 spec:
   size: 1
-  image: vault:0.11.5
+  image: vault:1.0.0
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
   # Support for custom Vault (and sidecar) pod annotations

--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -213,8 +213,10 @@ func (v *vault) Init() error {
 	}
 
 	resp, err := v.cl.Sys().Init(&api.InitRequest{
-		SecretShares:    v.config.SecretShares,
-		SecretThreshold: v.config.SecretThreshold,
+		SecretShares:      v.config.SecretShares,
+		SecretThreshold:   v.config.SecretThreshold,
+		RecoveryShares:    v.config.SecretShares,
+		RecoveryThreshold: v.config.SecretThreshold,
 	})
 
 	if err != nil {

--- a/vault-config.yml
+++ b/vault-config.yml
@@ -107,6 +107,7 @@ secrets:
     description: General secrets.
     options:
       version: 2
+
   # Mounts non-default plugin's path
   - path: ethereum-gateway
     type: plugin
@@ -174,9 +175,13 @@ secrets:
         generate_lease: true
         ttl: 30m
 
-# Registers a new plugin in Vault's plugin catalog. "plugin_directory" setting should be set it Vault server configuration and plugin binary should be present in plugin directory. Also, for some plugins readOnlyRootFilesystem Pod Security Policy should be disabled to allow RPC communication between plugin and Vault server via Unix socket
-# See https://www.vaultproject.io/api/system/plugins-catalog.html and https://github.com/hashicorp/go-plugin/blob/master/docs/internals.md for details.
+# Registers a new plugin in Vault's plugin catalog. "plugin_directory" setting should be set it Vault server configuration
+# and plugin binary should be present in plugin directory. Also, for some plugins readOnlyRootFilesystem Pod Security Policy
+# should be disabled to allow RPC communication between plugin and Vault server via Unix socket
+# See https://www.vaultproject.io/api/system/plugins-catalog.html and
+#     https://github.com/hashicorp/go-plugin/blob/master/docs/internals.md for details.
 plugins:
   - plugin_name: ethereum-plugin
     command: ethereum-vault-plugin --ca-cert=/vault/tls/client/ca.crt --client-cert=/vault/tls/server/server.crt --client-key=/vault/tls/server/server.key
     sha256: 62fb461a8743f2a0af31d998074b58bb1a589ec1d28da3a2a5e8e5820d2c6e0a
+    type: secret


### PR DESCRIPTION
Updates the API client used to talk with Vault 1.0.0.

- [x] Vault 0.11.x still works. (not sure, testing)

Fixes: #222 Depends on: https://github.com/hashicorp/vault/pull/5913