### PR TITLE
Use uid instead of username due to runAsNonRoot securityContext

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,6 @@ FROM alpine:3.7
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/bin/bank-vaults /usr/local/bin/bank-vaults
+USER 65534
 
 ENTRYPOINT ["/usr/local/bin/bank-vaults"]

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -20,7 +20,6 @@ RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/bin/manager /usr/local/bin/vault-operator
 
-RUN adduser -D vault-operator
-USER vault-operator
+USER 65534
 
 ENTRYPOINT ["/usr/local/bin/vault-operator"]

--- a/Dockerfile.webhook
+++ b/Dockerfile.webhook
@@ -21,6 +21,6 @@ COPY --from=builder /go/bin/vault-secrets-webhook /usr/local/bin/vault-secrets-w
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENV DEBUG false
-USER nobody
+USER 65534
 
 ENTRYPOINT ["/usr/local/bin/vault-secrets-webhook"]


### PR DESCRIPTION
fixes: #367 
relates: https://github.com/banzaicloud/banzai-charts/issues/717