### PR TITLE
Enable Controller prometheus metrics

### DIFF
--- a/operator/deploy/operator-rbac.yaml
+++ b/operator/deploy/operator-rbac.yaml
@@ -36,6 +36,12 @@ rules:
   - apiGroups:
       - apps
     resources:
+      - replicasets
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
       - deployments
       - statefulsets
     verbs:

--- a/operator/deploy/operator.yaml
+++ b/operator/deploy/operator.yaml
@@ -15,6 +15,9 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8383"
   name: vault-operator
 spec:
   replicas: 1
@@ -34,7 +37,7 @@ spec:
           image: banzaicloud/vault-operator:latest
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 9091
+            - containerPort: 8383
               name: metrics
           command:
             - vault-operator


### PR DESCRIPTION
Prometheus metrics for the Controller are now available out of the box, as described [here](https://github.com/operator-framework/operator-sdk/tree/master/doc/user/metrics)

exposed (useful) metrics are
```
controller_runtime_reconcile_queue_length{controller="vault-controller"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="vault-controller",le="0.005"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="vault-controller",le="0.01"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="vault-controller",le="0.025"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="vault-controller",le="0.05"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="vault-controller",le="0.1"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="vault-controller",le="0.25"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="vault-controller",le="0.5"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="vault-controller",le="1"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="vault-controller",le="2.5"} 0
controller_runtime_reconcile_time_seconds_bucket{controller="vault-controller",le="5"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="vault-controller",le="10"} 1
controller_runtime_reconcile_time_seconds_bucket{controller="vault-controller",le="+Inf"} 3
controller_runtime_reconcile_time_seconds_sum{controller="vault-controller"} 32.514783989
controller_runtime_reconcile_time_seconds_count{controller="vault-controller"} 3
controller_runtime_reconcile_total{controller="vault-controller",result="success"} 3
```

Unfortunately though if we want the metrics to be enabled by default this is a **breaking change** since to expose the service using `_, err = metrics.ExposeMetricsPort(context.TODO(), metricsPort)` the operator need to be able to `GET replicasets` and the current RBAC does not allow for that.

This is now added to the example operator-rbac but if anyone was going to update to a version of the operator with this feature enabled it would break on start with a forbidden get request for replicasets.

Alternatively i could use an Environment variable to enable the feature and have it set to false by default. That would be backward compatible but it would also break the rule of having **sane defaults**