### PR TITLE
specify global resourcequota everywhere

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,10 @@
 Dockerfile*
+.circle/
 .git/
 bin/
 docs/
 operator/build/
 vendor/
+hack/
+*.yaml
+*.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 Dockerfile*
-.circle/
+.circleci/
 .git/
 bin/
 docs/

--- a/deploy/test-deployment.yaml
+++ b/deploy/test-deployment.yaml
@@ -25,6 +25,10 @@ spec:
         env:
         - name: AWS_SECRET_ACCESS_KEY
           value: vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
       containers:
       - name: alpine
         image: alpine
@@ -32,6 +36,10 @@ spec:
         env:
         - name: AWS_SECRET_ACCESS_KEY
           value: vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
       - name: mysql
         image: mysql # see that containers without explicit command can work
         env:
@@ -40,5 +48,9 @@ spec:
         ports:
         - name: mysql
           containerPort: 3306
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
       # imagePullSecrets:
       # - sample-secret

--- a/docs/mutating-webhook/consul-template.md
+++ b/docs/mutating-webhook/consul-template.md
@@ -95,7 +95,9 @@ vault.security.banzaicloud.io/vault-ct-configmap|""|A configmap name which holds
 vault.security.banzaicloud.io/vault-ct-image|""|Specify a custom image for consul template|
 vault.security.banzaicloud.io/vault-ct-once|false|do not run consul-template in daemon mode, useful for kubernetes jobs|
 vault.security.banzaicloud.io/vault-ct-pull-policy|IfNotPresent|the Pull policy for the consul template container|
-vault.security.banzaicloud.io/vault-ct-share-process-namespace|Same as VAULT_CT_SHARE_PROCESS_NAMESPACE above||
+vault.security.banzaicloud.io/vault-ct-share-process-namespace|Same as VAULT_CT_SHARE_PROCESS_NAMESPACE above|
+vault.security.banzaicloud.io/vault-ct-cpu|"100m"|Specify the consul-template container CPU resource limit|
+vault.security.banzaicloud.io/vault-ct-memory|"128Mi"|Specify the consul-template container memory resource limit|
 vault.security.banzaicloud.io/vault-ignore-missing-secrets|"false"|When enabled will only log warnings when Vault secrets are missing|
 vault.security.banzaicloud.io/vault-env-passthrough|""|Comma seprated list of `VAULT_*` related environment variables to pass through to main process. E.g.`VAULT_ADDR,VAULT_ROLE`.
 

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -57,7 +57,6 @@ kubectl delete -f operator/deploy/cr-etcd-ha.yaml
 kubectl apply -f operator/deploy/cr.yaml
 waitfor kubectl get pod/vault-0
 kubectl wait --for=condition=ready pod/vault-0 --timeout=120s
-kubectl delete --wait=true -f operator/deploy/cr.yaml
 
 # Run a client test
 
@@ -65,7 +64,7 @@ kubectl delete --wait=true -f operator/deploy/cr.yaml
 sleep 20
 
 # Run an internal client which tries to read from Vault with the configured Kubernetes auth backend
-go get -v github.com/banzaicloud/kurun
+go get github.com/banzaicloud/kurun
 git checkout -- go.mod go.sum
 export PATH=${PATH}:${GOPATH}/bin
 kurun cmd/examples/main.go

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -21,6 +21,9 @@ function finish {
 
 trap finish EXIT
 
+# Create a resource quota in the default namespace
+kubectl create quota bank-vaults --hard=cpu=2,memory=4G,pods=10,services=10,replicationcontrollers=10,secrets=10,persistentvolumeclaims=10
+
 # Install the operators and companion
 kubectl apply -f operator/deploy/etcd-rbac.yaml
 kubectl apply -f operator/deploy/etcd-operator.yaml

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -5,7 +5,7 @@ function waitfor {
     WAIT_MAX=0
     until $@ &> /dev/null || [ $WAIT_MAX -eq 30 ]; do
         sleep 1
-        (( WAIT_MAX++ ))
+        (( WAIT_MAX = WAIT_MAX + 1 ))
     done
 }
 

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -38,7 +38,7 @@ kubectl apply -f operator/deploy/rbac.yaml
 
 # First test: single node cluster
 kubectl apply -f operator/deploy/cr.yaml
-sleep 5
+kubectl 10
 kubectl wait --for=condition=ready pod/vault-0 --timeout=120s
 kubectl delete --wait=true -f operator/deploy/cr.yaml
 

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -14,7 +14,7 @@ function finish {
     kubectl get pods
     kubectl logs deployment/vault-operator
     kubectl describe pod -l name=vault-operator
-    kubectl describe pod vault-0 vault-1
+    kubectl describe pod -l app=vault
     kubectl describe pod -l app=vault-configurator
     kubectl get services --show-labels -l vault_cr=vault
     kubectl get ep --show-labels -l vault_cr=vault

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -41,22 +41,23 @@ kubectl apply -f operator/deploy/operator-rbac.yaml
 kubectl apply -f operator/deploy/operator.yaml
 kubectl wait --for=condition=available deployment/vault-operator --timeout=120s
 
+# Install common RBAC setup for CRs
 kubectl apply -f operator/deploy/rbac.yaml
 
-# First test: single node cluster
-kubectl apply -f operator/deploy/cr.yaml
-waitfor kubectl get pod/vault-0
-kubectl wait --for=condition=ready pod/vault-0 --timeout=120s
-kubectl delete --wait=true -f operator/deploy/cr.yaml
-
-
-# Second test: HA setup with etcd
+# First test: HA setup with etcd
 kubectl apply -f operator/deploy/cr-etcd-ha.yaml
 waitfor kubectl get etcdclusters.etcd.database.coreos.com/etcd-cluster
 kubectl wait --for=condition=available etcdclusters.etcd.database.coreos.com/etcd-cluster --timeout=120s
 waitfor kubectl get pod/vault-0
 waitfor kubectl get pod/vault-1
 kubectl wait --for=condition=ready pod/vault-0 --timeout=120s
+kubectl delete -f operator/deploy/cr-etcd-ha.yaml
+
+# Second test: single node cluster, for additional tests
+kubectl apply -f operator/deploy/cr.yaml
+waitfor kubectl get pod/vault-0
+kubectl wait --for=condition=ready pod/vault-0 --timeout=120s
+kubectl delete --wait=true -f operator/deploy/cr.yaml
 
 # Run a client test
 

--- a/operator/deploy/etcd-operator.yaml
+++ b/operator/deploy/etcd-operator.yaml
@@ -42,4 +42,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+          resources:
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
       serviceAccount: etcd-operator

--- a/operator/deploy/operator.yaml
+++ b/operator/deploy/operator.yaml
@@ -70,5 +70,5 @@ spec:
               value: "vault-operator"
           resources:
             limits:
-              cpu: "300m"
+              cpu: "100m"
               memory: "128Mi"

--- a/operator/deploy/operator.yaml
+++ b/operator/deploy/operator.yaml
@@ -70,5 +70,5 @@ spec:
               value: "vault-operator"
           resources:
             limits:
-              cpu: "200m"
+              cpu: "300m"
               memory: "128Mi"

--- a/operator/deploy/operator.yaml
+++ b/operator/deploy/operator.yaml
@@ -68,3 +68,7 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "vault-operator"
+          resources:
+            limits:
+              cpu: "200m"
+              memory: "128Mi"


### PR DESCRIPTION
Fixes: #515 

- set resource limits on ALL resources
- set a `resourcequota` globally in CI to verify this in the acceptance test
- make the acceptance test more robust
