### PR TITLE
make preFlightChecks true by default

### DIFF
--- a/cmd/bank-vaults/init.go
+++ b/cmd/bank-vaults/init.go
@@ -66,7 +66,7 @@ It will not unseal the Vault instance after initialising.`,
 func init() {
 	initCmd.PersistentFlags().String(cfgInitRootToken, "", "root token for the new vault cluster")
 	initCmd.PersistentFlags().Bool(cfgStoreRootToken, true, "should the root token be stored in the key store")
-	initCmd.PersistentFlags().Bool(cfgPreFlightChecks, false, "should the key store be tested first to validate access rights")
+	initCmd.PersistentFlags().Bool(cfgPreFlightChecks, true, "should the key store be tested first to validate access rights")
 
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -143,7 +143,7 @@ func init() {
 	unsealCmd.PersistentFlags().Bool(cfgOnce, false, "Run unseal only once")
 	unsealCmd.PersistentFlags().String(cfgInitRootToken, "", "Root token for the new vault cluster (only if -init=true)")
 	unsealCmd.PersistentFlags().Bool(cfgStoreRootToken, true, "Should the root token be stored in the key store (only if -init=true)")
-	unsealCmd.PersistentFlags().Bool(cfgPreFlightChecks, false, "should the key store be tested first to validate access rights")
+	unsealCmd.PersistentFlags().Bool(cfgPreFlightChecks, true, "should the key store be tested first to validate access rights")
 	unsealCmd.PersistentFlags().Bool(cfgAuto, false, "Run in auto-unseal mode")
 
 	rootCmd.AddCommand(unsealCmd)

--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -87,6 +87,7 @@ spec:
   unsealConfig:
     options:
       # The preFlightChecks flag enables unseal and root token storage tests
+      # This is true by default
       preFlightChecks: true
     kubernetes:
       secretNamespace: default

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -587,12 +587,12 @@ type UnsealConfig struct {
 
 // UnsealOptions represents the common options to all unsealing backends
 type UnsealOptions struct {
-	PreFlightChecks bool `json:"preFlightChecks,omitempty"`
+	PreFlightChecks *bool `json:"preFlightChecks,omitempty"`
 }
 
 func (uso UnsealOptions) ToArgs() []string {
 	args := []string{}
-	if uso.PreFlightChecks {
+	if uso.PreFlightChecks == nil || *uso.PreFlightChecks {
 		args = append(args, "--pre-flight-checks", "true")
 	}
 	return args


### PR DESCRIPTION
Fixes: #558 

This should prevent a lot of bad Vault initializations, where the unseal keys can't be saved.