### PR TITLE
configurer: fix regression regarding missing secret engine options

### DIFF
--- a/cmd/examples/main.go
+++ b/cmd/examples/main.go
@@ -35,7 +35,7 @@ func vaultExample() {
 
 	log.Println("Created Vault client")
 
-	secret, err := client.Vault().Logical().List("secret/accesstokens")
+	secret, err := client.Vault().Logical().List("secret/metadata/accounts")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -43,14 +43,14 @@ func vaultExample() {
 		for _, v := range secret.Data {
 			log.Printf("-> %+v", v)
 			for _, v := range v.([]interface{}) {
-				log.Printf("-> %+v", v)
+				log.Printf("  -> %+v", v)
 			}
 		}
 
 		log.Println("Finished reading Vault")
 
 	} else {
-		log.Println("Found nothing")
+		log.Fatal("Found no data in vault")
 	}
 }
 

--- a/operator/deploy/cr-etcd-ha.yaml
+++ b/operator/deploy/cr-etcd-ha.yaml
@@ -62,6 +62,7 @@ spec:
         rules: path "secret/*" {
           capabilities = ["create", "read", "update", "delete", "list"]
           }
+
     auth:
       - type: kubernetes
         roles:
@@ -71,3 +72,20 @@ spec:
             bound_service_account_namespaces: default
             policies: allow_secrets
             ttl: 1h
+
+    secrets:
+      - path: secret
+        type: kv
+        description: General secrets.
+        options:
+          version: 2
+
+    # Allows writing some secrets to Vault (useful for development purposes).
+    # See https://www.vaultproject.io/docs/secrets/kv/index.html for more information.
+    startupSecrets:
+      - type: kv
+        path: secret/data/accounts/aws
+        data:
+          data:
+            AWS_ACCESS_KEY_ID: secretId
+            AWS_SECRET_ACCESS_KEY: s3cr3t

--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -1310,11 +1310,10 @@ func isOverwriteProhibitedError(err error) bool {
 func getMountConfigInput(secretEngine map[string]interface{}) (api.MountConfigInput, error) {
 	var mountConfigInput api.MountConfigInput
 	config, ok := secretEngine["config"]
-	if !ok {
-		return api.MountConfigInput{}, nil
-	}
-	if err := mapstructure.Decode(config, &mountConfigInput); err != nil {
-		return mountConfigInput, fmt.Errorf("error parsing config for secret engine: %s", err.Error())
+	if ok {
+		if err := mapstructure.Decode(config, &mountConfigInput); err != nil {
+			return mountConfigInput, fmt.Errorf("error parsing config for secret engine: %s", err.Error())
+		}
 	}
 
 	// Bank-Vaults supported options outside config to be used options in the mount request


### PR DESCRIPTION
Secret engine options weren't applied, this was introduced in 0.4.16.