### PR TITLE
Make Watch function work on multiple Directories

### DIFF
--- a/cmd/bank-vaults/configure.go
+++ b/cmd/bank-vaults/configure.go
@@ -181,7 +181,6 @@ func watchConfigurations(vaultConfigFiles []string, configurations chan *viper.V
 				logrus.Infof("File has changed: %s", event.Name)
 				configurations <- parseConfiguration(filepath.Clean(event.Name))
 			} else if event.Op&fsnotify.Create == fsnotify.Create && filepath.Base(event.Name) == "..data" {
-				logrus.Infof("Files : %v", configFileDirs[filepath.Dir(event.Name)])
 				for _, fileName := range configFileDirs[filepath.Dir(event.Name)] {
 					logrus.Infof("ConfgMap has changed, reparsing: %s", fileName)
 					configurations <- parseConfiguration(fileName)

--- a/cmd/bank-vaults/configure.go
+++ b/cmd/bank-vaults/configure.go
@@ -176,14 +176,14 @@ func watchConfigurations(vaultConfigFiles []string, configurations chan *viper.V
 		select {
 		case event := <-watcher.Events:
 			// we only care about the config file or the ConfigMap directory (if in Kubernetes)
-			// For real Files we only need to watch thw WRITE Event # TODO: Sometimes it triggers 2 WRITE when a file is edited and saved
+			// For real Files we only need to watch the WRITE Event # TODO: Sometimes it triggers 2 WRITE when a file is edited and saved
 			// For Kubernetes configMaps we need to watch for CREATE on the "..data"
 			if event.Op&fsnotify.Write == fsnotify.Write && stringInSlice(filepath.Clean(event.Name), vaultConfigFiles) {
 				logrus.Infof("File has changed: %s", event.Name)
 				configurations <- parseConfiguration(filepath.Clean(event.Name))
 			} else if event.Op&fsnotify.Create == fsnotify.Create && filepath.Base(event.Name) == "..data" {
 				for _, fileName := range configFileDirs[filepath.Dir(event.Name)] {
-					logrus.Infof("ConfgMap has changed, reparsing: %s", fileName)
+					logrus.Infof("ConfigMap has changed, reparsing: %s", fileName)
 					configurations <- parseConfiguration(fileName)
 				}
 			}

--- a/cmd/bank-vaults/configure.go
+++ b/cmd/bank-vaults/configure.go
@@ -158,14 +158,15 @@ func watchConfigurations(vaultConfigFiles []string, configurations chan *viper.V
 		// we have to watch the entire directory to pick up renames/atomic saves in a cross-platform way
 		configFile := vaultConfigFile
 		configDir, _ := filepath.Split(configFile)
+		configDirTrimmed := strings.TrimRight(configDir, "/")
 
 		files := make([]string, 0)
-		if len(configFileDirs[strings.TrimRight(configDir, "/")]) != 0 {
-			files = configFileDirs[strings.TrimRight(configDir, "/")]
+		if len(configFileDirs[configDirTrimmed]) != 0 {
+			files = configFileDirs[configDirTrimmed]
 		}
 		files = append(files, configFile)
 
-		configFileDirs[strings.TrimRight(configDir, "/")] = files
+		configFileDirs[configDirTrimmed] = files
 
 		logrus.Infof("Watching Directory for changes: %s", configDir)
 		watcher.Add(configDir)

--- a/cmd/bank-vaults/configure.go
+++ b/cmd/bank-vaults/configure.go
@@ -167,7 +167,7 @@ func watchConfigurations(vaultConfigFiles []string, configurations chan *viper.V
 
 		configFileDirs[strings.TrimRight(configDir, "/")] = files
 
-		logrus.Debugf("Watching Directory for changes: %s", configDir)
+		logrus.Infof("Watching Directory for changes: %s", configDir)
 		watcher.Add(configDir)
 	}
 

--- a/cmd/bank-vaults/configure.go
+++ b/cmd/bank-vaults/configure.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 	"time"
 
@@ -82,7 +83,8 @@ var configureCmd = &cobra.Command{
 
 		configurations := make(chan *viper.Viper, len(vaultConfigFiles))
 
-		for _, vaultConfigFile := range vaultConfigFiles {
+		for i, vaultConfigFile := range vaultConfigFiles {
+			vaultConfigFiles[i] = filepath.Clean(vaultConfigFile)
 			configurations <- parseConfiguration(vaultConfigFile)
 		}
 
@@ -133,8 +135,20 @@ var configureCmd = &cobra.Command{
 	},
 }
 
+func stringInSlice(match string, list []string) bool {
+	for _, item := range list {
+		if item == match {
+			return true
+		}
+	}
+	return false
+}
+
 func watchConfigurations(vaultConfigFiles []string, configurations chan *viper.Viper) {
 	watcher, err := fsnotify.NewWatcher()
+	// Map used to match on kubernetes ..data to files inside of directory
+	configFileDirs := make(map[string][]string)
+
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -142,29 +156,42 @@ func watchConfigurations(vaultConfigFiles []string, configurations chan *viper.V
 
 	for _, vaultConfigFile := range vaultConfigFiles {
 		// we have to watch the entire directory to pick up renames/atomic saves in a cross-platform way
-		configFile := filepath.Clean(vaultConfigFile)
+		configFile := vaultConfigFile
 		configDir, _ := filepath.Split(configFile)
 
-		done := make(chan bool)
-		go func() {
-			for {
-				select {
-				case event := <-watcher.Events:
-					// we only care about the config file or the ConfigMap directory (if in Kubernetes)
-					if filepath.Clean(event.Name) == configFile || filepath.Base(event.Name) == "..data" {
-						if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
-							configurations <- parseConfiguration(configFile)
-						}
-					}
-				case err := <-watcher.Errors:
-					logrus.Error(err)
+		files := make([]string, 0)
+		if len(configFileDirs[strings.TrimRight(configDir, "/")]) != 0 {
+			files = configFileDirs[strings.TrimRight(configDir, "/")]
+		}
+		files = append(files, configFile)
+
+		configFileDirs[strings.TrimRight(configDir, "/")] = files
+
+		logrus.Debugf("Watching Directory for changes: %s", configDir)
+		watcher.Add(configDir)
+	}
+
+	for {
+		select {
+		case event := <-watcher.Events:
+			// we only care about the config file or the ConfigMap directory (if in Kubernetes)
+			// For real Files we only need to watch thw WRITE Event # TODO: Sometimes it triggers 2 WRITE when a file is edited and saved
+			// For Kubernetes configMaps we need to watch for CREATE on the "..data"
+			if event.Op&fsnotify.Write == fsnotify.Write && stringInSlice(filepath.Clean(event.Name), vaultConfigFiles) {
+				logrus.Infof("File has changed: %s", event.Name)
+				configurations <- parseConfiguration(filepath.Clean(event.Name))
+			} else if event.Op&fsnotify.Create == fsnotify.Create && filepath.Base(event.Name) == "..data" {
+				logrus.Infof("Files : %v", configFileDirs[filepath.Dir(event.Name)])
+				for _, fileName := range configFileDirs[filepath.Dir(event.Name)] {
+					logrus.Infof("ConfgMap has changed, reparsing: %s", fileName)
+					configurations <- parseConfiguration(fileName)
 				}
 			}
-		}()
-
-		watcher.Add(configDir)
-		<-done
+		case err := <-watcher.Errors:
+			logrus.Errorf("Watcher Event Error: %s", err.Error())
+		}
 	}
+
 }
 
 func parseConfiguration(vaultConfigFile string) *viper.Viper {


### PR DESCRIPTION
Fixes #405 

* Watch multiple directories
* Reload on WRITE on Real Files
* Reload on CREATE on Kubernetes re-link of ..data for any number of files in the configMap
* The Events watching does not need to run in its own GO thread since the whole function is already running as such
* We don't have access to the Filename in the event watching but just the event.Name
  * For real files we can safely use that
  * For Kubernetes Configmaps we need to path the basepath to a saved map of DIR: FILES and just reload all files