### PR TITLE
Describe how to encrypt root token stored in AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,18 @@ The keys that will be stored are:
 HashiCorp [recommends to revoke root tokens](https://www.vaultproject.io/docs/concepts/tokens.html#root-tokens) after the initial set up of Vault has been completed.
 To unseal Vault the `vault-root` token is not needed and can be removed from the storage if it was put there via the `--init` call to `bank-vaults`.
 
+### Decrypting root token
+
+#### AWS
+
+To use KMS-encrypted root token with vault CLI
+
+1. Download root token file to your local file system
+1. Decrypt the token and save it as an environment variable
+    ```bash
+    export VAULT_TOKEN="$(aws kms decrypt --ciphertext-blob fileb://<encrypted token file> --encryption-context Tool=bank-vaults --query Plaintext --output text | base64 -d)"
+    ```
+
 ## Examples for using the library part
 
 Some examples are in `cmd/examples/main.go`


### PR DESCRIPTION
Very short description how to encrypt root token stored in S3 and encrypted with AWS KMS service.

I am not sure if you will accept such documentation update, I really wanted to have vault token, before I will try to use AWS auth plugin. It took me some time to figure out proper decryption process, maybe it will be useful for someone else.

I know it is kinda against recommendations described a few lines earlier. So if you will reject this PR it is fine ;-)