### PR TITLE
[webhook]: Add support for a default imagePullSecret

### DIFF
--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -22,6 +22,11 @@ env:
   VAULT_IMAGE: vault:latest
   VAULT_ENV_IMAGE: banzaicloud/vault-env:latest
   # VAULT_CAPATH: /vault/tls
+  # used when the pod that should get secret injected does not specify
+  # an imagePullSecret
+  # DEFAULT_IMAGE_PULL_SECRET:
+  # DEFAULT_IMAGE_PULL_SECRET_NAMESPACE:
+
 
 volumes: []
 # - name: vault-tls

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -832,6 +832,7 @@ func init() {
 	viper.SetDefault("listen_address", ":8443")
 	viper.SetDefault("default_image_pull_secret", "")
 	viper.SetDefault("default_image_pull_secret_namespace", "")
+	viper.SetDefault("registry_skip_verify", "false")
 	viper.SetDefault("debug", "false")
 	viper.AutomaticEnv()
 

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -830,6 +830,8 @@ func init() {
 	viper.SetDefault("vault_env_passthrough", "")
 	viper.SetDefault("mutate_configmap", "false")
 	viper.SetDefault("listen_address", ":8443")
+	viper.SetDefault("default_image_pull_secret", "")
+	viper.SetDefault("default_image_pull_secret_namespace", "")
 	viper.SetDefault("debug", "false")
 	viper.AutomaticEnv()
 

--- a/cmd/vault-secrets-webhook/registry/registry.go
+++ b/cmd/vault-secrets-webhook/registry/registry.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 	"sync"
 
@@ -107,12 +106,12 @@ func GetImageConfig(
 func getImageBlob(container ContainerInfo) (*imagev1.ImageConfig, error) {
 	imageName, tag := parseContainerImage(container.Image)
 
-	registrySkipVerify := os.Getenv("REGISTRY_SKIP_VERIFY")
+	registrySkipVerify := viper.GetBool("registry_skip_verify")
 
 	var hub *registry.Registry
 	var err error
 
-	if registrySkipVerify == "true" {
+	if registrySkipVerify {
 		hub, err = registry.NewInsecure(container.RegistryAddress, container.RegistryUsername, container.RegistryPassword)
 	} else {
 		hub, err = registry.New(container.RegistryAddress, container.RegistryUsername, container.RegistryPassword)


### PR DESCRIPTION
**Description:**
Add environment variables to the vault-secrets-webhook that allow the specification of a default imagePullSecret that will be used when the pod that should get secrets injected does not specify an imagePullSecret (or the specified imagePullSecret does not contain matching credentials).

**Use case:**
We use a centralized docker registry to host our images and to proxy requests to upstream registries. There is only one set of credentials that is configured by default on all our kubernetes nodes so that we do not have to hand out the credentials to our users.

By being able to specify a default secret for the vault-secret-webhook, we can keep a setup where our users do not need to know about the credentials of the central docker registry. But the implementation still retains the option to explicitly specify a secret on the pod-to-be-injected if necessary.