### PR TITLE
[Operator] Support generic PodSpec fields on CRD

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/hashicorp/vault v1.1.2
 	github.com/heroku/docker-registry-client v0.0.0-20181004091502-47ecf50fd8d4
 	github.com/huandu/xstrings v1.0.0 // indirect
-	github.com/imdario/mergo v0.3.4 // indirect
+	github.com/imdario/mergo v0.3.4
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jinzhu/gorm v1.9.1 // indirect
 	github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a // indirect

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/spf13/cast"
 	v1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -112,8 +112,10 @@ type VaultSpec struct {
 	Annotations                map[string]string     `json:"annotations"`
 	VaultAnnotations           map[string]string     `json:"vaultAnnotations"`
 	VaultLabels                map[string]string     `json:"vaultLabels"`
+	VaultPodSpec               v1.PodSpec            `json:"vaultPodSpec"`
 	VaultConfigurerAnnotations map[string]string     `json:"vaultConfigurerAnnotations"`
 	VaultConfigurerLabels      map[string]string     `json:"vaultConfigurerLabels"`
+	VaultConfigurerPodSpec     v1.PodSpec            `json:"vaultConfigurerPodSpec"`
 	Config                     VaultConfig           `json:"config"`
 	ExternalConfig             VaultExternalConfig   `json:"externalConfig"`
 	UnsealConfig               UnsealConfig          `json:"unsealConfig"`

--- a/operator/pkg/apis/vault/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/vault/v1alpha1/zz_generated.deepcopy.go
@@ -355,6 +355,7 @@ func (in *VaultSpec) DeepCopyInto(out *VaultSpec) {
 			(*out)[key] = val
 		}
 	}
+	in.VaultPodSpec.DeepCopyInto(&out.VaultPodSpec)
 	if in.VaultConfigurerAnnotations != nil {
 		in, out := &in.VaultConfigurerAnnotations, &out.VaultConfigurerAnnotations
 		*out = make(map[string]string, len(*in))
@@ -369,6 +370,7 @@ func (in *VaultSpec) DeepCopyInto(out *VaultSpec) {
 			(*out)[key] = val
 		}
 	}
+	in.VaultConfigurerPodSpec.DeepCopyInto(&out.VaultConfigurerPodSpec)
 	out.Config = in.Config.DeepCopy()
 	out.ExternalConfig = in.ExternalConfig.DeepCopy()
 	in.UnsealConfig.DeepCopyInto(&out.UnsealConfig)


### PR DESCRIPTION
This PR addresses https://github.com/banzaicloud/bank-vaults/issues/530

This enables users to update the pod spec for created pods without having to add new fields to the CRD. The merge functionality ensures operator defined fields on the PodSpec are always respected. 

In the future, following a deprecation schedule, we could remove all of these fields and achieve the same results by using only the pod spec. 

```go
PodAntiAffinity       string                        `json:"podAntiAffinity"`
NodeAffinity          v1.NodeAffinity               `json:"nodeAffinity"`
NodeSelector          map[string]string             `json:"nodeSelector"`
Tolerations           []v1.Toleration               `json:"tolerations"`
ServiceAccount        string                        `json:"serviceAccount"`
Volumes               []v1.Volume                   `json:"volumes,omitempty"`
VolumeMounts          []v1.VolumeMount              `json:"volumeMounts,omitempty"`
VaultEnvsConfig       []v1.EnvVar                   `json:"vaultEnvsConfig"`
Resources             *Resources                    `json:"resources,omitempty"`
```
https://github.com/banzaicloud/bank-vaults/blob/master/operator/pkg/apis/vault/v1alpha1/vault_types.go#L133-L141 