### PR TITLE
Allow to use ha_storage in replicated vault setup

### DIFF
--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -68,11 +68,15 @@ var HAStorageTypes = map[string]bool{
 	"zookeeper": true,
 }
 
-// HasHAStorage detects if Vault is configured to use a storage backend which supports High Availability
+// HasHAStorage detects if Vault is configured to use a storage backend which supports High Availability or if it has
+// ha_storage stanza, then doesn't check for ha_enabled flag
 func (spec *VaultSpec) HasHAStorage() bool {
 	storageType := spec.GetStorageType()
 	if _, ok := HAStorageTypes[storageType]; ok {
 		return spec.HasStorageHAEnabled()
+	}
+	if len(spec.getHAStorage()) != 0 {
+		return true
 	}
 	return false
 }
@@ -85,6 +89,10 @@ func (spec *VaultSpec) GetStorage() map[string]interface{} {
 
 func (spec *VaultSpec) getStorage() map[string]interface{} {
 	return cast.ToStringMap(spec.Config["storage"])
+}
+
+func (spec *VaultSpec) getHAStorage() map[string]interface{} {
+	return cast.ToStringMap(spec.Config["ha_storage"])
 }
 
 // GetStorageType returns the type of Vault's storage stanza


### PR DESCRIPTION
Setup with ha_storage should be equal to setup with storage and ha_enabled flag set to true, as described per official documentation https://www.vaultproject.io/docs/configuration/index.html#ha_storage.

Currently, operator throws error:
```
..."error":"failed to fabricate StatefulSet: more than 1 replicas are not supported without HA storage backend"...
```

In setup like:

```
...
    storage:
      s3:
        bucket: vault
    ha_storage:
      dynamodb:
        table: vault
...
```

Which is valid from 1.0.0(?).