### PR TITLE
RBAC - allow Operator to list replicasets

### DIFF
--- a/operator/deploy/operator-rbac.yaml
+++ b/operator/deploy/operator-rbac.yaml
@@ -40,6 +40,7 @@ rules:
     resources:
       - replicasets
     verbs:
+      - list
       - get
   - apiGroups:
       - apps


### PR DESCRIPTION
Bug fix Vault Operator: user forbidden for access metrics in replicaset.app 

Grant access to list replicaset K8s objects. 