### PR TITLE
Cluster vs namespaced Role seemed to be swapped around, the chart dep…

### DIFF
--- a/operator/deploy/operator-rbac.yaml
+++ b/operator/deploy/operator-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: vault-operator
 rules:
@@ -73,7 +73,7 @@ rules:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: vault-operator
 rules:


### PR DESCRIPTION
…loys it 'this way' as well (chart Cluster Role link: https://github.com/banzaicloud/banzai-charts/blob/master/vault-operator/templates/role.yaml)

as per conversation with 'Jared E' on slack:

```
{"level":"info","ts":1561520235.3518147,"logger":"metrics","msg":"Metrics Service object created","Service.Name":"vault-operator","Service.Namespace":"default"}
{"level":"info","ts":1561520235.3518553,"logger":"cmd","msg":"Starting the Cmd."}
E0626 03:37:15.353833       1 reflector.go:134] pkg/mod/k8s.io/client-go@v2.0.0-alpha.0.0.20181213151034-8d9ed539ba31+incompatible/tools/cache/reflector.go:95: Failed to list *v1alpha1.Vault: vaults.vault.banzaicloud.com is forbidden: User "system:serviceaccount:default:vault-operator" cannot list vaults.vault.banzaicloud.com at the cluster scope
```