### PR TITLE
Allow to control vault's log level with env

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We use Vault across our large Kubernetes deployments and all the projects were `
 - [Operator](#operator)
 - [Mutating Webhook](#mutating-webhook)
 - [Unseal Keys](#unseal-keys)
-- [Examples](#examples)
+- [Examples for using the library part](#examples-for-using-the-library-part)
 - [Getting and Installing](#getting-and-installing)
 - [Monitoring](#monitoring)
 - [Contributing](#contributing)

--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -73,7 +73,9 @@ spec:
         description: General secrets.
         options:
           version: 2
-
+  vaultEnvsConfig:
+    - name: VAULT_LOG_LEVEL
+      value: debug
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -616,7 +616,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault) (*appsv1.StatefulSet, error) {
 							Image:           v.Spec.Image,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "vault",
-							Args:            []string{"server", "-log-level=debug"},
+							Args:            []string{"server"},
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 8200,


### PR DESCRIPTION
According to vault server -help, -log-level can be set with VAULT_LOG_LEVEL. There is no need to set it explicitly.

Also, fix link to Examples in README.md.