### PR TITLE
Add support for creating vault configurations as Secrets

### DIFF
--- a/operator/deploy/secret.yaml
+++ b/operator/deploy/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  vault-config.yml: cG9saWNpZXM6CiAgLSBuYW1lOiBhbGxvd19hY2Nlc3NfdG9fc2VjcmV0c19mcm9tX3NlY3JldAogICAgcnVsZXM6IHBhdGggInNlY3JldC8qIiB7CiAgICAgIGNhcGFiaWxpdGllcyA9IFsiY3JlYXRlIiwgInJlYWQiLCAidXBkYXRlIiwgImRlbGV0ZSIsICJsaXN0Il0KICAgICAgfQoK
+kind: Secret
+metadata:
+  name: config-from-secret
+  namespace: vault
+  labels:
+    app: vault-configurator
+    vault_cr: vault


### PR DESCRIPTION
Uses the same pattern as the configmaps, it will be useful when used alongside
sealed-secrets controller (or similar) to push sensitive vault configurations into git