### PR TITLE
[backport 0.5.x] Support creating group-aliases with same name and different mount_accessor path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ jobs:
             make docker-operator
             make docker-vault-env
             make docker-webhook
+          no_output_timeout: 30m
 
       - run:
           name: Wait for minikube

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190308093441-53f19b3c6bee
 	github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20171213061034-52de7239022c
 	github.com/aokoli/goutils v1.0.1 // indirect
+	github.com/apache/thrift v0.12.0
 	github.com/aws/aws-sdk-go v1.15.31
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
 	github.com/banzaicloud/k8s-objectmatcher v1.0.0
@@ -105,3 +106,5 @@ replace k8s.io/client-go => k8s.io/client-go v2.0.0-alpha.0.0.20181213151034-8d9
 replace k8s.io/code-generator => k8s.io/code-generator v0.0.0-20190416052311-01a054e913a9
 
 replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -3,7 +3,6 @@ cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 contrib.go.opencensus.io/exporter/ocagent v0.4.11 h1:Zwy9skaqR2igcEfSVYDuAsbpa33N0RPtnYTHEe2whPI=
 contrib.go.opencensus.io/exporter/ocagent v0.4.11/go.mod h1:7ihiYRbdcVfW4m4wlXi9WRPdv79C0fStcjNlyE6ek9s=
-git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/Azure/azure-sdk-for-go v23.2.0+incompatible h1:bch1RS060vGpHpY3zvQDV4rOiRw25J1zmR/B9a76aSA=
 github.com/Azure/azure-sdk-for-go v23.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=

--- a/pkg/vault/operator_client.go
+++ b/pkg/vault/operator_client.go
@@ -1257,7 +1257,19 @@ func getVaultGroupAliasName(aliasId string, client *api.Client) (id string, err 
 	return alias.Data["name"].(string), nil
 }
 
-func findVaultGroupAliasIDFromName(name string, client *api.Client) (id string, err error) {
+func getVaultGroupAliasMount(aliasId string, client *api.Client) (id string, err error) {
+	alias, err := readVaultGroupAlias(aliasId, client)
+	if err != nil {
+		return "", fmt.Errorf("error reading group alias %s: %s", aliasId, err)
+	}
+	if alias == nil {
+		return "", fmt.Errorf("group alias %s does not exist", aliasId)
+	}
+	return alias.Data["mount_accessor"].(string), nil
+}
+
+
+func findVaultGroupAliasIDFromNameAndMount(name string, accessor string, client *api.Client) (id string, err error) {
 	aliases, err := client.Logical().List("identity/group-alias/id")
 
 	if err != nil {
@@ -1270,14 +1282,20 @@ func findVaultGroupAliasIDFromName(name string, client *api.Client) (id string, 
 	for _, alias := range aliases.Data["keys"].([]interface{}) {
 		aliasName, err := getVaultGroupAliasName(cast.ToString(alias), client)
 		if err != nil {
-			return "", fmt.Errorf("error fetching name for alias id: %s", alias)
+			return "", fmt.Errorf("error fetching name for alias id: %s err: %s", alias, err)
 		}
-		if aliasName == name {
+
+		aliasMount, err := getVaultGroupAliasMount(cast.ToString(alias), client)
+		if err != nil {
+			return "", fmt.Errorf("error fetching mount for alias id: %s err: %s", alias, err)
+		}
+
+		if aliasName == name && aliasMount == accessor {
 			return cast.ToString(alias), nil
 		}
 	}
 
-	// Did not find any alias matching ID to Name
+	// Did not find any alias matching Name and MountPath
 	return "", nil
 }
 
@@ -1329,12 +1347,9 @@ func (v *vault) configureIdentityGroups(config *viper.Viper) error {
 		}
 	}
 
+	// Group Aliases for External Groups might require to have the same Name when on different Mount/Path combinations
+	// external groups can only have ONE alias so we need to make sure not to overwrite any
 	for _, groupAlias := range groupAliases {
-		ga, err := findVaultGroupAliasIDFromName(cast.ToString(groupAlias["name"]), v.cl)
-		if err != nil {
-			return fmt.Errorf("error finding group-alias: %s", err)
-		}
-
 		accessor, err := getVaultAuthMountAccessor(cast.ToString(groupAlias["mountpath"]), v.cl)
 		if err != nil {
 			return fmt.Errorf("error getting mount accessor for %s: %s", groupAlias["mountpath"], err)
@@ -1351,14 +1366,20 @@ func (v *vault) configureIdentityGroups(config *viper.Viper) error {
 			"canonical_id":   id,
 		}
 
+		// Find a matching alias for NAME and MOUNT 
+		ga, err := findVaultGroupAliasIDFromNameAndMount(cast.ToString(groupAlias["name"]), accessor, v.cl)
+		if err != nil {
+			return fmt.Errorf("error finding group-alias: %s", err)
+		}
+
 		if ga == "" {
-			logrus.Infof("creating group-alias: %s", groupAlias["name"])
+			logrus.Infof("creating group-alias: %s@%s", groupAlias["name"], accessor)
 			_, err = v.cl.Logical().Write("identity/group-alias", config)
 			if err != nil {
 				return fmt.Errorf("failed to create group-alias %s : %v", groupAlias["name"], err)
 			}
 		} else {
-			logrus.Infof("tuning already existing group-alias: %s - ID: %s", groupAlias["name"], ga)
+			logrus.Infof("tuning already existing group-alias: %s@%s - ID: %s", groupAlias["name"], accessor, ga)
 			_, err = v.cl.Logical().Write(fmt.Sprintf("identity/group-alias/id/%s", ga), config)
 			if err != nil {
 				return fmt.Errorf("failed to tune group-alias %s : %v", ga, err)


### PR DESCRIPTION

* For external groups the name of the alias is the name in the external datastore, so is possible to have the same group name
  from different datastores / group-external

* fix go mod for git.apache.org/thrift => github.com/apache/thrift

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/bank-vaults/pull/652
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Backport of https://github.com/banzaicloud/bank-vaults/pull/652 to the 0.5.x branch.


