### PR TITLE
webhook: fix the chart install and port-forward execution order

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -840,7 +840,7 @@ func (mw *mutatingWebhook) mutatePod(pod *corev1.Pod, vaultConfig vaultConfig, n
 			logger.Debugf("Test our Kubernetes API Version and make the final decision on enabling ShareProcessNamespace")
 			apiVersion, _ := mw.k8sClient.Discovery().ServerVersion()
 			versionCompared := kubeVer.CompareKubeAwareVersionStrings("v1.12.0", apiVersion.String())
-			logger.Debugf("Kuberentes API version detected: %s", apiVersion.String())
+			logger.Debugf("Kubernetes API version detected: %s", apiVersion.String())
 
 			if versionCompared >= 0 {
 				vaultConfig.ctShareProcess = true

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Azure/go-autorest v11.7.0+incompatible
 	github.com/Masterminds/semver v1.4.2
 	github.com/Masterminds/sprig v2.15.0+incompatible
-	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190308093441-53f19b3c6bee
 	github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20171213061034-52de7239022c
 	github.com/aokoli/goutils v1.0.1 // indirect
@@ -82,6 +81,3 @@ replace k8s.io/client-go => k8s.io/client-go v10.0.0+incompatible
 replace k8s.io/code-generator => k8s.io/code-generator v0.0.0-20190416052311-01a054e913a9
 
 replace golang.org/x/oauth2 => golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
-
-// ref: https://github.com/hashicorp/terraform/issues/22664#issuecomment-527142529
-replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview of the implementation, which decisions were made and why. -->
The chart has to be installed first and after that, we can try port-forwarding with the TLS Secret in the given namespace.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


