### PR TITLE
Allow enable debug logs

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -829,6 +829,11 @@ func init() {
 	viper.AutomaticEnv()
 
 	logger = log.New()
+	b, _ := strconv.ParseBool(viper.GetString("debug"))
+	if b {
+		logger.SetLevel(log.DebugLevel)
+		logger.Debug("Debug mode enabled")
+	}
 }
 
 func healthzHandler(w http.ResponseWriter, r *http.Request) {
@@ -852,7 +857,6 @@ func handlerFor(config mutating.WebhookConfig, mutator mutating.MutatorFunc, log
 var logger *log.Logger
 
 func main() {
-
 	k8sClient, err := newK8SClient()
 	if err != nil {
 		log.Fatalf("error creating k8s client: %s", err)

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -829,8 +829,7 @@ func init() {
 	viper.AutomaticEnv()
 
 	logger = log.New()
-	b, _ := strconv.ParseBool(viper.GetString("debug"))
-	if b {
+	if viper.GetBool("debug") {
 		logger.SetLevel(log.DebugLevel)
 		logger.Debug("Debug mode enabled")
 	}


### PR DESCRIPTION
Hello

Looks like after https://github.com/banzaicloud/bank-vaults/commit/f4cb1be2a1e48f3a439b7744bca9f36ca0e41440 debug logs can't be enabled by setting `DEBUG` environment variable, it's so sad when you trying to understand why something doesn't work.
