### PR TITLE
Enable possibility for JSON logging

### DIFF
--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -54,6 +54,21 @@ var sanitizeEnvmap = map[string]bool{
 	"VAULT_PATH":                   true,
 	"VAULT_IGNORE_MISSING_SECRETS": true,
 	"VAULT_ENV_PASSTHROUGH":        true,
+    "VAULT_JSON_LOG":               true,
+}
+
+var logger *log.Logger
+
+type GlobalHook struct {
+}
+
+func (h *GlobalHook) Levels() []log.Level {
+    return log.AllLevels
+}
+
+func (h *GlobalHook) Fire(e *log.Entry) error {
+    e.Data["app"] = "vault-env"
+    return nil
 }
 
 // Appends variable an entry (name=value) into the environ list.
@@ -66,6 +81,15 @@ func (environ *sanitizedEnviron) append(iname interface{}, ivalue interface{}) {
 }
 
 func main() {
+    enableJsonLog := os.Getenv("VAULT_JSON_LOG")
+
+    logger = log.New()
+    // Add additonal fields to all log messages
+	logger.AddHook(&GlobalHook{})
+    if enableJsonLog == "true" {
+        logger.SetFormatter(&log.JSONFormatter{})
+    }
+
 	ignoreMissingSecrets := os.Getenv("VAULT_IGNORE_MISSING_SECRETS") == "true"
 
 	// The login procedure takes the token from a file (if using Vault Agent)
@@ -81,7 +105,7 @@ func main() {
 		vault.ClientAuthPath(os.Getenv("VAULT_PATH")),
 	)
 	if err != nil {
-		log.Fatal("failed to create vault client", err.Error())
+		logger.Fatal("failed to create vault client", err.Error())
 	}
 
 	passthroughEnvVars := strings.Split(os.Getenv("VAULT_ENV_PASSTHROUGH"), ",")
@@ -146,7 +170,7 @@ func main() {
 				if update {
 					secret, err = client.RawClient().Logical().Write(path, map[string]interface{}{})
 					if err != nil {
-						log.Fatalln("failed to write secret to path:", path, err.Error())
+						logger.Fatalln("failed to write secret to path:", path, err.Error())
 					} else {
 						secretCache[path] = secret
 					}
@@ -154,9 +178,9 @@ func main() {
 					secret, err = client.RawClient().Logical().ReadWithData(path, map[string][]string{"version": {version}})
 					if err != nil {
 						if ignoreMissingSecrets {
-							log.Errorln("failed to read secret from path:", path, err.Error())
+							logger.Errorln("failed to read secret from path:", path, err.Error())
 						} else {
-							log.Fatalln("failed to read secret from path:", path, err.Error())
+							logger.Fatalln("failed to read secret from path:", path, err.Error())
 						}
 					} else {
 						secretCache[path] = secret
@@ -166,9 +190,9 @@ func main() {
 
 			if secret == nil {
 				if ignoreMissingSecrets {
-					log.Warnln("path not found:", path)
+					logger.Warnln("path not found:", path)
 				} else {
-					log.Fatalln("path not found:", path)
+					logger.Fatalln("path not found:", path)
 				}
 			} else {
 				var data map[string]interface{}
@@ -179,12 +203,12 @@ func main() {
 					// Check if a given version of a path is destroyed
 					metadata := secret.Data["metadata"].(map[string]interface{})
 					if metadata["destroyed"].(bool) {
-						log.Warnln("version of secret has been permanently destroyed version:", version, "path:", path)
+						logger.Warnln("version of secret has been permanently destroyed version:", version, "path:", path)
 					}
 
 					// Check if a given version of a path still exists
 					if deletionTime, ok := metadata["deletion_time"].(string); ok && deletionTime != "" {
-						log.Warnln("cannot find data for path, given version has been deleted",
+						logger.Warnln("cannot find data for path, given version has been deleted",
 							"path:", path, "version:", version,
 							"deletion_time", deletionTime)
 					}
@@ -194,7 +218,7 @@ func main() {
 				if value, ok := data[key]; ok {
 					sanitized.append(name, value)
 				} else {
-					log.Fatalln("key not found:", key)
+					logger.Fatalln("key not found:", key)
 				}
 			}
 		} else {
@@ -204,16 +228,16 @@ func main() {
 
 	var entrypointCmd []string
 	if len(os.Args) == 1 {
-		log.Fatalln("no command is given, vault-env can't determine the entrypoint (command), please specify it explicitly or let the webhook query it (see documentation)")
+		logger.Fatalln("no command is given, vault-env can't determine the entrypoint (command), please specify it explicitly or let the webhook query it (see documentation)")
 	} else {
 		entrypointCmd = os.Args[1:]
 	}
 	binary, err := exec.LookPath(entrypointCmd[0])
 	if err != nil {
-		log.Fatalln("binary not found", entrypointCmd[0])
+		logger.Fatalln("binary not found", entrypointCmd[0])
 	}
 	err = syscall.Exec(binary, entrypointCmd, sanitized)
 	if err != nil {
-		log.Fatalln("failed to exec process", binary, entrypointCmd, err.Error())
+		logger.Fatalln("failed to exec process", binary, entrypointCmd, err.Error())
 	}
 }

--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -54,21 +54,24 @@ var sanitizeEnvmap = map[string]bool{
 	"VAULT_PATH":                   true,
 	"VAULT_IGNORE_MISSING_SECRETS": true,
 	"VAULT_ENV_PASSTHROUGH":        true,
-    "VAULT_JSON_LOG":               true,
+	"VAULT_JSON_LOG":               true,
 }
 
 var logger *log.Logger
 
+// GlobalHook struct used for adding additional fields to the log
 type GlobalHook struct {
 }
 
+// Levels returning all log levels
 func (h *GlobalHook) Levels() []log.Level {
-    return log.AllLevels
+	return log.AllLevels
 }
 
+// Fire adding the additional fields to all log entries
 func (h *GlobalHook) Fire(e *log.Entry) error {
-    e.Data["app"] = "vault-env"
-    return nil
+	e.Data["app"] = "vault-env"
+	return nil
 }
 
 // Appends variable an entry (name=value) into the environ list.
@@ -81,14 +84,14 @@ func (environ *sanitizedEnviron) append(iname interface{}, ivalue interface{}) {
 }
 
 func main() {
-    enableJsonLog := os.Getenv("VAULT_JSON_LOG")
+	enableJSONLog := os.Getenv("VAULT_JSON_LOG")
 
-    logger = log.New()
-    // Add additonal fields to all log messages
+	logger = log.New()
+	// Add additonal fields to all log messages
 	logger.AddHook(&GlobalHook{})
-    if enableJsonLog == "true" {
-        logger.SetFormatter(&log.JSONFormatter{})
-    }
+	if enableJSONLog == "true" {
+		logger.SetFormatter(&log.JSONFormatter{})
+	}
 
 	ignoreMissingSecrets := os.Getenv("VAULT_IGNORE_MISSING_SECRETS") == "true"
 

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -898,7 +898,7 @@ func init() {
 	viper.SetDefault("default_image_pull_docker_config_json_key", corev1.DockerConfigJsonKey)
 	viper.SetDefault("registry_skip_verify", "false")
 	viper.SetDefault("debug", "false")
-	viper.SetDefault("enable_json_log", "true")
+	viper.SetDefault("enable_json_log", "false")
 	viper.AutomaticEnv()
 
 	logger = log.New()

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -911,7 +911,6 @@ func init() {
 
 	if viper.GetBool("debug") {
 		logger.SetLevel(log.DebugLevel)
-		logger.SetReportCaller(true)
 		logger.Debug("Debug mode enabled")
 	}
 }

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -62,7 +62,7 @@ type vaultConfig struct {
 	vaultEnvPassThrough         string
 	configfilePath              string
 	mutateConfigMap             bool
-	enableJsonLog               string
+	enableJSONLog               string
 }
 
 var vaultAgentConfig = `
@@ -450,9 +450,9 @@ func parseVaultConfig(obj metav1.Object) vaultConfig {
 	}
 
 	if val, ok := annotations["vault.security.banzaicloud.io/enable-json-log"]; ok {
-		vaultConfig.enableJsonLog = val
+		vaultConfig.enableJSONLog = val
 	} else {
-		vaultConfig.enableJsonLog = viper.GetString("enable_json_log")
+		vaultConfig.enableJSONLog = viper.GetString("enable_json_log")
 	}
 
 	return vaultConfig
@@ -667,7 +667,7 @@ func (mw *mutatingWebhook) mutateContainers(containers []corev1.Container, podSp
 			},
 			{
 				Name:  "VAULT_JSON_LOG",
-				Value: vaultConfig.enableJsonLog,
+				Value: vaultConfig.enableJSONLog,
 			},
 		}...)
 
@@ -902,17 +902,17 @@ func init() {
 	viper.AutomaticEnv()
 
 	logger = log.New()
-    // Add additonal fields to all log messages
+	// Add additonal fields to all log messages
 	logger.AddHook(&GlobalHook{})
 
 	if viper.GetBool("enable_json_log") {
-	    logger.SetFormatter(&log.JSONFormatter{})
+		logger.SetFormatter(&log.JSONFormatter{})
 	}
 
 	if viper.GetBool("debug") {
-        logger.SetLevel(log.DebugLevel)
-        logger.SetReportCaller(true)
-	    logger.Debug("Debug mode enabled")
+		logger.SetLevel(log.DebugLevel)
+		logger.SetReportCaller(true)
+		logger.Debug("Debug mode enabled")
 	}
 }
 
@@ -936,16 +936,19 @@ func handlerFor(config mutating.WebhookConfig, mutator mutating.MutatorFunc, rec
 
 var logger *log.Logger
 
+// GlobalHook struct used for adding additional fields to the log
 type GlobalHook struct {
 }
 
+// Levels returning all log levels
 func (h *GlobalHook) Levels() []log.Level {
-    return log.AllLevels
+	return log.AllLevels
 }
 
+// Fire adding the additional fields to all log entries
 func (h *GlobalHook) Fire(e *log.Entry) error {
-    e.Data["app"] = "vault-secrets-webhook"
-    return nil
+	e.Data["app"] = "vault-secrets-webhook"
+	return nil
 }
 
 func serveMetrics(addr string) {

--- a/cmd/vault-secrets-webhook/registry/registry.go
+++ b/cmd/vault-secrets-webhook/registry/registry.go
@@ -38,9 +38,9 @@ var imageCache ImageCache
 
 func init() {
 	logger = log.New()
-    if viper.GetBool("enable_json_log") {
-        logger.SetFormatter(&log.JSONFormatter{})
-    }
+	if viper.GetBool("enable_json_log") {
+		logger.SetFormatter(&log.JSONFormatter{})
+	}
 	imageCache = NewInMemoryImageCache()
 }
 

--- a/cmd/vault-secrets-webhook/registry/registry.go
+++ b/cmd/vault-secrets-webhook/registry/registry.go
@@ -32,12 +32,15 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var logger log.FieldLogger
+var logger *log.Logger
 
 var imageCache ImageCache
 
 func init() {
 	logger = log.New()
+    if viper.GetBool("enable_json_log") {
+        logger.SetFormatter(&log.JSONFormatter{})
+    }
 	imageCache = NewInMemoryImageCache()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/go-autorest v11.7.0+incompatible
 	github.com/Masterminds/semver v1.4.2
 	github.com/Masterminds/sprig v2.15.0+incompatible
+	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190308093441-53f19b3c6bee
 	github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20171213061034-52de7239022c
 	github.com/aokoli/goutils v1.0.1 // indirect
@@ -54,8 +55,13 @@ require (
 	github.com/spf13/cobra v0.0.4
 	github.com/spf13/viper v1.4.0
 	github.com/ugorji/go v1.1.7 // indirect
+	golang.org/x/crypto v0.0.0-20190927123631-a832865fa7ad // indirect
+	golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac // indirect
+	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	golang.org/x/tools v0.0.0-20190731214159-1e85ed8060aa // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/sys v0.0.0-20190927073244-c990c680b611 // indirect
+	golang.org/x/tools v0.0.0-20190929041059-e7abfedfabcf // indirect
 	google.golang.org/api v0.3.0
 	google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610 // indirect
 	google.golang.org/grpc v1.22.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -678,6 +678,7 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190927123631-a832865fa7ad/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -688,6 +689,8 @@ golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac h1:8R1esu+8QioDxo4E4mX6bFztO+dMTM49DNAaWfO5OeY=
+golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -716,6 +719,7 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 h1:Ao/3l156eZf2AW5wK8a7/smtodRU+gha3+BeqJ69lRk=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190926025831-c00fd9afed17/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -726,6 +730,7 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -754,6 +759,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa h1:KIDDMLT1O0Nr7TSxp8xM5tJcdn8tgyAONntO829og1M=
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190927073244-c990c680b611/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -791,6 +797,9 @@ golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190731214159-1e85ed8060aa h1:kwa/4M1dbmhZqOIqYiTtbA6JrvPwo1+jqlub2qDXX90=
 golang.org/x/tools v0.0.0-20190731214159-1e85ed8060aa/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20190929041059-e7abfedfabcf h1:NvypsVlesF+lEDKVK5RNkww4fzArJXChZxNin79j05M=
+golang.org/x/tools v0.0.0-20190929041059-e7abfedfabcf/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=

--- a/pkg/sdk/vault/client.go
+++ b/pkg/sdk/vault/client.go
@@ -49,7 +49,7 @@ type clientOptions struct {
 	role      string
 	authPath  string
 	tokenPath string
-	token	  string
+	token     string
 }
 
 // ClientOption configures a Vault client using the functional options paradigm popularized by Rob Pike and Dave Cheney.
@@ -116,12 +116,12 @@ func NewClientWithConfig(config *vaultapi.Config, role, path string) (*Client, e
 
 // NewClientFromConfig creates a new Vault client from custom configuration.
 func NewClientFromConfig(config *vaultapi.Config, opts ...ClientOption) (*Client, error) {
-    enableJsonLog := os.Getenv("VAULT_JSON_LOG")
+	enableJSONLog := os.Getenv("VAULT_JSON_LOG")
 
-    logger = log.New()
-    if enableJsonLog == "true" {
-        logger.SetFormatter(&log.JSONFormatter{})
-    }
+	logger = log.New()
+	if enableJSONLog == "true" {
+		logger.SetFormatter(&log.JSONFormatter{})
+	}
 
 	rawClient, err := vaultapi.NewClient(config)
 	if err != nil {

--- a/pkg/sdk/vault/client.go
+++ b/pkg/sdk/vault/client.go
@@ -17,7 +17,6 @@ package vault
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -27,7 +26,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/hashicorp/vault/api"
 	vaultapi "github.com/hashicorp/vault/api"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 )
 
@@ -35,6 +34,8 @@ const (
 	serviceAccountFile  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	initialTokenTimeout = 10 * time.Second
 )
+
+var logger *log.Logger
 
 // NewData is a helper function for Vault KV Version two secret data creation
 func NewData(cas int, data map[string]interface{}) map[string]interface{} {
@@ -115,6 +116,13 @@ func NewClientWithConfig(config *vaultapi.Config, role, path string) (*Client, e
 
 // NewClientFromConfig creates a new Vault client from custom configuration.
 func NewClientFromConfig(config *vaultapi.Config, opts ...ClientOption) (*Client, error) {
+    enableJsonLog := os.Getenv("VAULT_JSON_LOG")
+
+    logger = log.New()
+    if enableJsonLog == "true" {
+        logger.SetFormatter(&log.JSONFormatter{})
+    }
+
 	rawClient, err := vaultapi.NewClient(config)
 	if err != nil {
 		return nil, err
@@ -155,14 +163,14 @@ func NewClientFromConfig(config *vaultapi.Config, opts ...ClientOption) (*Client
 						if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
 							err := config.ReadEnvironment()
 							if err != nil {
-								logrus.Println("failed to reload Vault config:", err)
+								logger.Println("failed to reload Vault config:", err)
 							} else {
-								logrus.Println("CA certificate reloaded")
+								logger.Println("CA certificate reloaded")
 							}
 						}
 					}
 				case err := <-watch.Errors:
-					logrus.Println("watcher error:", err)
+					logger.Println("watcher error:", err)
 				}
 			}
 		}()
@@ -243,18 +251,18 @@ func NewClientFromRawClient(rawClient *vaultapi.Client, opts ...ClientOption) (*
 
 					secret, err := logical.Write(fmt.Sprintf("auth/%s/login", o.authPath), data)
 					if err != nil {
-						log.Println("Failed to request new Vault token", err.Error())
+						logger.Println("Failed to request new Vault token", err.Error())
 						time.Sleep(1 * time.Second)
 						continue
 					}
 
 					if secret == nil {
-						log.Println("Received empty answer from Vault, retrying")
+						logger.Println("Received empty answer from Vault, retrying")
 						time.Sleep(1 * time.Second)
 						continue
 					}
 
-					log.Println("Received new Vault token")
+					logger.Println("Received new Vault token")
 
 					// Set the first token from the response
 					rawClient.SetToken(secret.Auth.ClientToken)
@@ -267,7 +275,7 @@ func NewClientFromRawClient(rawClient *vaultapi.Client, opts ...ClientOption) (*
 					// Start the renewing process
 					tokenRenewer, err = rawClient.NewRenewer(&vaultapi.RenewerInput{Secret: secret})
 					if err != nil {
-						log.Println("Failed to renew Vault token", err.Error())
+						logger.Println("Failed to renew Vault token", err.Error())
 						continue
 					}
 
@@ -279,12 +287,12 @@ func NewClientFromRawClient(rawClient *vaultapi.Client, opts ...ClientOption) (*
 
 					runRenewChecker(tokenRenewer)
 				}
-				log.Println("Vault token renewal closed")
+				logger.Println("Vault token renewal closed")
 			}()
 
 			select {
 			case <-initialTokenArrived:
-				log.Println("Initial Vault token arrived")
+				logger.Println("Initial Vault token arrived")
 
 			case <-time.After(initialTokenTimeout):
 				client.Close()
@@ -301,11 +309,11 @@ func runRenewChecker(tokenRenewer *vaultapi.Renewer) {
 		select {
 		case err := <-tokenRenewer.DoneCh():
 			if err != nil {
-				log.Println("Vault token renewal error:", err.Error())
+				logger.Println("Vault token renewal error:", err.Error())
 			}
 			return
 		case <-tokenRenewer.RenewCh():
-			log.Printf("Renewed Vault Token")
+			logger.Printf("Renewed Vault Token")
 		}
 	}
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
Added the possibility of logging in JSON format in both `vault-secrets-webhook` as well as in `vault-env`. Furthermore I've added a global hook for adding additional field to all log entries. I added `app` as a first field, for easier debugging.

Enabling JSON logging can be configured through the environment variable `enable_json_log` and can be overridden individually through the annotation: `vault.security.banzaicloud.io/enable-json-log` to control the output of `vault-env`.

Cleanup and parity of log methods were also done. So now logrus is used everywhere.

### Why?
JSON logging is very useful for structured logging, and is easily parseable for tools such as Datadog, 
Papertrail, etc. Furthermore JSON logging makes it easy to add new fields.


### Checklist
- [x] Logging code meets the guideline (TODO)

### To Do
I would like if someone could help me thoroughly test this feature for any regression.