### PR TITLE
Added release namespace to webhook helm templates

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.1"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.5.2
+version: 0.5.3
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -14,6 +14,7 @@ items:
   kind: Secret
   metadata:
     name: {{ template "vault-secrets-webhook.fullname" . }}
+    namespace: {{ .Release.Namespace }}
   data:
     tls.crt: {{ b64enc $server.Cert }}
     tls.key: {{ b64enc $server.Key }}
@@ -23,6 +24,7 @@ items:
   kind: MutatingWebhookConfiguration
   metadata:
     name: {{ template "vault-secrets-webhook.fullname" . }}
+    namespace: {{ .Release.Namespace }}
   webhooks:
   - name: pods.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
     clientConfig:

--- a/charts/vault-secrets-webhook/templates/prometheus-monitorservice.yaml
+++ b/charts/vault-secrets-webhook/templates/prometheus-monitorservice.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "vault-secrets-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/name: {{ template "vault-secrets-webhook.name" . }}
@@ -36,6 +37,7 @@ kind: Service
 metadata:
   annotations:
   name: {{ template "vault-secrets-webhook.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/name: {{ template "vault-secrets-webhook.name" . }}

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "vault-secrets-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/name: {{ template "vault-secrets-webhook.name" . }}

--- a/charts/vault-secrets-webhook/templates/webhook-pdb.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "vault-secrets-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/name: {{ template "vault-secrets-webhook.fullname" . }}

--- a/charts/vault-secrets-webhook/templates/webhook-psp.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-psp.yaml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "vault-secrets-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default
     seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
@@ -37,6 +38,7 @@ metadata:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default
     seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
   name: {{ template "vault-secrets-webhook.fullname" . }}.mutate
+  namespace: {{ .Release.Namespace }}
 spec:
   allowPrivilegeEscalation: false
   fsGroup:

--- a/charts/vault-secrets-webhook/templates/webhook-service.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vault-secrets-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/name: {{ template "vault-secrets-webhook.fullname" . }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | none - fixes configured namespace not being used in the templates
| License         | Apache 2.0


### What's in this PR?
We configured a namespace with helm but the namespace was not used at all points within the templates


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Related Helm chart(s) updated (if needed)