### PR TITLE
[vault-secrets-webhook] Fix Handle pod spec when CMD is absent and ARGS are present.

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -563,7 +563,7 @@ func (mw *mutatingWebhook) mutateContainers(containers []corev1.Container, podSp
 
 		mutated = true
 
-		args := append(container.Command, container.Args...)
+		args := container.Command
 
 		// the container has no explicitly specified command
 		if len(args) == 0 {
@@ -575,6 +575,7 @@ func (mw *mutatingWebhook) mutateContainers(containers []corev1.Container, podSp
 			args = append(args, imageConfig.Entrypoint...)
 			args = append(args, imageConfig.Cmd...)
 		}
+		args = append(args, container.Args...)
 
 		container.Command = []string{"/vault/vault-env"}
 		container.Args = args

--- a/cmd/vault-secrets-webhook/registry/registry.go
+++ b/cmd/vault-secrets-webhook/registry/registry.go
@@ -253,6 +253,18 @@ func (k *ContainerInfo) Collect(container *corev1.Container, podSpec *corev1.Pod
 		}
 	}
 
+	// In case of other public docker registry
+	if k.RegistryName == "" && k.RegistryAddress == "" {
+		registryName := container.Image
+		if strings.HasPrefix(registryName, "https://") {
+			registryName = strings.TrimPrefix(registryName, "https://")
+		}
+
+		registryName = strings.Split(registryName, "/")[0]
+		k.RegistryName = registryName
+		k.RegistryAddress = fmt.Sprintf("https://%s", registryName)
+	}
+
 	// Clean registry from image
 	k.Image = strings.TrimPrefix(k.Image, fmt.Sprintf("%s/", k.RegistryName))
 


### PR DESCRIPTION
Also 
Fix handling other public docker registries without docker creds.

Fix for cases like https://github.com/helm/charts/tree/master/stable/external-dns