### PR TITLE
Adding the ability to define nodeSelector and tolerations

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.8.0
+version: 0.8.1
 appVersion: 1.1.5
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/charts/vault/README.md
+++ b/charts/vault/README.md
@@ -129,8 +129,10 @@ The following tables lists the configurable parameters of the vault chart and th
 | `resources.limits.cpu`  | Container requested CPU             | `nil`                                               |
 | `resources.limits.memory` | Container requested memory        | `nil`                                               |
 | `unsealer.args`         | Bank Vaults args | `["--mode", "k8s", "--k8s-secret-namespace", "default", "--k8s-secret-name", "bank-vaults"]` |
-| `rabc.enabled`          | Use rbac                            | `true`                                              |
-| `rabc.psp.enabled`      | Use pod security policy             | `false`                                             |
+| `rbac.enabled`          | Use rbac                            | `true`                                              |
+| `rbac.psp.enabled`      | Use pod security policy             | `false`                                             |
+| `nodeSelector`          | Node labels for pod assignment. https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector                                                           | `{}`        
+| `tolerations`                                  | List of node tolerations for the pods. https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/                                                           | `[]`        
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -58,6 +58,7 @@ spec:
           mountPath: /vault/raw-config/
         - name: vault-config
           mountPath: /vault/config/
+        
       containers:
       - name: vault
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -226,6 +227,14 @@ spec:
           mountPath: /tmp/
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}      
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}      
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -65,6 +65,18 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+## Node labels for pod assignment
+nodeSelector: {}
+
+
+## Add tolerations if specified
+tolerations: []
+# - effect: NoSchedule
+#   key: "key"
+#   operator: Equal
+#   value: "value"
+
 vault:
   # Allows the mounting of various custom secrets to enable production vault
   # configurations. The comments show an example usage for mounting a TLS


### PR DESCRIPTION
Signed-off-by: Murphy, Kealan <kealan.murphy@aspect.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #689
| License         | Apache 2.0


### What's in this PR?
This PR add's the ability to specify a nodeSelecotr and or toleration's to the Vault statefulset pods when being installed from the Vault chart.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x ] Related Helm chart(s) updated (if needed)

