### PR TITLE
Object matcher and vault CR status matcher fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ include main-targets.mk
 .PHONY: up
 up: ## Set up the development environment
 
-
 .PHONY: down
 down: clean ## Destroy the development environment
 
@@ -127,4 +126,15 @@ minor: ## Release a new minor version
 .PHONY: major
 major: ## Release a new major version
 	@${MAKE} release-$(shell git describe --abbrev=0 --tags | awk -F'[ .]' '{print $$1+1".0.0"}')
+
+.PHONY: operator-up
+operator-up:
+	kubectl apply -f operator/deploy/crd.yaml
+	kubectl apply -f operator/deploy/rbac.yaml
+	OPERATOR_NAME=vault-dev go run operator/cmd/manager/main.go -verbose
+
+.PHONY: operator-down
+operator-down:
+	kubectl delete -f operator/deploy/crd.yaml
+	kubectl delete -f operator/deploy/rbac.yaml
 

--- a/operator/deploy/crd.yaml
+++ b/operator/deploy/crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: vaults.vault.banzaicloud.com
+spec:
+  group: vault.banzaicloud.com
+  names:
+    kind: Vault
+    listKind: VaultList
+    plural: vaults
+    singular: vault
+  scope: Namespaced
+  version: v1alpha1


### PR DESCRIPTION
- The annotation required for object matching must be applied after the patch calculation, but before setting the resource version.
- Pod names must be sorted to avoid unncessary updates.