### PR TITLE
[helm vault-secrets-webhook] Allow setting pod annotations

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.5.0
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.3.0
+version: 0.4.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -57,7 +57,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | image.imagePullSecrets | image pull secrets for private repositories         | []                                |
 | namespaceSelector      | namespace selector to use, will limit webhook scope | {}                                |
 | nodeSelector           | node selector to use                                | {}                                |
-| podAnnotations         | extra annotations to add to the podSpec             | {}                                |
+| podAnnotations         | extra annotations to add to pod metadata            | {}                                |
 | replicaCount           | number of replicas                                  | 1                                 |
 | resources              | resources to request                                | {}                                |
 | service.externalPort   | webhook service external port                       | 443                               |

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -57,6 +57,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | image.imagePullSecrets | image pull secrets for private repositories         | []                                |
 | namespaceSelector      | namespace selector to use, will limit webhook scope | {}                                |
 | nodeSelector           | node selector to use                                | {}                                |
+| podAnnotations         | extra annotations to add to the podSpec             | {}                                |
 | replicaCount           | number of replicas                                  | 1                                 |
 | resources              | resources to request                                | {}                                |
 | service.externalPort   | webhook service external port                       | 443                               |

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -21,6 +21,9 @@ spec:
         release: {{ .Release.Name }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/apiservice-webhook.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "vault-secrets-webhook.fullname" . }}
       volumes:

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -45,6 +45,8 @@ volumeMounts: []
 # - name: vault-tls
 #   mountPath: /vault/tls
 
+podAnnotations: {}
+
 resources: {}
 
 nodeSelector: {}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Allow setting pod annotations for the vault-secrets-webhook Helm chart from values.yaml.


### Why?
Currently there is no way to set pod annotations for the webhook deployment. 

This is helpful to have in many setups, for example: In a cluster where Istio mTLS is required, the readiness probes for the webhook's deployment will fail as the containerPort is intercepted by the Envoy sidecar. Adding the pod annotation `sidecar.istio.io/rewriteAppHTTPProbers: "true"` fixes the probe.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Tested deployment with both default values, as well as values override for `podAnnotations`.

I bumped the minor chart version as IMO this introduces a new feature as described by SemVer, but if desired I can also just bump the patch version.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] If the PR is not complete but you want to discuss the approach, list what remains to be done here
