### PR TITLE
operator: configurer shouldn't get unseal options

### DIFF
--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -314,12 +314,17 @@ type UnsealOptions struct {
 	PreFlightChecks bool `json:"preFlightChecks,omitempty"`
 }
 
+func (uso UnsealOptions) ToArgs() []string {
+	args := []string{}
+	if uso.PreFlightChecks {
+		args = append(args, "--pre-flight-checks", "true")
+	}
+	return args
+}
+
 // ToArgs returns the UnsealConfig as and argument array for bank-vaults
 func (usc *UnsealConfig) ToArgs(vault *Vault) []string {
 	args := []string{}
-	if usc.Options.PreFlightChecks {
-		args = append(args, "--pre-flight-checks", "true")
-	}
 	if usc.Kubernetes != nil {
 
 		secretNamespace := vault.Namespace

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1004,7 +1004,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault) (*appsv1.StatefulSet, error) {
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "bank-vaults",
 							Command:         []string{"bank-vaults", "unseal", "--init"},
-							Args:            v.Spec.UnsealConfig.ToArgs(v),
+							Args:            append(v.Spec.UnsealConfig.Options.ToArgs(), v.Spec.UnsealConfig.ToArgs(v)...),
 							Env: withSecretEnv(v, withTLSEnv(v, true, withCredentialsEnv(v, []corev1.EnvVar{
 								{
 									Name:  k8s.EnvK8SOwnerReference,


### PR DESCRIPTION
Only the init/unseal container should get the unseal options.