### PR TITLE
Move init outside the loop + increase http.Timeout

### DIFF
--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -83,6 +83,13 @@ from one of the followings:
 		metrics := prometheusExporter{Vault: v, Mode: "unseal"}
 		go metrics.Run()
 
+		if unsealConfig.proceedInit {
+			logrus.Info("initializing vault...")
+			if err := v.Init(); err != nil {
+				logrus.Fatalf("error initializing vault: %s", err.Error())
+			}
+		}
+
 		for {
 			unseal(unsealConfig, v)
 
@@ -93,15 +100,6 @@ from one of the followings:
 }
 
 func unseal(unsealConfig unsealCfg, v vault.Vault) {
-	if unsealConfig.proceedInit {
-		logrus.Info("initializing vault...")
-		if err := v.Init(); err != nil {
-			logrus.Fatalf("error initializing vault: %s", err.Error())
-		} else {
-			unsealConfig.proceedInit = false
-		}
-	}
-
 	logrus.Debug("checking if vault is sealed...")
 	sealed, err := v.Sealed()
 	if err != nil {

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -244,6 +245,6 @@ func NewRawClient() (*api.Client, error) {
 	if config.Error != nil {
 		return nil, config.Error
 	}
-	config.HttpClient.Timeout = 5 * time.Second
+	config.HttpClient.Transport.(*http.Transport).TLSHandshakeTimeout = 5 * time.Second
 	return vaultapi.NewClient(config)
 }

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -241,6 +241,9 @@ func (client *Client) Close() {
 
 func NewRawClient() (*api.Client, error) {
 	config := vaultapi.DefaultConfig()
+	if config.Error != nil {
+		return nil, config.Error
+	}
 	config.HttpClient.Timeout = 5 * time.Second
 	return vaultapi.NewClient(config)
 }

--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -221,7 +221,7 @@ func (v *vault) Init() error {
 		if notFound && err != nil {
 			return fmt.Errorf("error before init: checking key '%s' failed: %s", key, err.Error())
 		} else if !notFound && err == nil {
-			return fmt.Errorf("error before init: keystore value for '%s' already exists", key)
+			return fmt.Errorf("error before init: value for key '%s' already exists", key)
 		}
 	}
 


### PR DESCRIPTION
Fixes: #400 

The 5 seconds global HTTP timeout caused init to fail sometimes (mostly when using remote backends).