### PR TITLE
use VAULT_CLUSTER_INTERFACE to have correct HA Cluster address

### DIFF
--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -809,6 +809,11 @@ func statefulSetForVault(v *vaultv1alpha1.Vault) (*appsv1.StatefulSet, error) {
 									Name:  "VAULT_LOCAL_CONFIG",
 									Value: configJSON,
 								},
+								// https://github.com/hashicorp/docker-vault/blob/master/0.X/docker-entrypoint.sh#L12
+								{
+									Name:  "VAULT_CLUSTER_INTERFACE",
+									Value: "eth0",
+								},
 							}))),
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
With the help of the wrapper script we are able to provide correct HA Cluster address:
https://github.com/hashicorp/docker-vault/blob/master/0.X/docker-entrypoint.sh#L12

This way the standby node says:
```
$ kubectl exec -it vault-0 sh                                                                             
/ # vault status
Key                    Value
---                    -----
Seal Type              shamir
Initialized            true
Sealed                 false
Total Shares           5
Threshold              3
Version                1.0.3
Cluster Name           vault-cluster-4f0be265
Cluster ID             9399bbe1-dcaf-44fc-0d90-6cf0275a94c5
HA Enabled             true
HA Cluster             https://10.1.0.153:8201
HA Mode                standby
Active Node Address    https://vault.default:8200
```

cc @primeroz 