### PR TITLE
webhook: vault-agent-fix

### DIFF
--- a/deploy/test-deployment.yaml
+++ b/deploy/test-deployment.yaml
@@ -16,6 +16,7 @@ spec:
         vault.security.banzaicloud.io/vault-role: "default"
         vault.security.banzaicloud.io/vault-skip-verify: "true"
         vault.security.banzaicloud.io/vault-path: "kubernetes"
+        # vault.security.banzaicloud.io/vault-agent: "true"
     spec:
       initContainers:
       - name: init-ubuntu


### PR DESCRIPTION
The vault-agent implementation was broken for a while, this PR addresses that.

- mount_path was missing `auth/`
- ownerReferences wasn't set in agent ConfigMap
- name and namespace was empty for the obj, we get those from other sources now