### PR TITLE
make the webhook failure policy configurable, also set the default to…

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.4.0
+version: 0.4.1
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -40,7 +40,11 @@ items:
       - "*"
       resources:
       - pods
-    failurePolicy: Fail
+    {{ if .Values.PodsFailurePolicy }}
+    failurePolicy: {{ .Values.PodsFailurePolicy }}
+    {{- else -}}
+    failurePolicy: Ignore
+    {{- end }}
     namespaceSelector:
     {{- if .Values.namespaceSelector.matchLabels }}
       matchLabels:
@@ -71,7 +75,11 @@ items:
       - "*"
       resources:
       - secrets
-    failurePolicy: Fail
+    {{ if .Values.SecretsfailurePolicy }}
+    failurePolicy: {{ .Values.SecretsFailurePolicy }}
+    {{- else -}}
+    failurePolicy: Ignore
+    {{- end }}
     namespaceSelector:
     {{- if .Values.namespaceSelector.matchLabels }}
       matchLabels:
@@ -103,7 +111,11 @@ items:
           - "*"
         resources:
           - configmaps
-    failurePolicy: Fail
+    {{ if .Values.ConfigmapFailurePolicy }}
+    failurePolicy: {{ .Values.ConfigmapFailurePolicy }}
+    {{- else -}}
+    failurePolicy: Ignore
+    {{- end }}
     namespaceSelector:
     {{- if .Values.namespaceSelector.matchLabels }}
       matchLabels:

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -40,11 +40,7 @@ items:
       - "*"
       resources:
       - pods
-    {{ if .Values.PodsFailurePolicy }}
-    failurePolicy: {{ .Values.PodsFailurePolicy }}
-    {{- else -}}
-    failurePolicy: Ignore
-    {{- end }}
+    failurePolicy: {{ .Values.podsFailurePolicy }}
     namespaceSelector:
     {{- if .Values.namespaceSelector.matchLabels }}
       matchLabels:
@@ -75,11 +71,7 @@ items:
       - "*"
       resources:
       - secrets
-    {{ if .Values.SecretsfailurePolicy }}
-    failurePolicy: {{ .Values.SecretsFailurePolicy }}
-    {{- else -}}
-    failurePolicy: Ignore
-    {{- end }}
+    failurePolicy: {{ .Values.secretsFailurePolicy }}
     namespaceSelector:
     {{- if .Values.namespaceSelector.matchLabels }}
       matchLabels:
@@ -111,11 +103,7 @@ items:
           - "*"
         resources:
           - configmaps
-    {{ if .Values.ConfigmapFailurePolicy }}
-    failurePolicy: {{ .Values.ConfigmapFailurePolicy }}
-    {{- else -}}
-    failurePolicy: Ignore
-    {{- end }}
+    failurePolicy: {{ .Values.configmapFailurePolicy }}
     namespaceSelector:
     {{- if .Values.namespaceSelector.matchLabels }}
       matchLabels:

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -49,3 +49,9 @@ rbac:
 
 # This can cause issues when used with Helm, so it is not enabled by default
 configMapMutation: false
+
+configmapFailurePolicy: Ignore
+
+podsFailurePolicy: Ignore
+
+secretsFailurePolicy: Ignore


### PR DESCRIPTION
… Ignore, having it as fail means if the webhook starts failing all pods/resources will not schedule/update!