### PR TITLE
Use `path` when configuring Kubernetes auth roles

### DIFF
--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -400,7 +400,7 @@ func (v *vault) Configure() error {
 				return fmt.Errorf("error configuring kubernetes auth for vault: %s", err.Error())
 			}
 			roles := authMethod["roles"].([]interface{})
-			err = v.configureKubernetesRoles(roles)
+			err = v.configureKubernetesRoles(path, roles)
 			if err != nil {
 				return fmt.Errorf("error configuring kubernetes auth roles for vault: %s", err.Error())
 			}
@@ -579,14 +579,14 @@ func (v *vault) configurePolicies() error {
 	return nil
 }
 
-func (v *vault) configureKubernetesRoles(roles []interface{}) error {
+func (v *vault) configureKubernetesRoles(path string, roles []interface{}) error {
 	for _, roleInterface := range roles {
 		role, err := cast.ToStringMapE(roleInterface)
 		if err != nil {
 			return fmt.Errorf("error converting role for kubernetes: %s", err.Error())
 		}
 
-		_, err = v.cl.Logical().Write(fmt.Sprint("auth/kubernetes/role/", role["name"]), role)
+		_, err = v.cl.Logical().Write(fmt.Sprint("auth/%s/role/%s", path, role["name"]), role)
 
 		if err != nil {
 			return fmt.Errorf("error putting %s kubernetes role into vault: %s", role["name"], err.Error())

--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -586,7 +586,7 @@ func (v *vault) configureKubernetesRoles(path string, roles []interface{}) error
 			return fmt.Errorf("error converting role for kubernetes: %s", err.Error())
 		}
 
-		_, err = v.cl.Logical().Write(fmt.Sprint("auth/%s/role/%s", path, role["name"]), role)
+		_, err = v.cl.Logical().Write(fmt.Sprintf("auth/%s/role/%s", path, role["name"]), role)
 
 		if err != nil {
 			return fmt.Errorf("error putting %s kubernetes role into vault: %s", role["name"], err.Error())


### PR DESCRIPTION
Currently, roles are being written to the default Kubernetes auth path, `auth/kubernetes`. This change will have the method `configureKubernetesRoles` use the value of `path` instead, as done in `kubernetesAuthConfig`.