### PR TITLE
sdk/auth: make TokenStore optional

### DIFF
--- a/pkg/sdk/auth/auth.go
+++ b/pkg/sdk/auth/auth.go
@@ -45,7 +45,13 @@ type ScopedClaims struct {
 	Text string    `json:"text,omitempty"`
 }
 
-// JWTAuth returns a new JWT authentication handler
+// JWTAuth returns a new JWT authentication Gin Handler
+// Parameters:
+// - tokenStore (optional) - checks if the incoming JWT Bearer token's ID is present in this TokenStore
+//							(can be nil, which pypasses the check)
+// - signingKey - the HMAC JWT token signing key
+// - claimConverter - converts the JWT token into a JWT claim object, which will be saved into the request context
+// - extractors... (optional) - additional token extractors to use besides github.com/dgrijalva/jwt-go/request.OAuth2Extractor
 func JWTAuth(tokenStore TokenStore, signingKey string, claimConverter ClaimConverter, extractors ...jwtRequest.Extractor) gin.HandlerFunc {
 
 	signingKeyBase32 := []byte(base32.StdEncoding.EncodeToString([]byte(signingKey)))
@@ -102,6 +108,9 @@ func JWTAuth(tokenStore TokenStore, signingKey string, claimConverter ClaimConve
 }
 
 func isTokenWhitelisted(tokenStore TokenStore, claims *ScopedClaims) (bool, error) {
+	if tokenStore == nil {
+		return true, nil
+	}
 	userID := claims.Subject
 	tokenID := claims.Id
 	token, err := tokenStore.Lookup(userID, tokenID)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/hollowtrees/pull/24
| License         | Apache 2.0


### What's in this PR?
This PR makes TokenStore an optional parameter, which in the case of nil bypasses the token lookup.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To make client usage easier.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


