### PR TITLE
make the webhook locally runnable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,3 +138,8 @@ operator-down:
 	kubectl delete -f operator/deploy/crd.yaml
 	kubectl delete -f operator/deploy/rbac.yaml
 
+.PHONY: webhook-up
+webhook-up:
+	helm upgrade --install vault-secrets-webhook charts/vault-secrets-webhook --namespace vault-infra --set replicaCount=0
+	go run ./cmd/vault-secrets-webhook
+	# kurun port-forward localhost:8443 --namespace vault-infra --servicename vault-secrets-webhook --tlssecret vault-secrets-webhook

--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,14 @@ operator-down:
 	kubectl delete -f operator/deploy/crd.yaml
 	kubectl delete -f operator/deploy/rbac.yaml
 
-.PHONY: webhook-up
-webhook-up:
+.PHONY: webhook-run
+webhook-run: ## Install the webhook chart and run the webhook locally
 	helm upgrade --install vault-secrets-webhook charts/vault-secrets-webhook --namespace vault-infra --set replicaCount=0
 	go run ./cmd/vault-secrets-webhook
-	# kurun port-forward localhost:8443 --namespace vault-infra --servicename vault-secrets-webhook --tlssecret vault-secrets-webhook
+
+.PHONY: webhook-forward ## Run kurun to port-forward the local webhook into Kubernetes
+webhook-forward:
+	kurun port-forward localhost:8443 --namespace vault-infra --servicename vault-secrets-webhook --tlssecret vault-secrets-webhook
+
+.PHONY: webhook-up ## Run the webhook and `kurun port-forward` in foreground. Use with make -j.
+webhook-up: webhook-run webhook-forward

--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.4.3
+version: 0.4.4
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -15,9 +15,9 @@ items:
   metadata:
     name: {{ template "vault-secrets-webhook.fullname" . }}
   data:
-    servingCert: {{ b64enc $server.Cert }}
-    servingKey: {{ b64enc $server.Key }}
-    caCert: {{ b64enc $ca.Cert }}
+    tls.crt: {{ b64enc $server.Cert }}
+    tls.key: {{ b64enc $server.Key }}
+    ca.crt:  {{ b64enc $ca.Cert }}
 
 - apiVersion: admissionregistration.k8s.io/v1beta1
   kind: MutatingWebhookConfiguration

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -40,9 +40,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: TLS_CERT_FILE
-              value: /var/serving-cert/servingCert
+              value: /var/serving-cert/tls.crt
             - name: TLS_PRIVATE_KEY_FILE
-              value: /var/serving-cert/servingKey
+              value: /var/serving-cert/tls.key
             - name: DEBUG
               value: {{ .Values.debug | quote }}
             {{- range $key, $value := .Values.env }}

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -38,7 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeVer "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	kubernetesConfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 type vaultConfig struct {
@@ -716,16 +716,12 @@ func newVaultClient(vaultConfig vaultConfig) (*vault.Client, error) {
 }
 
 func newK8SClient() (*kubernetes.Clientset, error) {
-	kubeConfig, err := rest.InClusterConfig()
+	kubeConfig, err := kubernetesConfig.GetConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	clientset, err := kubernetes.NewForConfig(kubeConfig)
-	if err != nil {
-		return nil, err
-	}
-	return clientset, nil
+	return kubernetes.NewForConfig(kubeConfig)
 }
 
 func (mw *mutatingWebhook) mutatePod(pod *corev1.Pod, vaultConfig vaultConfig, ns string, dryRun bool) error {

--- a/cmd/vault-secrets-webhook/registry/registry.go
+++ b/cmd/vault-secrets-webhook/registry/registry.go
@@ -312,7 +312,7 @@ func (k *ContainerInfo) Collect(container *corev1.Container, podSpec *corev1.Pod
 	}
 
 	if !found {
-		logger.Infof("found no credentials for registry %s, assuming it is public")
+		logger.Infof("found no credentials for registry %s, assuming it is public", k.RegistryName)
 	}
 
 	// In case of other public docker registry


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
This small change makes it possible to run the mutating webhook outside of Kubernetes for rapid development with kurun.

### Why?
Makes the development cycle rapid and the app debuggable.


### Additional context
You need to install [kurun](https://github.com/banzaicloud/kurun) for this.

