### PR TITLE
webhook/configmap: mutate BinaryData as well

### DIFF
--- a/deploy/test-configmap.yaml
+++ b/deploy/test-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: configMap
+metadata:
+  name: sample-configmap
+  annotations:
+    vault.security.banzaicloud.io/vault-addr: "https://vault.default.svc.cluster.local:8200"
+    vault.security.banzaicloud.io/vault-role: "default"
+    vault.security.banzaicloud.io/vault-skip-verify: "true"
+    vault.security.banzaicloud.io/vault-path: "kubernetes"
+data:
+  certificate.pem: vault:secret/data/certificates/web#certificate
+binaryData:
+  certificate.key: dmF1bHQ6c2VjcmV0L2RhdGEvY2VydGlmaWNhdGVzL3dlYiNjZXJ0aWZpY2F0ZV9rZXk=


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds the possibility to mutate the binary data of configmaps.
Binary data must be base64 encoded inside vault (https://github.com/hashicorp/vault/issues/1423)

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
We need to mutate configMaps with binary data

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
This only work with base64 encoded data inside vault since vault cannot store binary data without encoding

