### PR TITLE
Fix json: unsupported type: map[interface {}]interface {} for jwt nested maps

### DIFF
--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -766,6 +766,16 @@ func (v *vault) configureJwtRoles(path string, roles []interface{}) error {
 		if err != nil {
 			return fmt.Errorf("error converting roles for jwt: %s", err.Error())
 		}
+		// role can have have a bound_claims or claim_mappings child dict. But it will cause:
+		// `json: unsupported type: map[interface {}]interface {}`
+		// So check and replace by `map[string]interface{}` before using it.
+		if val, ok := role["bound_claims"]; ok {
+			role["bound_claims"] = cast.ToStringMap(val)
+		}
+		if val, ok := role["claim_mappings"]; ok {
+			role["claim_mappings"] = cast.ToStringMap(val)
+		}
+
 		_, err = v.cl.Logical().Write(fmt.Sprintf("auth/%s/role/%s", path, role["name"]), role)
 
 		if err != nil {


### PR DESCRIPTION
Issue caused by YAML parser and Json Marshalling.

Already happening int he "configure secret" generic function https://github.com/primeroz/bank-vaults/blob/ffc94f13794be5429969a420197700f3e80cb439/pkg/vault/operator_client.go#L979 

