### PR TITLE
Fix parsing of Image Name with digest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/go-autorest v11.7.0+incompatible
 	github.com/Masterminds/semver v1.4.2
 	github.com/Masterminds/sprig v2.15.0+incompatible
+	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190308093441-53f19b3c6bee
 	github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20171213061034-52de7239022c
 	github.com/aokoli/goutils v1.0.1 // indirect
@@ -81,3 +82,6 @@ replace k8s.io/client-go => k8s.io/client-go v10.0.0+incompatible
 replace k8s.io/code-generator => k8s.io/code-generator v0.0.0-20190416052311-01a054e913a9
 
 replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
+
+// ref: https://github.com/hashicorp/terraform/issues/22664#issuecomment-527142529
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?

* Fix parsing Docker Image Name with digest

url:

```
eu.gcr.io/project/repo@sha256:7918a9a8ed9aebc21cd8408ae8e1bb6e4aea7ccf81f1bb81147ced54198f074a 
```

parsed as:

```
url=https://eu.gcr.io/v2/project/repo@sha256/manifests/7918a9a8ed9aebc21cd8408ae8e1bb6e4aea7ccf81f1bb81147ced54198f074a
repository=project/repo@sha256
reference=7918a9a8ed9aebc21cd8408ae8e1bb6e4aea7ccf81f1bb81147ced54198f074a
```

* Replace git.apache.org/thrift.git with github.com/apache/thrift

### Why?

* Incorrect parsing doesn't allow to start jobs/pods/etc
* git.apache.org is not responding