### PR TITLE
[config] Add support for auth mount config

### DIFF
--- a/docs/cli-tool/README.md
+++ b/docs/cli-tool/README.md
@@ -68,7 +68,7 @@ auth:
       oidc_discovery_url: https://myco.auth0.com/
     roles:
     - name: role1
-      bound_audiences:                                                                                                                                                                                                                        
+      bound_audiences:
         - https://vault.plugin.auth.jwt.test
       user_claim: https://vault/user
       groups_claim: https://vault/groups
@@ -80,6 +80,11 @@ auth:
   # See https://www.vaultproject.io/docs/auth/github.html#configuration for
   # more information.
   - type: github
+    # Make the auth provider visible in the web ui
+    # See https://www.vaultproject.io/api/system/auth.html#config for more
+    # information.
+    options:
+      listing_visibility: "unauth"
     config:
       organization: banzaicloud
     map:
@@ -95,6 +100,11 @@ auth:
   # See https://www.vaultproject.io/docs/auth/aws.html for
   # more information.
   - type: aws
+    # Make the auth provider visible in the web ui
+    # See https://www.vaultproject.io/api/system/auth.html#config for more
+    # information.
+    options:
+      listing_visibility: "unauth"
     config:
       access_key: VKIAJBRHKH6EVTTNXDHA
       secret_key: vCtSM8ZUEQ3mOFVlYPBQkf2sO6F/W7a5TVzrl3Oj
@@ -121,6 +131,11 @@ auth:
   # See https://www.vaultproject.io/docs/auth/gcp.html for
   # more information.
   - type: gcp
+    # Make the auth provider visible in the web ui
+    # See https://www.vaultproject.io/api/system/auth.html#config for more
+    # information.
+    options:
+      listing_visibility: "unauth"
     config:
       # Credentials context is service account's key. Can download when you create a key for service account. 
       # No need to manually create it. Just paste the json context as multiline yaml.
@@ -159,6 +174,11 @@ auth:
   # Start an LDAP admin server: docker run -it --rm -p 6443:443 --link ldap:ldap -e PHPLDAPADMIN_LDAP_HOSTS=ldap -e PHPLDAPADMIN_LDAP_CLIENT_TLS=false osixia/phpldapadmin
   - type: ldap
     description: LDAP directory auth.
+    # add mount options
+    # See https://www.vaultproject.io/api/system/auth.html#config for more
+    # information.
+    options:
+      listing_visibility: "unauth"
     config:
       url: ldap://localhost
       binddn: "cn=admin,dc=example,dc=org"
@@ -311,7 +331,7 @@ secrets:
             access_key: "${env `AWS_ACCESS_KEY_ID`}"
             secret_key: "${env `AWS_SECRET_ACCESS_KEY`}"
             region: us-east-1
-        roles: 
+        roles:
           - credential_type: iam_user
             policy_arns: arn-of-policy
             name: my-aws-role

--- a/vault-config.yml
+++ b/vault-config.yml
@@ -37,6 +37,11 @@ auth:
   # See https://www.vaultproject.io/docs/auth/github.html#configuration for
   # more information.
   - type: github
+    # Make the auth provider visible in the web ui
+    # See https://www.vaultproject.io/api/system/auth.html#config for more
+    # information.
+    options:
+      listing_visibility: "unauth"
     config:
       organization: banzaicloud
     map:
@@ -65,6 +70,11 @@ auth:
   # See https://www.vaultproject.io/docs/auth/aws.html for
   # more information.
   - type: aws
+    # Make the auth provider visible in the web ui
+    # See https://www.vaultproject.io/api/system/auth.html#config for more
+    # information.
+    options:
+      listing_visibility: "unauth"
     config:
       access_key: "${env "AWS_ACCESS_KEY_ID"}" # or you can put the credential literals directly here
       secret_key: "${env "AWS_SECRET_ACCESS_KEY"}"
@@ -94,6 +104,11 @@ auth:
   # Start an LDAP admin server: docker run -it --rm -p 6443:443 --link ldap:ldap -e PHPLDAPADMIN_LDAP_HOSTS=ldap -e PHPLDAPADMIN_LDAP_CLIENT_TLS=false osixia/phpldapadmin
   - type: ldap
     description: LDAP directory auth.
+    # Make the auth provider visible in the web ui
+    # See https://www.vaultproject.io/api/system/auth.html#config for more
+    # information.
+    options:
+      listing_visibility: "unauth"
     config:
       url: ldap://localhost
       binddn: "cn=admin,dc=example,dc=org"
@@ -114,6 +129,11 @@ auth:
   # The okta auth method allows authentication using Okta and user/password credentials.
   # See https://www.vaultproject.io/docs/auth/okta.html for more information.
   - type: okta
+    # Make the auth provider visible in the web ui
+    # See https://www.vaultproject.io/api/system/auth.html#config for more
+    # information.
+    options:
+      listing_visibility: "unauth"
     config:
       organization: banzaicloud
       base_url: okta.com


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Add support for the mount options described at https://www.vaultproject.io/api/system/auth.html#config

This adds a new "options" field to the auth method configuration:

```
auth:
  - type: ""
    path: ""
    options:
      listing_visibility: "unauth"
      ...
    config: {}
    roles: []
```

### Why?
The main reason to implement this was the ability to set the listing_visibility option for authentication methods to configure which auth methods will be listed in the web ui.


### Checklist
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)

I am not sure about the error handling guideline, I followed the style I found in the file I modified itself.
