### PR TITLE
[webhook,operator] Webhook docker credentials auth + documentation update

### DIFF
--- a/docs/mutating-webhook/README.md
+++ b/docs/mutating-webhook/README.md
@@ -151,6 +151,9 @@ kubectl annotate secret dockerhub vault.security.banzaicloud.io/vault-path="kube
 
 The Webhook is now capable of determining the container's entrypoint and command with the help of image metadata queried from the image registry, this data is cached until the webhook Pod is restarted. If the registry is publicly accessible (without authentication) you don't need to do anything, but if the registry requires authentication the credentials have to be available in the Pod's `imagePullSecrets` section.
 
+You can also specify a default secret to be used by the webhook for cases where a pod has no `imagePullSecrets` specified. For this to work you have to set the environment variables `DEFAULT_IMAGE_PULL_SECRET` and `DEFAULT_IMAGE_PULL_SECRET_NAMESPACE` when deploying the vault-secrets-webhook. Have a look at the values.yaml of the
+[vault-secrets-webhook](https://github.com/banzaicloud/bank-vaults/blob/master/charts/vault-secrets-webhook/values.yaml) helm chart to see how this is done.
+
 Future improvements:
 - on AWS and GKE get a credential dynamically with the specific SDK
 - query the ServiceAccount's `imagePullSecrets` as well

--- a/operator/deploy/cr-transit-unseal.yaml
+++ b/operator/deploy/cr-transit-unseal.yaml
@@ -81,8 +81,8 @@ spec:
           # Allow every the tenant Vault Pod in the tenant namespace to use
           # its transit engine
           - name: tenant
-            bound_service_account_names: default
-            bound_service_account_namespaces: tenant
+            bound_service_account_names: ["default", "vault-secrets-webhook"]
+            bound_service_account_namespaces: ["tenant","vswh"]
             policies: allow_tenant_transit
             ttl: 1m
 
@@ -92,6 +92,7 @@ spec:
   caNamespaces:
     - "tenant"
     - "vault-infra"
+    - "vswh"
 
   # Request and mount a Persistent Volume to this Vault instance
   volumes:


### PR DESCRIPTION
**Add support for the `auth` field in docker credentials**
Instead of solely relying on the `username` / `password` fields in the `imagePullSecrets` for a given registry, fall back to the `auth` field if necessary.

I did some research and found no conclusive information if any of the fields are "required". https://github.com/moby/moby/blob/master/api/types/auth.go lists all fields as "omitempty". Doing a `docker login` with a recent version of docker creates a config.json only containing the `auth` field. Using `kubectl create secret docker-registry` creates a secret containing all 3 fields.

**Update webhook documentation**
Add a reference to the default imagePullSecrets to the webhook documentation

**Update operator transit unseal example**
From what I see in other examples e.g. https://github.com/banzaicloud/bank-vaults/blob/73c7c5bff7ebcdefec89e640eeb725d99015ce87/operator/deploy/cr.yaml#L123-L126 and my own experiments the ServiceAccount used for the vault-secrets-webhook also needs access to the unseal vault to at least retrieve the `VAULT_TOKEN: "vault:login"`