### PR TITLE
explicitly define the config file in the volume mount so the file is i…

### DIFF
--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -720,10 +720,11 @@ func deploymentForConfigurer(v *vaultv1alpha1.Vault, configmaps corev1.ConfigMap
 
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{
 				Name:      cm.Name,
-				MountPath: "/config/" + cm.Name,
+				MountPath: "/config/" + cm.Name + "/" + vault.DefaultConfigFile,
+				SubPath:   vault.DefaultConfigFile,
 			})
 
-			configArgs = append(configArgs, "--vault-config-file", "/config/"+cm.Name+"/"+vault.DefaultConfigFile)
+			configArgs = append(configArgs, "--vault-config-file", "/config/"+cm.Name+"/" + vault.DefaultConfigFile)
 		}
 	}
 


### PR DESCRIPTION
…n the container, Here is the error I was getting in the configurer consol logs:

```
time="2019-05-14T23:56:41Z" level=fatal msg="error executing vault config template: template: no template \"/config/vault-configurer/vault-config.yml\" associated with template \"vault-config-file\""
```