### PR TITLE
Add support to config secret engine, which nosub-path after config

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ secrets:
     description: General secrets.
     options:
       version: 2
+    configuration:
+      config:
+        - max_versions: 100
   # Mounts non-default plugin's path
   - path: ethereum-gateway
     type: plugin

--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -38,7 +38,7 @@ import (
 const DefaultConfigFile = "vault-config.yml"
 
 // Secret engine config no need name
-var secretEngineConfigNoNeedName = [...]string{"ad", "alicloud", "azure", "gcp", "gcpkms", "kv"}
+var secretEngineConfigNoNeedName = map[string]bool{"ad": true, "alicloud": true, "azure": true, "gcp": true, "gcpkms": true, "kv": true}
 
 // Config holds the configuration of the Vault initialization
 type Config struct {
@@ -982,10 +982,9 @@ func getMountConfigInput(secretEngine map[string]interface{}) (api.MountConfigIn
 
 func isConfigNoNeedName(secretEngineType string, configOption string) bool {
 	if configOption == "config" {
-		for _, secretEngine := range secretEngineConfigNoNeedName {
-			if secretEngineType == secretEngine {
-				return true
-			}
+		_, ok := secretEngineConfigNoNeedName[secretEngineType]
+		if ok {
+			return true
 		}
 	}
 

--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -37,6 +37,9 @@ import (
 // DefaultConfigFile is the name of the default config file
 const DefaultConfigFile = "vault-config.yml"
 
+// Secret engine config no need name
+var secretEngineConfigNoNeedName = [...]string{"ad", "alicloud", "azure", "gcp", "gcpkms", "kv"}
+
 // Config holds the configuration of the Vault initialization
 type Config struct {
 	// how many key parts exist
@@ -873,7 +876,7 @@ func (v *vault) configureSecretEngines() error {
 				}
 
 				name, ok := subConfigData["name"]
-				if !ok {
+				if !ok && !isConfigNoNeedName(secretEngineType, configOption) {
 					return fmt.Errorf("error finding sub config data name for secret engine")
 				}
 
@@ -887,7 +890,12 @@ func (v *vault) configureSecretEngines() error {
 					}
 				}
 
-				configPath := fmt.Sprintf("%s/%s/%s", path, configOption, name)
+				var configPath string
+				if name != nil {
+					configPath = fmt.Sprintf("%s/%s/%s", path, configOption, name)
+				} else {
+					configPath = fmt.Sprintf("%s/%s", path, configOption)
+				}
 				_, err = v.cl.Logical().Write(configPath, subConfigData)
 
 				if err != nil {
@@ -970,4 +978,16 @@ func getMountConfigInput(secretEngine map[string]interface{}) (api.MountConfigIn
 	mountConfigInput.Options = options
 
 	return mountConfigInput, nil
+}
+
+func isConfigNoNeedName(secretEngineType string, configOption string) bool {
+	if configOption == "config" {
+		for _, secretEngine := range secretEngineConfigNoNeedName {
+			if secretEngineType == secretEngine {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -983,9 +983,7 @@ func getMountConfigInput(secretEngine map[string]interface{}) (api.MountConfigIn
 func isConfigNoNeedName(secretEngineType string, configOption string) bool {
 	if configOption == "config" {
 		_, ok := secretEngineConfigNoNeedName[secretEngineType]
-		if ok {
-			return true
-		}
+		return ok
 	}
 
 	return false


### PR DESCRIPTION
Like "ad", "alicloud", "azure", "gcp", "gcpkms", "kv" secret engine