### PR TITLE
append to the slice, not overwrite the slice

### DIFF
--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -516,7 +516,7 @@ func getServicePorts(v *vaultv1alpha1.Vault) ([]corev1.ServicePort, []corev1.Con
 				Port: i,
 			},
 		}
-		serviceports = append(serviceport)
+		serviceports = append(serviceports, serviceport)
 
 		containerport := []corev1.ContainerPort{
 			{
@@ -524,7 +524,7 @@ func getServicePorts(v *vaultv1alpha1.Vault) ([]corev1.ServicePort, []corev1.Con
 				Name:          	k,
 			},
 		}
-		containerports = append(containerport)
+		containerports = append(containerports, containerport)
 	}
 
 	return serviceports, containerports

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -510,19 +510,15 @@ func getServicePorts(v *vaultv1alpha1.Vault) ([]corev1.ServicePort, []corev1.Con
 	}
 
 	for k, i := range v.Spec.ServicePorts {
-		serviceport := []corev1.ServicePort{
-			{
+		serviceport := corev1.ServicePort{
 				Name: k,
 				Port: i,
-			},
 		}
 		serviceports = append(serviceports, serviceport)
 
-		containerport := []corev1.ContainerPort{
-			{
-				ContainerPort: 	i,
-				Name:          	k,
-			},
+		containerport := corev1.ContainerPort{
+			ContainerPort: 	i,
+			Name:          	k,
 		}
 		containerports = append(containerports, containerport)
 	}


### PR DESCRIPTION
fix bug in `0.4.15-rc.1` that I introduced when setting custom ports, the slice is overwriting. Need to append to the declared slice.