### PR TITLE
[operator] preserve NodePort for Services

### DIFF
--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -45,7 +45,7 @@ spec:
   serviceAccount: vault
 
   # Specify the Service's type where the Vault Service is exposed
-  # Please not that some Ingress controllers like https://github.com/kubernetes/ingress-gce
+  # Please note that some Ingress controllers like https://github.com/kubernetes/ingress-gce
   # forces you to expose your Service on a NodePort
   serviceType: ClusterIP
 

--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -45,6 +45,8 @@ spec:
   serviceAccount: vault
 
   # Specify the Service's type where the Vault Service is exposed
+  # Please not that some Ingress controllers like https://github.com/kubernetes/ingress-gce
+  # forces you to expose your Service on a NodePort
   serviceType: ClusterIP
 
   # Request an Ingress controller with the default configuration


### PR DESCRIPTION
Also, add the GKE Ingress controller specific Service annotation in case of HTTPS.

Fixes #482 