### PR TITLE
[bankVaultsMounts] Allow Mounts for bank-vaults sidecar

### DIFF
--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -112,6 +112,10 @@ type VaultSpec struct {
 	// BankVaultsImage specifies the Bank Vaults image to use for Vault unsealing and configuration
 	// default: banzaicloud/bank-vaults:latest
 	BankVaultsImage string `json:"bankVaultsImage"`
+	
+	// BankVaultsVolumeMounts define some extra Kubernetes Volume mounts for the Bank Vaults Sidecar container.
+	// default:
+	BankVaultsVolumeMounts []v1.VolumeMount `json:"bankVaultsVolumeMounts,omitempty"`
 
 	// StatsDDisabled specifies if StatsD based metrics should be disabled
 	// default: false

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -885,10 +885,14 @@ func deploymentForConfigurer(v *vaultv1alpha1.Vault, configmaps corev1.ConfigMap
 				},
 			})
 
+			volumes = withVaultVolumes(v, volumes)
+
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{
 				Name:      cm.Name,
 				MountPath: "/config/" + cm.Name,
 			})
+
+			volumeMounts = withBanksVaultsVolumeMounts(v, volumeMounts)
 
 			configArgs = append(configArgs, "--vault-config-file", "/config/"+cm.Name+"/"+vault.DefaultConfigFile)
 		}

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -932,7 +932,7 @@ func deploymentForConfigurer(v *vaultv1alpha1.Vault, configmaps corev1.ConfigMap
 					ContainerPort: 9091,
 					Protocol:      "TCP",
 				}},
-				Env:          withSecretEnv(v, withTLSEnv(v, false, withCredentialsEnv(v, []corev1.EnvVar{}))),
+				Env:          withSecretEnv(v, withTLSEnv(v, false, withCredentialsEnv(v, withVaultEnv(v, []corev1.EnvVar{})))),
 				VolumeMounts: withTLSVolumeMount(v, withCredentialsVolumeMount(v, volumeMounts)),
 				WorkingDir:   "/config",
 				Resources:    *getBankVaultsResource(v),
@@ -1199,7 +1199,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 				Name:            "bank-vaults",
 				Command:         unsealCommand,
 				Args:            append(v.Spec.UnsealConfig.Options.ToArgs(), v.Spec.UnsealConfig.ToArgs(v)...),
-				Env: withSecretEnv(v, withTLSEnv(v, true, withCredentialsEnv(v, []corev1.EnvVar{
+				Env: withSecretEnv(v, withTLSEnv(v, true, withCredentialsEnv(v, withVaultEnv(v, []corev1.EnvVar{
 					{
 						Name:  k8s.EnvK8SOwnerReference,
 						Value: string(ownerJSON),
@@ -1212,7 +1212,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 							},
 						},
 					},
-				}))),
+				})))),
 				Ports: []corev1.ContainerPort{{
 					Name:          "metrics",
 					ContainerPort: 9091,

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1214,7 +1214,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 					ContainerPort: 9091,
 					Protocol:      "TCP",
 				}},
-				VolumeMounts: withTLSVolumeMount(v, withCredentialsVolumeMount(v, []corev1.VolumeMount{})),
+				VolumeMounts: withBanksVaultsVolumeMounts(v, withTLSVolumeMount(v, withCredentialsVolumeMount(v, []corev1.VolumeMount{}))),
 				Resources:    *getBankVaultsResource(v),
 			},
 		})),
@@ -1603,6 +1603,21 @@ func getVaultURIScheme(v *vaultv1alpha1.Vault) corev1.URIScheme {
 		return corev1.URISchemeHTTP
 	}
 	return corev1.URISchemeHTTPS
+}
+
+func withBanksVaultsVolumeMounts(v *vaultv1alpha1.Vault, volumeMounts []corev1.VolumeMount) []corev1.VolumeMount {
+	index := map[string]corev1.VolumeMount{}
+	for _, v := range append(volumeMounts, v.Spec.BankVaultsVolumeMounts...) {
+		index[v.Name] = v
+	}
+
+	volumeMounts = []corev1.VolumeMount{}
+	for _, v := range index {
+		volumeMounts = append(volumeMounts, v)
+	}
+
+	sort.Slice(volumeMounts, func(i, j int) bool { return volumeMounts[i].Name < volumeMounts[j].Name })
+	return volumeMounts
 }
 
 func withVaultVolumes(v *vaultv1alpha1.Vault, volumes []corev1.Volume) []corev1.Volume {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | related to #687
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
The example edited in #687 utilizes volumeMounts to perform unseal and store vault token. These mounts are mounted to the vault container and not to the BankVaults sidecar causing the bank-vaults container to default to kubernetes auth as the file token doesn't exist. This allows one to specify mounts for the sidecar as well.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Allows bank-vaults sidecar to read token from generic volumeMount and not just a secret.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Utilizing a hostPath based token, I was not able to automate the unseal and initialization of vault.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)
