### PR TITLE
Env update

### DIFF
--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -97,7 +97,7 @@ func main() {
 			path = split[0]
 
 			var key string
-			if len(split) > 0 {
+			if len(split) > 1 {
 				key = split[1]
 			}
 			

--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -86,10 +86,10 @@ func main() {
 		value := split[1]
 		var update bool
 		if strings.HasPrefix(value, ">>") {
-			value := strings.TrimPrefix(value, ">>")
-			update = True
+			value = strings.TrimPrefix(value, ">>")
+			update = true
 		} else {
-			update = False
+			update = false
 		}
 		if strings.HasPrefix(value, "vault:") {
 			path := strings.TrimPrefix(value, "vault:")
@@ -101,15 +101,24 @@ func main() {
 				key = split[1]
 			}
 			
+			var secret *vaultapi.Secret
+			var err error
+			
 			if update {
-				secret, err := client.Vault().Logical().Write(path)
+				var empty map[string]interface{}
+				secret, err = client.Vault().Logical().Write(path, empty)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "failed to write secret '%s': %s\n", path, err.Error())
+					os.Exit(1)
+				}
 			} else {
-				secret, err := client.Vault().Logical().Read(path)
+				secret, err = client.Vault().Logical().Read(path)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "failed to read secret '%s': %s\n", path, err.Error())
+					os.Exit(1)
+				}
 			}
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to read secret '%s': %s\n", path, err.Error())
-				os.Exit(1)
-			}
+		
 
 			if secret == nil {
 				fmt.Fprintf(os.Stderr, "path not found: %s\n", path)

--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -84,7 +84,13 @@ func main() {
 		split := strings.SplitN(env, "=", 2)
 		name := split[0]
 		value := split[1]
-
+		var update bool
+		if strings.HasPrefix(value, ">>") {
+			value := strings.TrimPrefix(value, ">>")
+			update = True
+		} else {
+			update = False
+		}
 		if strings.HasPrefix(value, "vault:") {
 			path := strings.TrimPrefix(value, "vault:")
 			split := strings.SplitN(path, "#", 2)
@@ -94,8 +100,12 @@ func main() {
 			if len(split) > 0 {
 				key = split[1]
 			}
-
-			secret, err := client.Vault().Logical().Read(path)
+			
+			if update {
+				secret, err := client.Vault().Logical().Write(path)
+			} else {
+				secret, err := client.Vault().Logical().Read(path)
+			}
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to read secret '%s': %s\n", path, err.Error())
 				os.Exit(1)

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -220,7 +220,7 @@ func lookForEnvFrom(envFrom []corev1.EnvFromSource, ns string) ([]corev1.EnvVar,
 				return envVars, err
 			}
 			for key, value := range data {
-				if strings.HasPrefix(value, "vault:") {
+				if (strings.HasPrefix(value, "vault:") || strings.HasPrefix(value, ">>vault:")){
 					envFromCM := corev1.EnvVar{
 						Name:  key,
 						Value: value,
@@ -235,7 +235,7 @@ func lookForEnvFrom(envFrom []corev1.EnvFromSource, ns string) ([]corev1.EnvVar,
 				return envVars, err
 			}
 			for key, value := range data {
-				if strings.HasPrefix(string(value), "vault:") {
+				if (strings.HasPrefix(string(value), "vault:") || strings.HasPrefix(string(value), ">>vault:")){
 					envFromSec := corev1.EnvVar{
 						Name:  key,
 						Value: string(value),


### PR DESCRIPTION
Adds rudimentary support for update / write style requests to the webhook.

### Reason:
It wasn't possible to generate certificates via the webhook as this required a write to the `intermediate-ca/issue/cert-name` .

### Solution:
Added write support to vault-env via a prepend to the vault URI.
The proposed prepend that has been implemented is `>>`

### Example:
If you wanted to issue a new cert you would use the URI `>>vault:intermediate-ca/issue/cert-name`.

### Future:
It might also be good to support data in the write (it is currently an empty write). This could be done via an append to the path. (E.G. `>>vault:intermediate-ca/issue/cert-name{}` where the {} is json data)