### PR TITLE
allow for annotations overrides of the consul template image

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -43,6 +43,7 @@ type vaultConfig struct {
 	tlsSecret                   string
 	useAgent                    bool
 	ctConfigMap                 string
+	ctImage                     string
 	ctOnce                      bool
 	ctShareProcess              bool
 	ctShareProcessDefault       string
@@ -167,7 +168,7 @@ func getContainers(vaultConfig vaultConfig, containerEnvVars []corev1.EnvVar, co
 
 	containers = append(containers, corev1.Container{
 		Name:            "consul-template",
-		Image:           viper.GetString("vault_ct_image"),
+		Image:           vaultConfig.ctImage,
 		Args:            ctCommandString,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: securityContext,
@@ -309,6 +310,12 @@ func parseVaultConfig(obj metav1.Object) vaultConfig {
 		vaultConfig.ctConfigMap = val
 	} else {
 		vaultConfig.ctConfigMap = ""
+	}
+
+	if val, ok := annotations["vault.security.banzaicloud.io/vault-ct-image"]; ok {
+		vaultConfig.ctImage = val
+	} else {
+		vaultConfig.ctImage = viper.GetString("vault_ct_image")
 	}
 
 	if val, ok := annotations["vault.security.banzaicloud.io/vault-ct-once"]; ok {


### PR DESCRIPTION
I have run into an edge case where the deployment may have security contexts set and you will need to override the stuff that is hard coded on a case by case basis.

It will require creating a custom image and setting securitycontext runAsUser UID, depending on your preferred approach.

The initContainer podSpec and Container podSpec I think are different so only touching the Container one.

The UID in the hashicorp container is 100:1000 for the user/group `consul-template`

