### PR TITLE
[vault-env] Revoke token

### DIFF
--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -243,6 +243,7 @@ func main() {
 	}
 
 	if os.Getenv("VAULT_REVOKE_TOKEN") == "true" {
+		// ref: https://www.vaultproject.io/api/auth/token/index.html#revoke-a-token-self-
 		err = client.RawClient().Auth().Token().RevokeSelf(client.RawClient().Token())
 		if err != nil {
 			// Do not exit on error, token revoking can be denied by policy

--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -55,6 +55,7 @@ var sanitizeEnvmap = map[string]bool{
 	"VAULT_IGNORE_MISSING_SECRETS": true,
 	"VAULT_ENV_PASSTHROUGH":        true,
 	"VAULT_JSON_LOG":               true,
+	"VAULT_REVOKE_TOKEN":           true,
 }
 
 var logger *log.Logger
@@ -241,9 +242,12 @@ func main() {
 		}
 	}
 
-	err = client.RawClient().Auth().Token().RevokeSelf(client.RawClient().Token())
-	if err != nil {
-		logger.Warnln("failed to revoke token")
+	if os.Getenv("VAULT_REVOKE_TOKEN") == "true" {
+		err = client.RawClient().Auth().Token().RevokeSelf(client.RawClient().Token())
+		if err != nil {
+			// Do not exit on error, token revoking can be denied by policy
+			logger.Warnln("failed to revoke token")
+		}
 	}
 
 	err = syscall.Exec(binary, entrypointCmd, sanitized)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

1. Allow revoke vault's token;
1. Move on top checking Args and LookPath.


### Why?

In some cases Kubernetes auth backend may be configured with long-life token. Setting `VAULT_REVOKE_TOKEN=true` can revoke token.
