### PR TITLE
Make ImagePull Docker Config JSON key configurable

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -878,6 +878,7 @@ func init() {
 	viper.SetDefault("telemetry_listen_address", "")
 	viper.SetDefault("default_image_pull_secret", "")
 	viper.SetDefault("default_image_pull_secret_namespace", "")
+	viper.SetDefault("default_image_pull_docker_config_json_key", corev1.DockerConfigJsonKey)
 	viper.SetDefault("registry_skip_verify", "false")
 	viper.SetDefault("debug", "false")
 	viper.AutomaticEnv()

--- a/cmd/vault-secrets-webhook/registry/registry.go
+++ b/cmd/vault-secrets-webhook/registry/registry.go
@@ -262,7 +262,8 @@ func (k *ContainerInfo) checkImagePullSecret(namespace string, secret string) (b
 
 	var dockerCreds DockerCreds
 
-	err = json.Unmarshal(data[corev1.DockerConfigJsonKey], &dockerCreds)
+	dockerConfigJSONKey := viper.GetString("default_image_pull_docker_config_json_key")
+	err = json.Unmarshal(data[dockerConfigJSONKey], &dockerCreds)
 	if err != nil {
 		return false, fmt.Errorf("cannot unmarshal docker configuration from imagePullSecret: %s", err.Error())
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

PR allows to passing JSON key for Docker config from ImagePull Secret.


### Why?

You may rewrite default value prevent duplication of secrets that may used in another automatization.