### PR TITLE
Watch the entire cluster if the watched namespace is not set

### DIFF
--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -76,8 +76,8 @@ func main() {
 	if !isSet {
 		namespace, err = k8sutil.GetWatchNamespace()
 		if err != nil {
-			log.Error(err, "failed to get watch namespace")
-			os.Exit(1)
+			log.Info("No watched namespace found, watching the entire cluster")
+			namespace = ""
 		}
 	}
 	log.Info(fmt.Sprintf("Watched namespace: %s", namespace))


### PR DESCRIPTION
It seems that the WATCH_NAMESPACE environment variable is not set when the value
is set to `""` in deployment. This lead to a crash of the operator. Watching the
entire cluster in this case seems like a better default.