### PR TITLE
Extend Annotations support for operator 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,4 +8,5 @@
 - [Unseal Keys](unseal-keys/README.md)
 - [Getting and Installing](installing/README.md)
 - [Monitoring](monitoring/README.md)
+- [Annotations](annotations/README.md)
 - [Contributing](contributing/README.md)

--- a/docs/annotations/README.md
+++ b/docs/annotations/README.md
@@ -1,0 +1,88 @@
+# Annotations
+
+The Vault Operator suypport annotating most of the resources it creates using a set of fields in the Vault Specs:
+
+## Common Vault Resources annotations
+```
+apiVersion: "vault.banzaicloud.com/v1alpha1"
+kind: "Vault"
+metadata:
+  name: "vault"
+	spec:
+	  annotations:
+		  example.com/test: "something"
+```
+
+These annotations are common to all Vault Created resources
+  - Vault Statefulset
+	- Vault Pods
+	- Vault Configurer Deployment
+	- Vault Configurer Pod
+	- Vault Services
+	- Vault Configurer Service
+	- Vault TLS Secret
+
+
+## Vault Statefulset Resources annotations
+```
+apiVersion: "vault.banzaicloud.com/v1alpha1"
+kind: "Vault"
+metadata:
+  name: "vault"
+	spec:
+	  vaultAnnotations:
+		  example.com/vault: "true"
+```
+
+These annotations are common to all Vault Statefulset Created resources
+  - Vault Statefulset
+	- Vault Pods
+	- Vault Services
+	- Vault TLS Secret
+
+These annotations will override any annotation defined in the common set
+
+## Vault Configurer deployment Resources annotations
+```
+apiVersion: "vault.banzaicloud.com/v1alpha1"
+kind: "Vault"
+metadata:
+  name: "vault"
+	spec:
+	  vaultConfigurerAnnotations:
+		  example.com/vaultConfigurer: "true"
+```
+
+These annotations are common to all Vault Configurer Deployment Created resources
+	- Vault Configurer Deployment
+	- Vault Configurer Pod
+	- Vault Configurer Service
+
+These annotations will override any annotation defined in the common set
+
+## ETCD CRD Annotations
+```
+apiVersion: "vault.banzaicloud.com/v1alpha1"
+kind: "Vault"
+metadata:
+  name: "vault"
+	spec:
+	  etcdAnnotations:
+		  etcd.database.coreos.com/scope: clusterwide
+```
+
+These annotations are set *only* on the etcdcluster resource
+
+## ETCD PODs Annotations
+```
+apiVersion: "vault.banzaicloud.com/v1alpha1"
+kind: "Vault"
+metadata:
+  name: "vault"
+	spec:
+	  etcdPodAnnotations:
+		  backup.velero.io/backup-volumes: "YOUR_VOLUME_NAME"
+```
+
+These annotations are set *only* on the etcd pods created by the etcd-operator
+

--- a/operator/deploy/cr-credentialFromSecret.yaml
+++ b/operator/deploy/cr-credentialFromSecret.yaml
@@ -7,10 +7,17 @@ spec:
   image: vault:1.1.0
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
-  # Support for custom Vault (and sidecar) pod annotations
+  # Common annotations for all created resources
   annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9102"
+    common/annotation: "true"
+
+  # Vault Pods , Services and TLS Secret annotations
+  vaultAnnotations:
+    type/instance: "vault"
+
+  # Vault Configurer Pods and Services annotations
+  vaultConfigurerAnnotations:
+    type/instance: "vaultconfigurer"
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/operator/deploy/cr-customports.yaml
+++ b/operator/deploy/cr-customports.yaml
@@ -7,10 +7,17 @@ spec:
   image: vault:1.1.0
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
-  # Support for custom Vault (and sidecar) pod annotations
+  # Common annotations for all created resources
   annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9102"
+    common/annotation: "true"
+  
+  # Vault Pods , Services and TLS Secret annotations
+  vaultAnnotations:
+    type/instance: "vault"
+  
+  # Vault Configurer Pods and Services annotations
+  vaultConfigurerAnnotations:
+    type/instance: "vaultconfigurer"
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/operator/deploy/cr-etcd-ha.yaml
+++ b/operator/deploy/cr-etcd-ha.yaml
@@ -29,6 +29,10 @@ spec:
   etcdAnnotations:
     etcd.database.coreos.com/scope: clusterwide
 
