### PR TITLE
operator: support Volumes in Vault CRD

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -18,10 +18,16 @@ kubectl apply -f operator/deploy/rbac.yaml     # If you have an RBAC enabled clu
 kubectl apply -f operator/deploy/operator.yaml
 ```
 
-This will create a Kubernetes `CustomResourceDefinition` called Vault. A documented example of this CRD can be found in operator/deploy/cr.yaml:
+This will create a Kubernetes `CustomResourceDefinition` called Vault (and a PersistentVolume for it). A documented example of this CRD can be found in operator/deploy/cr.yaml:
 
 ```bash
 kubectl apply -f operator/deploy/cr.yaml
+```
+
+Delete Vault and the PersistentVolume:
+
+```bash
+kubectl delete -f operator/deploy/cr.yaml
 ```
 
 ## HA setup with etcd

--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -18,6 +18,16 @@ spec:
   # Specify the Service's type where the Vault Service is exposed
   serviceType: ClusterIP
 
+  # Use local disk to store Vault file data, see config section.
+  volumes:
+    - name: vault-file
+      persistentVolumeClaim:
+        claimName: vault-file
+
+  volumeMounts:
+    - name: vault-file
+      mountPath: /vault/file
+
   # Describe where you would like to store the Vault unseal keys and root token.
   unsealConfig:
     kubernetes:
@@ -63,3 +73,31 @@ spec:
       description: General secrets.
       options:
         version: 2
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vault-file
+spec:
+  # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
+  # storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+# ---
+# apiVersion: v1
+# kind: PersistentVolume
+# metadata:
+#   name: vault-file
+# spec:
+#   capacity:
+#     storage: 1Gi
+#   accessModes:
+#   - ReadWriteOnce
+#   persistentVolumeReclaimPolicy: Delete
+#   hostPath:
+#     path: /vault/file

--- a/operator/pkg/apis/vault/v1alpha1/types.go
+++ b/operator/pkg/apis/vault/v1alpha1/types.go
@@ -73,6 +73,8 @@ type VaultSpec struct {
 	ServiceType     string            `json:"serviceType"`
 	PodAntiAffinity string            `json:"podAntiAffinity"`
 	ServiceAccount  string            `json:"serviceAccount"`
+	Volumes         []v1.Volume       `json:"volumes,omitempty"`
+	VolumeMounts    []v1.VolumeMount  `json:"volumeMounts,omitempty"`
 }
 
 // HAStorageTypes is the set of storage backends supporting High Availability


### PR DESCRIPTION
Fixes: #235 

With this change, persistent volumes can be attached to the Vault pods through the CRD definition, useful for the file based Vault backend.