### PR TITLE
[helm vault-secrets-webhook] Fix indentation for webhook selector matchLabels

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.4.4
+version: 0.4.5
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -44,7 +44,7 @@ items:
     namespaceSelector:
     {{- if .Values.namespaceSelector.matchLabels }}
       matchLabels:
-{{ toYaml .Values.namespaceSelector.matchLabels | indent 6 }}
+{{ toYaml .Values.namespaceSelector.matchLabels | indent 8 }}
     {{- end }}
       matchExpressions:
       {{- if .Values.namespaceSelector.matchExpressions }}
@@ -75,7 +75,7 @@ items:
     namespaceSelector:
     {{- if .Values.namespaceSelector.matchLabels }}
       matchLabels:
-{{ toYaml .Values.namespaceSelector.matchLabels | indent 6 }}
+{{ toYaml .Values.namespaceSelector.matchLabels | indent 8 }}
     {{- end }}
       matchExpressions:
       {{- if .Values.namespaceSelector.matchExpressions }}
@@ -107,7 +107,7 @@ items:
     namespaceSelector:
     {{- if .Values.namespaceSelector.matchLabels }}
       matchLabels:
-{{ toYaml .Values.namespaceSelector.matchLabels | indent 6 }}
+{{ toYaml .Values.namespaceSelector.matchLabels | indent 8 }}
     {{- end }}
       matchExpressions:
     {{- if .Values.namespaceSelector.matchExpressions }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -75,3 +75,5 @@ namespaceSelector:
     operator: NotIn
     values:
     - kube-system
+  # matchLabels:
+  #   vault-injection: enabled

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -51,8 +51,6 @@ resources: {}
 
 nodeSelector: {}
 
-namespaceSelector: {}
-
 tolerations: []
 
 affinity: {}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Fix indentation for the mutating webhook config's `webhooks[].namespaceSelector.matchLabels` field.


### Why?
Indentation for the `matchLabels` in the mutating webhook config is incorrect:
```yaml
---
# input values.yaml
namespaceSelector:
  matchLabels:
    vault-injection: enabled

---
# templated apiservice-webhook.yaml
    namespaceSelector:
      matchLabels:
      # >>> Incorrect indentation below
      vault-injection: enabled

      matchExpressions:
      - key: name
        operator: NotIn
        values:
        - kube-system

      - key: name
        operator: NotIn
        values:
        - vault
```

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] If the PR is not complete but you want to discuss the approach, list what remains to be done here