+  # Annotations to be applied to the POD Specs
+  etcdPodAnnotations:
+    backup.velero.io/backup-volumes: "YOUR_VOLUME_NAME"
+
   # Describe where you would like to store the Vault unseal keys and root token.
   unsealConfig:
     kubernetes:

--- a/operator/deploy/cr-podAntiAffinity.yaml
+++ b/operator/deploy/cr-podAntiAffinity.yaml
@@ -12,10 +12,17 @@ spec:
   # And: https://kubernetes.io/docs/setup/multiple-zones/#nodes-are-labeled
   podAntiAffinity: failure-domain.beta.kubernetes.io/zone
 
-  # Support for custom Vault (and sidecar) pod annotations
+  # Common annotations for all created resources
   annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9102"
+    common/annotation: "true"
+  
+  # Vault Pods , Services and TLS Secret annotations
+  vaultAnnotations:
+    type/instance: "vault"
+  
+  # Vault Configurer Pods and Services annotations
+  vaultConfigurerAnnotations:
+    type/instance: "vaultconfigurer"
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/operator/deploy/cr-resource.yaml
+++ b/operator/deploy/cr-resource.yaml
@@ -36,10 +36,17 @@ spec:
         memory: "128Mi"
         cpu: "500m"
 
-  # Support for custom Vault (and sidecar) pod annotations
+  # Common annotations for all created resources
   annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9102"
+    common/annotation: "true"
+  
+  # Vault Pods , Services and TLS Secret annotations
+  vaultAnnotations:
+    type/instance: "vault"
+  
+  # Vault Configurer Pods and Services annotations
+  vaultConfigurerAnnotations:
+    type/instance: "vaultconfigurer"
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -7,10 +7,17 @@ spec:
   image: vault:1.1.0
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
-  # Support for custom Vault (and sidecar) pod annotations
+  # Common annotations for all created resources
   annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9102"
