### PR TITLE
Change hardcoded image PullPolicy

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -127,7 +127,7 @@ func getInitContainers(originalContainers []corev1.Container, vaultConfig vaultC
 		containers = append(containers, corev1.Container{
 			Name:            "vault-agent",
 			Image:           viper.GetString("vault_image"),
-			ImagePullPolicy: corev1.PullIfNotPresent,
+			ImagePullPolicy: corev1.PullPolicy(viper.GetString("vault_image_pull_policy")),
 			SecurityContext: securityContext,
 			Command:         []string{"vault", "agent", "-config=/vault/agent/config.hcl"},
 			Env:             containerEnvVars,
@@ -145,7 +145,7 @@ func getInitContainers(originalContainers []corev1.Container, vaultConfig vaultC
 		containers = append(containers, corev1.Container{
 			Name:            "copy-vault-env",
 			Image:           viper.GetString("vault_env_image"),
-			ImagePullPolicy: corev1.PullIfNotPresent,
+			ImagePullPolicy: corev1.PullPolicy(viper.GetString("vault_env_image_pull_policy")),
 			Command:         []string{"sh", "-c", "cp /usr/local/bin/vault-env /vault/"},
 			VolumeMounts: []corev1.VolumeMount{
 				{
@@ -858,7 +858,9 @@ func (mw *mutatingWebhook) mutatePod(pod *corev1.Pod, vaultConfig vaultConfig, n
 
 func init() {
 	viper.SetDefault("vault_image", "vault:latest")
+	viper.SetDefault("vault_image_pull_policy", string(corev1.PullIfNotPresent))
 	viper.SetDefault("vault_env_image", "banzaicloud/vault-env:latest")
+	viper.SetDefault("vault_env_image_pull_policy", string(corev1.PullIfNotPresent))
 	viper.SetDefault("vault_ct_image", "hashicorp/consul-template:0.19.6-dev-alpine")
 	viper.SetDefault("vault_addr", "https://vault:8200")
 	viper.SetDefault("vault_skip_verify", "false")


### PR DESCRIPTION
Parameterizing the PullPolicy for init containers will enable users to specify whether they want to cache images or pull from image repository on init inject.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A Slack
| License         | Apache 2.0


### What's in this PR?
This PR allows for passing in either through CLI args or environment the desired PullPolicy for init containers. 


### Why?
Some have voiced security concerns at caching docker images locally. Additionally, some organizations have enforced policies that don’t allow for locally cached images. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] Update Docs to reflect the new parameter
