### PR TITLE
[helm] Allow setting pod priority class for vault-operator and vault-secrets-webhook

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.5.0
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.3.0
+version: 0.4.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/charts/vault-operator/templates/deployment.yaml
+++ b/charts/vault-operator/templates/deployment.yaml
@@ -22,8 +22,11 @@ spec:
 {{- if .Values.podAnnotations }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
-{{- end }}       
+{{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       initContainers:
       {{- if index .Values "etcd-operator" "enabled" }}
       - name: check-etcd-crd

--- a/charts/vault-operator/values.yaml
+++ b/charts/vault-operator/values.yaml
@@ -45,6 +45,9 @@ resources:
 
 affinity: {}
 
+## Assign a PriorityClassName to pods if set
+priorityClassName: ""
+
 terminationGracePeriodSeconds: 10
 
 probePath: /

--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.4.5
+version: 0.5.0
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -26,6 +26,9 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "vault-secrets-webhook.fullname" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       volumes:
         - name: serving-cert
           secret:

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -6,9 +6,6 @@ replicaCount: 1
 
 debug: false
 
-## Assign a PriorityClassName to pods if set
-priorityClassName: ""
-
 image:
   repository: banzaicloud/vault-secrets-webhook
   tag: 0.5.0
@@ -57,6 +54,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+## Assign a PriorityClassName to pods if set
+priorityClassName: ""
 
 rbac:
   enabled: true

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -6,6 +6,9 @@ replicaCount: 1
 
 debug: false
 
+## Assign a PriorityClassName to pods if set
+priorityClassName: ""
+
 image:
   repository: banzaicloud/vault-secrets-webhook
   tag: 0.5.0


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Allow setting `pod.spec.priorityClassName` from Helm values for vault-operator and vault-secrets-webhook.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
There is currently no way to set pods' priority classes.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] If the PR is not complete but you want to discuss the approach, list what remains to be done here
