### PR TITLE
Add support for nodeAffinity for vault containers

### DIFF
--- a/operator/deploy/cr-nodeAffinity.yaml
+++ b/operator/deploy/cr-nodeAffinity.yaml
@@ -1,0 +1,66 @@
+apiVersion: "vault.banzaicloud.com/v1alpha1"
+kind: "Vault"
+metadata:
+  name: "vault"
+spec:
+  size: 3
+  image: vault:1.0.0
+  bankVaultsImage: banzaicloud/bank-vaults:latest
+
+  # A YAML representation of nodeAffinity
+  # Detail can reference: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  # And: https://kubernetes.io/docs/setup/multiple-zones/#nodes-are-labeled
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key : "kubernetes.io/hostname"
+          operator: In
+          values: ["minikube"]
+
+  # Support for custom Vault (and sidecar) pod annotations
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9102"
+
+  # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
+  serviceAccount: vault
+
+  # Describe where you would like to store the Vault unseal keys and root token.
+  unsealConfig:
+    kubernetes:
+      secretNamespace: default
+
+  # A YAML representation of a final vault config file.
+  # See https://www.vaultproject.io/docs/configuration/ for more information.
+  config:
+    storage:
+      file:
+        path: "/vault/file"
+    listener:
+      tcp:
+        address: "0.0.0.0:8200"
+        # Uncommenting the following line and deleting tls_cert_file and tls_key_file disables TLS
+        # tls_disable: true
+        tls_cert_file: /vault/tls/server.crt
+        tls_key_file: /vault/tls/server.key
+    telemetry:
+      statsd_address: localhost:9125
+    ui: true
+
+  # See: https://github.com/banzaicloud/bank-vaults#example-external-vault-configuration for more details.
+  externalConfig:
+    policies:
+      - name: allow_secrets
+        rules: path "secret/*" {
+          capabilities = ["create", "read", "update", "delete", "list"]
+          }
+    auth:
+      - type: kubernetes
+        roles:
+          # Allow every pod in the default namespace to use the secret kv store
+          - name: default
+            bound_service_account_names: default
+            bound_service_account_namespaces: default
+            policies: allow_secrets
+            ttl: 1h

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -50,6 +50,7 @@ type VaultSpec struct {
 	EtcdAnnotations map[string]string `json:"etcdAnnotations,omitempty"`
 	ServiceType     string            `json:"serviceType"`
 	PodAntiAffinity string            `json:"podAntiAffinity"`
+	NodeAffinity    v1.NodeAffinity   `json:"nodeAffinity"`
 	ServiceAccount  string            `json:"serviceAccount"`
 	Volumes         []v1.Volume       `json:"volumes,omitempty"`
 	VolumeMounts    []v1.VolumeMount  `json:"volumeMounts,omitempty"`


### PR DESCRIPTION
- Refactor getPodAntiAffinity for backwards compatibility
- Add nodeAffinity vault configuration option
- Add getNodeAffinity and assign output to the spec
- Add deploy example.