### PR TITLE
Add support for "create_only" field to secrets

### DIFF
--- a/operator/deploy/cr-gcs-ha.yaml
+++ b/operator/deploy/cr-gcs-ha.yaml
@@ -45,6 +45,12 @@ spec:
         rules: path "secret/*" {
           capabilities = ["create", "read", "update", "delete", "list"]
           }
+      - name: gcp_editor_access
+        rules: |
+          path "gcp/key/editor"
+          {
+            capabilities = ["read"]
+          }
     auth:
       - type: kubernetes
         roles:
@@ -54,6 +60,27 @@ spec:
             bound_service_account_namespaces: default
             policies: allow_secrets
             ttl: 1h
+    # See: https://www.vaultproject.io/docs/secrets/gcp/index.html
+    secrets:
+      - type: gcp
+        path: gcp/
+        description: Google cloud secret backend
+        configuration:
+          config:
+            - ttl: "60m"
+              max_ttl: "0"
+          roleset:
+            - name: editor
+              # To avoid vault deleting and recreating the Google Service Account everytime this config is applied 
+              # set create_only=true. Disable when you need to actually apply a change
+              create_only: "true"
+              secret_type: "service_account_key"
+              project: "continual-air-196513"
+              bindings: |
+                resource "//cloudresourcemanager.googleapis.com/projects/continual-air-196513" {
+                  roles = ["roles/editor", "roles/iam.securityAdmin", "roles/iam.roleAdmin", "roles/container.admin"]
+                }
+
 
   # If you are not using a Service Account to authenticate against GCP you can pass in an
   # GCP credentials refering to a Secret with the following configuration block. You have to

--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -1014,11 +1014,10 @@ func (v *vault) configureSecretEngines(config *viper.Viper) error {
 				// Control if the configs should be updated or just Created once and skipped later on
 				// This is a workaround to secrets backend like GCP that will destroy and recreate secrets at every iteration
 				create_only := cast.ToBool(subConfigData["create_only"])
+				// Delete the create_only key from the map, so we don't push it to vault
+				delete(subConfigData, "create_only")
 
 				if create_only && mountExists {
-					// Delete the create_only key from the map, just in case
-					delete(subConfigData, "create_only")
-
 					sec, err := v.cl.Logical().Read(configPath)
 					if err != nil {
 						return fmt.Errorf("error reading configPath %s: %s", configPath, err.Error())

--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -1011,6 +1011,25 @@ func (v *vault) configureSecretEngines(config *viper.Viper) error {
 					continue
 				}
 
+				// Control if the configs should be updated or just Created once and skipped later on
+				// This is a workaround to secrets backend like GCP that will destroy and recreate secrets at every iteration
+				create_only := cast.ToBool(subConfigData["create_only"])
+
+				if create_only && mountExists {
+					// Delete the create_only key from the map, just in case
+					delete(subConfigData, "create_only")
+
+					sec, err := v.cl.Logical().Read(configPath)
+					if err != nil {
+						return fmt.Errorf("error reading configPath %s: %s", configPath, err.Error())
+					}
+
+					if sec != nil {
+						logrus.Infoln("Secret at configpath ", configPath, "already exists, create_only was set so this will skipped and not updated")
+						continue
+					}
+				}
+
 				_, err = v.cl.Logical().Write(configPath, subConfigData)
 				if err != nil {
 					if isOverwriteProhibitedError(err) {


### PR DESCRIPTION
fixes #537 

I have been trying to get something to test this in the acceptance-test.sh but failed so far because the only backend i know to test this with is GCP Secrets and it does require a google configuration to be actually mounted and used
