### PR TITLE
webhook: mutate pods only for correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,11 +454,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vault-test
-  annotations:
-    vault.security.banzaicloud.io/vault-addr: "https://vault:8200"
-    vault.security.banzaicloud.io/vault-role: "default"
-    vault.security.banzaicloud.io/vault-skip-verify: "true"
-    vault.security.banzaicloud.io/vault-path: "kubernetes"
 spec:
   replicas: 1
   selector:
@@ -468,6 +463,11 @@ spec:
     metadata:
       labels:
         app: vault
+    annotations:
+      vault.security.banzaicloud.io/vault-addr: "https://vault:8200"
+      vault.security.banzaicloud.io/vault-role: "default"
+      vault.security.banzaicloud.io/vault-skip-verify: "true"
+      vault.security.banzaicloud.io/vault-path: "kubernetes"
     spec:
       serviceAccountName: default
       containers:

--- a/deploy/test-deployment.yaml
+++ b/deploy/test-deployment.yaml
@@ -2,11 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-secrets
-  annotations:
-    vault.security.banzaicloud.io/vault-addr: "https://vault:8200"
-    vault.security.banzaicloud.io/vault-role: "default"
-    vault.security.banzaicloud.io/vault-skip-verify: "true"
-    vault.security.banzaicloud.io/vault-path: "kubernetes"
 spec:
   replicas: 1
   selector:
@@ -16,6 +11,11 @@ spec:
     metadata:
       labels:
         app: hello-secrets
+      annotations:
+        vault.security.banzaicloud.io/vault-addr: "https://vault:8200"
+        vault.security.banzaicloud.io/vault-role: "default"
+        vault.security.banzaicloud.io/vault-skip-verify: "true"
+        vault.security.banzaicloud.io/vault-path: "kubernetes"
     spec:
       initContainers:
       - name: init-ubuntu


### PR DESCRIPTION
Breaking change! Annotations have to be moved to the `PodSpec` level as seen in the example deployment `hello-secrets`.

Fixes: #254 

The new Helm chart has to be used from now on: https://github.com/banzaicloud/banzai-charts/pull/584