### PR TITLE
Add postgresql as an allowed HA backend

### DIFF
--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -306,14 +306,15 @@ type VaultSpec struct {
 
 // HAStorageTypes is the set of storage backends supporting High Availability
 var HAStorageTypes = map[string]bool{
-	"consul":    true,
-	"dynamodb":  true,
-	"etcd":      true,
-	"gcs":       true,
-	"mysql":     true,
-	"raft":      true,
-	"spanner":   true,
-	"zookeeper": true,
+	"consul":     true,
+	"dynamodb":   true,
+	"etcd":       true,
+	"gcs":        true,
+	"mysql":      true,
+	"postgresql": true,
+	"raft":       true,
+	"spanner":    true,
+	"zookeeper":  true,
 }
 
 // HasHAStorage detects if Vault is configured to use a storage backend which supports High Availability or if it has


### PR DESCRIPTION
Allow PostgreSQL to be a valid HA backend

Fixes #639 