### PR TITLE
Fix configmap name for vault agent if ownerreference does not contain -

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -374,8 +374,12 @@ func getConfigMapForVaultAgent(obj metav1.Object, vaultConfig vaultConfig) *core
 	if name == "" {
 		ownerReferences = obj.GetOwnerReferences()
 		if len(ownerReferences) > 0 {
-			generateNameSlice := strings.Split(ownerReferences[0].Name, "-")
-			name = strings.Join(generateNameSlice[:len(generateNameSlice)-1], "-")
+			if strings.Contains(ownerReferences[0].Name, "-") {
+				generateNameSlice := strings.Split(ownerReferences[0].Name, "-")
+				name = strings.Join(generateNameSlice[:len(generateNameSlice)-1], "-")
+			} else {
+				name = ownerReferences[0].Name
+			}
 		}
 	}
 	return &corev1.ConfigMap{


### PR DESCRIPTION
Fixes #507 