### PR TITLE
Remove slashes from VERSION variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OPERATOR_DOCKER_IMAGE = banzaicloud/vault-operator
 # Build variables
 BUILD_DIR ?= build
 BUILD_PACKAGE = ${PACKAGE}/cmd/...
-VERSION ?= $(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)
+VERSION ?= $(shell echo `git symbolic-ref -q --short HEAD || git describe --tags --exact-match` | tr '[/]' '-')
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD 2>/dev/null)
 BUILD_DATE ?= $(shell date +%FT%T%z)
 LDFLAGS += -X main.version=${VERSION} -X main.commitHash=${COMMIT_HASH} -X main.buildDate=${BUILD_DATE}


### PR DESCRIPTION
CircleCI builds are holding a branch name containing slashes, this breaks the build as seen in: https://github.com/banzaicloud/bank-vaults/pull/253


```bash
#!/bin/bash -eo pipefail
make docker
make docker-operator
docker build -f Dockerfile.vault-env -t banzaicloud/vault-env:latest .
docker build -f Dockerfile.webhook -t banzaicloud/vault-secrets-webhook:latest .
docker build -t banzaicloud/bank-vaults:pull/253 -f Dockerfile .
invalid argument "banzaicloud/bank-vaults:pull/253" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
Makefile:58: recipe for target 'docker' failed
make: *** [docker] Error 125
Exited with code 2
```