### PR TITLE
Fix PKI engine TTL configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,9 +311,9 @@ secrets:
   # See https://www.vaultproject.io/docs/secrets/pki/index.html for more information
   - type: pki
     description: Vault PKI Backend
-    options:
-      default_ttl: 168h
-      max_ttl: 720h
+    config:
+      default_lease_ttl: 168h
+      max_lease_ttl: 720h    
     configuration:
       config:
       - name: urls


### PR DESCRIPTION
Previous example didn't worked (at least with vault 1.0.x). Now it works fine and sets proper TTL's.

I am not sure if `options` is specific for Vault <1.0.x, I am using 1.0.2. If it is the case, we may consider adding some side note. However, all other examples use config instead of options.