### PR TITLE
helm: bump chart and app versions

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.4.18
+appVersion: 0.5.0
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.2.17
+version: 0.3.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/charts/vault-operator/values.yaml
+++ b/charts/vault-operator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: banzaicloud/vault-operator
-  tag: 0.4.18
+  tag: 0.5.0
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.4.18"
+appVersion: "0.5.0"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.3.23
+version: 0.4.0
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -8,7 +8,7 @@ debug: false
 
 image:
   repository: banzaicloud/vault-secrets-webhook
-  tag: 0.4.18
+  tag: 0.5.0
   pullPolicy: IfNotPresent
   imagePullSecrets: []
 

--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.6.11
-appVersion: 1.1.2
+version: 0.7.1
+appVersion: 1.1.5
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -6,7 +6,7 @@ strategy:
   type: RollingUpdate
 image:
   repository: vault
-  tag: 1.1.2
+  tag: 1.1.5
   pullPolicy: IfNotPresent
 dockerizeImage:
   repository: jwilder/dockerize
@@ -167,7 +167,7 @@ vault:
 unsealer:
   image:
     repository: banzaicloud/bank-vaults
-    tag: 0.4.18
+    tag: 0.5.0
     pullPolicy: IfNotPresent
   args: [
       "--mode",


### PR DESCRIPTION
vault has been bumped to 0.7.1 since 0.7.0 was taken already.