### PR TITLE
Fix mount config input serialisation

### DIFF
--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -1309,9 +1309,9 @@ func isOverwriteProhibitedError(err error) bool {
 
 func getMountConfigInput(secretEngine map[string]interface{}) (api.MountConfigInput, error) {
 	var mountConfigInput api.MountConfigInput
-	config, err := getOrDefaultStringMapString(secretEngine, "config")
-	if err != nil {
-		return mountConfigInput, fmt.Errorf("error getting config for secret engine: %v", config)
+	config, ok := secretEngine["config"]
+	if !ok {
+		return mountConfigInput, fmt.Errorf("error config for secret enginer not found: %v", config)
 	}
 	if err := mapstructure.Decode(config, &mountConfigInput); err != nil {
 		return mountConfigInput, fmt.Errorf("error parsing config for secret engine: %s", err.Error())

--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -1311,7 +1311,7 @@ func getMountConfigInput(secretEngine map[string]interface{}) (api.MountConfigIn
 	var mountConfigInput api.MountConfigInput
 	config, ok := secretEngine["config"]
 	if !ok {
-		return mountConfigInput, fmt.Errorf("error config for secret enginer not found: %v", config)
+		return api.MountConfigInput{}, nil
 	}
 	if err := mapstructure.Decode(config, &mountConfigInput); err != nil {
 		return mountConfigInput, fmt.Errorf("error parsing config for secret engine: %s", err.Error())


### PR DESCRIPTION
There is no need to convert the config keys to string. This will lead to decoding errors.

```time="2019-05-16T08:01:17Z" level=error msg="error configuring vault: error configuring secret engines for vault: error parsing config for secret engine: 2 error(s) decoding:\n\n* 'force_no_cache' expected type 'bool', got unconvertible type 'string'\n* 'options' expected a map, got 'string'"```