### PR TITLE
Slim vault-env docker image size from 127Mb to 24Mb

### DIFF
--- a/Dockerfile.vault-env
+++ b/Dockerfile.vault-env
@@ -17,9 +17,9 @@ COPY . /build
 RUN go mod download
 
 COPY . /go/src/${PACKAGE}
-RUN CGO_ENABLED=0 go install ./cmd/vault-env
+RUN CGO_ENABLED=0 go build ./cmd/vault-env
 
+FROM alpine:3.10
 
-FROM vault:1.2.3
-
-COPY --from=builder /go/bin/vault-env /usr/local/bin/vault-env
+RUN apk add --update --no-cache ca-certificates
+COPY --from=builder /build/vault-env /usr/local/bin/vault-env


### PR DESCRIPTION
Hi,

I couldn't find out any use of vault inside `cmd/vault-env/main.go` and experimented with removing vault. Sure enough it worked.

The resulting image is now ~24Mb instead of 127Mb.

Hope you find this useful!

### What's in this PR?
vault-env no longer build from `vault:1.2.3` but from `alpine:3.10` to remove the unneeded dependency on vault.


### Why?
I was wondering why the docker-env image was so big, and found that it included the entire 104Mb vault binary.


### Checklist
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