+    common/annotation: "true"
+  
+  # Vault Pods , Services and TLS Secret annotations
+  vaultAnnotations:
+    type/instance: "vault"
+  
+  # Vault Configurer Pods and Services annotations
+  vaultConfigurerAnnotations:
+    type/instance: "vaultconfigurer"
 
   # Support for nodeAffinity Rules
   # nodeAffinity:

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -64,9 +64,9 @@ type VaultSpec struct {
 	FluentDEnabled             bool                   `json:"fluentdEnabled"`
 	FluentDImage               string                 `json:"fluentdImage"`
 	FluentDConfig              string                 `json:"fluentdConfig"`
-	Annotations                map[string]string      `json:"annotations,omitempty"`
-	VaultAnnotations           map[string]string      `json:"vaultAnnotations,omitempty"`
-	VaultConfigurerAnnotations map[string]string      `json:"vaultConfigurerAnnotations,omitempty"`
+	Annotations                map[string]string      `json:"annotations"`
+	VaultAnnotations           map[string]string      `json:"vaultAnnotations"`
+	VaultConfigurerAnnotations map[string]string      `json:"vaultConfigurerAnnotations"`
 	Config                     map[string]interface{} `json:"config"`
 	ExternalConfig             map[string]interface{} `json:"externalConfig"`
 	UnsealConfig               UnsealConfig           `json:"unsealConfig"`

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -79,6 +79,7 @@ type VaultSpec struct {
 	EtcdVersion           string                        `json:"etcdVersion"`
 	EtcdSize              int                           `json:"etcdSize"`
 	EtcdAnnotations       map[string]string             `json:"etcdAnnotations,omitempty"`
+	EtcdPodAnnotations    map[string]string             `json:"etcdPodAnnotations,omitempty"`
 	EtcdPVCSpec           *v1.PersistentVolumeClaimSpec `json:"etcdPVCSpec,omitempty"`
 	ServiceType           string                        `json:"serviceType"`
 	ServicePorts          map[string]int32              `json:"servicePorts"`

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -56,21 +56,23 @@ type VaultList struct {
 // VaultSpec defines the desired state of Vault
 type VaultSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	Size              int32                  `json:"size"`
-	Image             string                 `json:"image"`
-	BankVaultsImage   string                 `json:"bankVaultsImage"`
-	StatsdDisabled    bool                   `json:"statsdDisabled"`
-	StatsDImage       string                 `json:"statsdImage"`
-	FluentDEnabled    bool                   `json:"fluentdEnabled"`
-	FluentDImage      string                 `json:"fluentdImage"`
-	FluentDConfig     string                 `json:"fluentdConfig"`
-	Annotations       map[string]string      `json:"annotations"`
-	Config            map[string]interface{} `json:"config"`
-	ExternalConfig    map[string]interface{} `json:"externalConfig"`
-	UnsealConfig      UnsealConfig           `json:"unsealConfig"`
-	CredentialsConfig CredentialsConfig      `json:"credentialsConfig"`
-	EnvsConfig        []v1.EnvVar            `json:"envsConfig"`
-	SecurityContext   v1.PodSecurityContext  `json:"securityContext,omitempty"`
+	Size                       int32                  `json:"size"`
+	Image                      string                 `json:"image"`
+	BankVaultsImage            string                 `json:"bankVaultsImage"`
+	StatsdDisabled             bool                   `json:"statsdDisabled"`
+	StatsDImage                string                 `json:"statsdImage"`
+	FluentDEnabled             bool                   `json:"fluentdEnabled"`
+	FluentDImage               string                 `json:"fluentdImage"`
+	FluentDConfig              string                 `json:"fluentdConfig"`
+	Annotations                map[string]string      `json:"annotations,omitempty"`
+	VaultAnnotations           map[string]string      `json:"vaultAnnotations,omitempty"`
+	VaultConfigurerAnnotations map[string]string      `json:"vaultConfigurerAnnotations,omitempty"`
+	Config                     map[string]interface{} `json:"config"`
+	ExternalConfig             map[string]interface{} `json:"externalConfig"`
+	UnsealConfig               UnsealConfig           `json:"unsealConfig"`
+	CredentialsConfig          CredentialsConfig      `json:"credentialsConfig"`
+	EnvsConfig                 []v1.EnvVar            `json:"envsConfig"`
+	SecurityContext            v1.PodSecurityContext  `json:"securityContext,omitempty"`
 	// This option gives us the option to workaround current StatefulSet limitations around updates
 	// See: https://github.com/kubernetes/kubernetes/issues/67250
 	// TODO: Should be removed once the ParallelPodManagement policy supports the broken update.
@@ -219,20 +221,31 @@ func (spec *VaultSpec) GetStatsDImage() string {
 	return spec.StatsDImage
 }
 
-// GetAnnotations returns the Annotations
-func (spec *VaultSpec) GetAnnotations(promPort string) map[string]string {
+// GetAnnotations returns the Common Annotations
+func (spec *VaultSpec) GetAnnotations() map[string]string {
 	if spec.Annotations == nil {
 		spec.Annotations = map[string]string{}
 	}
 
-	if promPort == "" {
-		promPort = "9102"
+	return spec.Annotations
+}
+
+// GetVaultAnnotations returns the Vault Pod , Secret and ConfigMap Annotations
+func (spec *VaultSpec) GetVaultAnnotations() map[string]string {
+	if spec.VaultAnnotations == nil {
+		spec.VaultAnnotations = map[string]string{}
 	}
 
-	spec.Annotations["prometheus.io/scrape"] = "true"
-	spec.Annotations["prometheus.io/path"] = "/metrics"
-	spec.Annotations["prometheus.io/port"] = promPort
-	return spec.Annotations
+	return spec.VaultAnnotations
+}
+
+// GetVaultConfigurerAnnotations returns the Vault Configurer Pod Annotations
+func (spec *VaultSpec) GetVaultConfigurerAnnotations() map[string]string {
+	if spec.VaultConfigurerAnnotations == nil {
+		spec.VaultConfigurerAnnotations = map[string]string{}
+	}
+
+	return spec.VaultConfigurerAnnotations
 }
 
 // GetFluentDImage returns the FluentD image to use

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -502,6 +502,7 @@ func serviceForVault(v *vaultv1alpha1.Vault) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      v.Name,
 			Namespace: v.Namespace,
+			Annotations: withVaultAnnotations(v, getCommonAnnotations(v, map[string]string{})),
 			Labels:    ls,
 		},
 		Spec: corev1.ServiceSpec{
@@ -622,6 +623,7 @@ func perInstanceServicesForVault(v *vaultv1alpha1.Vault) []*corev1.Service {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      podName,
 				Namespace: v.Namespace,
+				Annotations: withVaultAnnotations(v, getCommonAnnotations(v, map[string]string{})),
 				Labels:    ls,
 			},
 			Spec: corev1.ServiceSpec{
@@ -653,6 +655,7 @@ func serviceForVaultConfigurer(v *vaultv1alpha1.Vault) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
 			Namespace: v.Namespace,
+			Annotations: withVaultConfigurerAnnotations(v, getCommonAnnotations(v, map[string]string{})),
 			Labels:    ls,
 		},
 		Spec: corev1.ServiceSpec{
@@ -755,6 +758,7 @@ func deploymentForConfigurer(v *vaultv1alpha1.Vault, configmaps corev1.ConfigMap
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      v.Name + "-configurer",
 			Namespace: v.Namespace,
+			Annotations: withVaultConfigurerAnnotations(v, getCommonAnnotations(v, map[string]string{})),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
@@ -933,6 +937,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault) (*appsv1.StatefulSet, error) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      v.Name,
 			Namespace: v.Namespace,
+			Annotations: withVaultAnnotations(v, getCommonAnnotations(v, map[string]string{})),
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &replicas,

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -953,7 +953,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault) (*appsv1.StatefulSet, error) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      ls,
-					Annotations: withVaultAnnotations(v, withPrometheusAnnotations("9091", getCommonAnnotations(v, map[string]string{}))),
+					Annotations: withVaultAnnotations(v, withPrometheusAnnotations("9102", getCommonAnnotations(v, map[string]string{}))),
 				},
 				Spec: corev1.PodSpec{
 					Affinity: &corev1.Affinity{

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -493,7 +493,7 @@ func serviceForVault(v *vaultv1alpha1.Vault) *corev1.Service {
 	ls["global_service"] = "true"
 	servicePorts, _ := getServicePorts(v)
 	servicePorts = append(servicePorts, corev1.ServicePort{Name: "metrics", Port: 9091})
-	servicePorts = append(servicePorts, corev1.ServicePort{Name: "statsd", Port: 9125})
+	servicePorts = append(servicePorts, corev1.ServicePort{Name: "statsd", Port: 9102})
 	service := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -763,7 +763,7 @@ func deploymentForConfigurer(v *vaultv1alpha1.Vault, configmaps corev1.ConfigMap
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      ls,
-					Annotations: withVaultConfigurerAnnotations(v, withPrometheusAnnotations("9091", v.Spec.GetAnnotations())),
+					Annotations: withVaultConfigurerAnnotations(v, withPrometheusAnnotations("9091", getCommonAnnotations(v, map[string]string{}))),
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: v.Spec.GetServiceAccount(),
@@ -946,7 +946,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault) (*appsv1.StatefulSet, error) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      ls,
-					Annotations: withVaultAnnotations(v, withPrometheusAnnotations("9102", v.Spec.GetAnnotations())),
+					Annotations: withVaultAnnotations(v, withPrometheusAnnotations("9091", getCommonAnnotations(v, map[string]string{}))),
 				},
 				Spec: corev1.PodSpec{
 					Affinity: &corev1.Affinity{
@@ -1036,6 +1036,14 @@ func statefulSetForVault(v *vaultv1alpha1.Vault) (*appsv1.StatefulSet, error) {
 
 // Annotations Functions
 
+func getCommonAnnotations(v *vaultv1alpha1.Vault, annotations map[string]string) map[string]string {
+	for key, value := range v.Spec.GetAnnotations() {
+		annotations[key] = value
+	}
+
+	return annotations
+}
+
 func withPrometheusAnnotations(prometheusPort string, annotations map[string]string) map[string]string {
 	if prometheusPort == "" {
 		prometheusPort = "9102"
@@ -1049,16 +1057,16 @@ func withPrometheusAnnotations(prometheusPort string, annotations map[string]str
 }
 
 func withVaultAnnotations(v *vaultv1alpha1.Vault, annotations map[string]string) map[string]string {
-	for k, v := range v.Spec.GetVaultAnnotations() {
-		annotations[k] = v
+	for key, value := range v.Spec.GetVaultAnnotations() {
+		annotations[key] = value
 	}
 
 	return annotations
 }
 
 func withVaultConfigurerAnnotations(v *vaultv1alpha1.Vault, annotations map[string]string) map[string]string {
-	for k, v := range v.Spec.GetVaultConfigurerAnnotations() {
-		annotations[k] = v
+	for key, value := range v.Spec.GetVaultConfigurerAnnotations() {
+		annotations[key] = value
 	}
 
 	return annotations

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -833,6 +833,7 @@ func secretForVault(om *vaultv1alpha1.Vault) (*corev1.Secret, error) {
 	secret.Name = om.Name + "-tls"
 	secret.Namespace = om.Namespace
 	secret.Labels = labelsForVault(om.Name)
+	secret.Annotations = withVaultAnnotations(om, getCommonAnnotations(om, map[string]string{}))
 	secret.StringData = map[string]string{}
 	secret.StringData["ca.crt"] = chain.CACert
 	secret.StringData["server.crt"] = chain.ServerCert

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -472,6 +472,7 @@ func etcdForVault(v *vaultv1alpha1.Vault) (*etcdv1beta2.EtcdCluster, error) {
 	etcdCluster.Spec.Pod = &etcdv1beta2.PodPolicy{
 		PersistentVolumeClaimSpec: v.Spec.EtcdPVCSpec,
 		Resources:                 *getEtcdResource(v),
+		Annotations:               v.Spec.EtcdPodAnnotations,
 	}
 	etcdCluster.Spec.Version = v.Spec.GetEtcdVersion()
 	etcdCluster.Spec.TLS = &etcdv1beta2.TLSPolicy{
@@ -500,10 +501,10 @@ func serviceForVault(v *vaultv1alpha1.Vault) *corev1.Service {
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      v.Name,
-			Namespace: v.Namespace,
+			Name:        v.Name,
+			Namespace:   v.Namespace,
 			Annotations: withVaultAnnotations(v, getCommonAnnotations(v, map[string]string{})),
-			Labels:    ls,
+			Labels:      ls,
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     serviceType(v),
@@ -621,10 +622,10 @@ func perInstanceServicesForVault(v *vaultv1alpha1.Vault) []*corev1.Service {
 				Kind:       "Service",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      podName,
-				Namespace: v.Namespace,
+				Name:        podName,
+				Namespace:   v.Namespace,
 				Annotations: withVaultAnnotations(v, getCommonAnnotations(v, map[string]string{})),
-				Labels:    ls,
+				Labels:      ls,
 			},
 			Spec: corev1.ServiceSpec{
 				Type:     serviceType(v),
@@ -653,10 +654,10 @@ func serviceForVaultConfigurer(v *vaultv1alpha1.Vault) *corev1.Service {
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName,
-			Namespace: v.Namespace,
+			Name:        serviceName,
+			Namespace:   v.Namespace,
 			Annotations: withVaultConfigurerAnnotations(v, getCommonAnnotations(v, map[string]string{})),
-			Labels:    ls,
+			Labels:      ls,
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,
@@ -756,8 +757,8 @@ func deploymentForConfigurer(v *vaultv1alpha1.Vault, configmaps corev1.ConfigMap
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      v.Name + "-configurer",
-			Namespace: v.Namespace,
+			Name:        v.Name + "-configurer",
+			Namespace:   v.Namespace,
 			Annotations: withVaultConfigurerAnnotations(v, getCommonAnnotations(v, map[string]string{})),
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -936,8 +937,8 @@ func statefulSetForVault(v *vaultv1alpha1.Vault) (*appsv1.StatefulSet, error) {
 			Kind:       "StatefulSet",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      v.Name,
-			Namespace: v.Namespace,
+			Name:        v.Name,
+			Namespace:   v.Namespace,
 			Annotations: withVaultAnnotations(v, getCommonAnnotations(v, map[string]string{})),
 		},
 		Spec: appsv1.StatefulSetSpec{


### PR DESCRIPTION
fixes #357 

* Split Annotations between
  * common ( Current annotations field in the spec )
  * vaultAnnotations
  * vaultConfigurerAnnotations
* Set prometheus annotations only on the pod templates
* Set annotations on Deployment and Statefulset ( needed by my use case )
* Annotate vault and vault-configurer Services
* Annotate vault-tls secret

* Fix port for prometheus-exporter in vault-service ( unrelated ) 

TODO:
* EtcdAnnotations propagation to Pods 

@bonifaido @pbalogh-sa @matyix This is a Draft pull request due the missing etcd annotations ( will do tomorrow ) and to make sure you are happy with the direction this implementation is getting. 

I mostly need this to support the External Reloader for vault when cert-manager letsencrypt tls is updated
