### PR TITLE
PSP AllowPrivilegeEscalation

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -327,7 +327,7 @@ func parseVaultConfig(obj metav1.Object) vaultConfig {
 
 	if val, ok := annotations["vault.security.banzaicloud.io/psp-allow-privilege-escalation"]; ok {
 		vaultConfig.pspAllowPrivilegeEscalation, _ = strconv.ParseBool(val)
-	} else if viper.GetString("psp_allow_privilege_escalation") != "" {
+	} else {
 		vaultConfig.pspAllowPrivilegeEscalation, _ = strconv.ParseBool(viper.GetString("psp_allow_privilege_escalation"))
 	}
 

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -684,6 +684,7 @@ func initConfig() {
 	viper.SetDefault("vault_tls_secret", "")
 	viper.SetDefault("vault_agent", "true")
 	viper.SetDefault("vault_ct_share_process_namespace", "")
+	viper.SetDefault("psp_allow_privilege_escalation", "false")
 	viper.AutomaticEnv()
 }
 

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -327,7 +327,7 @@ func parseVaultConfig(obj metav1.Object) vaultConfig {
 
 	if val, ok := annotations["vault.security.banzaicloud.io/psp-allow-privilege-escalation"]; ok {
 		vaultConfig.pspAllowPrivilegeEscalation, _ = strconv.ParseBool(val)
-	} else {
+	} else if viper.GetString("psp_allow_privilege_escalation") != "" {
 		vaultConfig.pspAllowPrivilegeEscalation, _ = strconv.ParseBool(viper.GetString("psp_allow_privilege_escalation"))
 	}
 


### PR DESCRIPTION
Allow to enable/disable AllowPrivilegeEscalation for injected containers to make it works with psp restricted deployments


Caused by error in replicaset
**is forbidden: unable to validate against any pod security policy: []'**
