### PR TITLE
move kv backend tests behind a flag

### DIFF
--- a/cmd/bank-vaults/init.go
+++ b/cmd/bank-vaults/init.go
@@ -22,6 +22,7 @@ import (
 
 const cfgInitRootToken = "init-root-token"
 const cfgStoreRootToken = "store-root-token"
+const cfgPreFlightChecks = "pre-flight-checks"
 
 var initCmd = &cobra.Command{
 	Use:   "init",
@@ -34,6 +35,7 @@ It will not unseal the Vault instance after initialising.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		appConfig.BindPFlag(cfgInitRootToken, cmd.PersistentFlags().Lookup(cfgInitRootToken))
 		appConfig.BindPFlag(cfgStoreRootToken, cmd.PersistentFlags().Lookup(cfgStoreRootToken))
+		appConfig.BindPFlag(cfgPreFlightChecks, cmd.PersistentFlags().Lookup(cfgPreFlightChecks))
 
 		store, err := kvStoreForConfig(appConfig)
 
@@ -68,6 +70,7 @@ It will not unseal the Vault instance after initialising.`,
 func init() {
 	initCmd.PersistentFlags().String(cfgInitRootToken, "", "root token for the new vault cluster")
 	initCmd.PersistentFlags().Bool(cfgStoreRootToken, true, "should the root token be stored in the key store")
+	initCmd.PersistentFlags().Bool(cfgPreFlightChecks, false, "should the key store be tested first to validate access rights")
 
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -49,6 +49,7 @@ from one of the followings:
 		appConfig.BindPFlag(cfgOnce, cmd.PersistentFlags().Lookup(cfgOnce))
 		appConfig.BindPFlag(cfgInitRootToken, cmd.PersistentFlags().Lookup(cfgInitRootToken))
 		appConfig.BindPFlag(cfgStoreRootToken, cmd.PersistentFlags().Lookup(cfgStoreRootToken))
+		appConfig.BindPFlag(cfgPreFlightChecks, cmd.PersistentFlags().Lookup(cfgPreFlightChecks))
 
 		var unsealConfig unsealCfg
 
@@ -140,6 +141,7 @@ func init() {
 	unsealCmd.PersistentFlags().Bool(cfgOnce, false, "Run unseal only once")
 	unsealCmd.PersistentFlags().String(cfgInitRootToken, "", "Root token for the new vault cluster (only if -init=true)")
 	unsealCmd.PersistentFlags().Bool(cfgStoreRootToken, true, "Should the root token be stored in the key store (only if -init=true)")
+	unsealCmd.PersistentFlags().Bool(cfgPreFlightChecks, false, "should the key store be tested first to validate access rights")
 
 	rootCmd.AddCommand(unsealCmd)
 }

--- a/cmd/bank-vaults/util.go
+++ b/cmd/bank-vaults/util.go
@@ -40,6 +40,8 @@ func vaultConfigForConfig(cfg *viper.Viper) (vault.Config, error) {
 
 		InitRootToken:  appConfig.GetString(cfgInitRootToken),
 		StoreRootToken: appConfig.GetBool(cfgStoreRootToken),
+
+		PreFlightChecks: appConfig.GetBool(cfgPreFlightChecks),
 	}, nil
 }
 

--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -60,6 +60,9 @@ type Config struct {
 	InitRootToken string
 	// should the root token be stored in the keyStore
 	StoreRootToken bool
+
+	// should the KV backend be tested first to validate access rights
+	PreFlightChecks bool
 }
 
 // vault is an implementation of the Vault interface that will perform actions
@@ -199,10 +202,12 @@ func (v *vault) Init() error {
 	logrus.Info("initializing vault")
 
 	// test backend first
-	tester := kv.Tester{Service: v.keyStore}
-	err = tester.Test(v.testKey())
-	if err != nil {
-		return fmt.Errorf("error testing keystore before init: %s", err.Error())
+	if v.config.PreFlightChecks {
+		tester := kv.Tester{Service: v.keyStore}
+		err = tester.Test(v.testKey())
+		if err != nil {
+			return fmt.Errorf("error testing keystore before init: %s", err.Error())
+		}
 	}
 
 	// test for an existing keys


### PR DESCRIPTION
The kv backend changes the way user IAM policies and other access rights have to be set up, so I have moved it behind a feature flag, people can enable it on their own will.