### PR TITLE
Trim / at the end of path if present

### DIFF
--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -440,6 +440,7 @@ func (v *vault) configureAuthMethods(config *viper.Viper) error {
 			if err != nil {
 				return fmt.Errorf("error converting path for auth method: %s", err.Error())
 			}
+			path = strings.Trim(path, "/")
 		}
 
 		description := fmt.Sprintf("%s backend", authMethodType)
@@ -899,6 +900,7 @@ func (v *vault) configureSecretEngines(config *viper.Viper) error {
 			if err != nil {
 				return fmt.Errorf("error converting path for secret engine: %s", err.Error())
 			}
+			path = strings.Trim(path, "/")
 		}
 
 		mounts, err := v.cl.Sys().ListMounts()
@@ -1028,6 +1030,7 @@ func (v *vault) configureAuditDevices(config *viper.Viper) error {
 			if err != nil {
 				return fmt.Errorf("error converting path for audit device: %s", err.Error())
 			}
+			path = strings.Trim(path, "/")
 		}
 
 		mounts, err := v.cl.Sys().ListAudit()


### PR DESCRIPTION
This will avoid confusing the configurer with `path already in use`

```
ERRO[0011] error configuring vault: error configuring auth methods for vault: error enabling approle auth method for vault: Error making API request.

URL: POST http://127.0.0.1:8200/v1/sys/auth/approle
Code: 400. Errors:

* path is already in use
```