### PR TITLE
use 'reclaim' policy for host-path PVs

### DIFF
--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -180,6 +180,6 @@ spec:
 #     storage: 1Gi
 #   accessModes:
 #   - ReadWriteOnce
-#   persistentVolumeReclaimPolicy: Reclaim
+#   persistentVolumeReclaimPolicy: Recycle
 #   hostPath:
 #     path: /vault/file

--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -180,6 +180,6 @@ spec:
 #     storage: 1Gi
 #   accessModes:
 #   - ReadWriteOnce
-#   persistentVolumeReclaimPolicy: Delete
+#   persistentVolumeReclaimPolicy: Reclaim
 #   hostPath:
 #     path: /vault/file


### PR DESCRIPTION
While the snippet for setting up a PV at the end of this file is only for example usage/testing it needs to use the `Reclaim` policy instead of `Delete` as `Delete` isn't supported for `hostPath` PVs.  Having this set to `Delete` would cause the contents of the PV to *NOT* be deleted even when the PV was deleted which would cause bringing up subsequent iterations of Vault to fail.