### PR TITLE
webhook: Add RunAsUser functionality within copy-vault-init and containers

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -176,11 +176,11 @@ func getInitContainers(originalContainers []corev1.Container, podSecurityContext
 	return containers
 }
 
-func getContainers(podSecurityContext *corev1.PodSecurityContext, vaultConfig vaultConfig, containerEnvVars []corev1.EnvVar, containerVolMounts []corev1.VolumeMount) []corev1.Container {
+func getContainers(vaultConfig vaultConfig, containerEnvVars []corev1.EnvVar, containerVolMounts []corev1.VolumeMount) []corev1.Container {
 	var containers = []corev1.Container{}
-	var securityContext *corev1.SecurityContext
-
-	securityContext = getSecurityContext(podSecurityContext, vaultConfig)
+	securityContext := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: &vaultConfig.pspAllowPrivilegeEscalation,
+	}
 
 	if vaultConfig.ctShareProcess {
 		securityContext = &corev1.SecurityContext{
@@ -884,7 +884,7 @@ func (mw *mutatingWebhook) mutatePod(pod *corev1.Pod, vaultConfig vaultConfig, n
 			shareProcessNamespace := true
 			pod.Spec.ShareProcessNamespace = &shareProcessNamespace
 		}
-		pod.Spec.Containers = append(getContainers(pod.Spec.SecurityContext, vaultConfig, containerEnvVars, containerVolMounts), pod.Spec.Containers...)
+		pod.Spec.Containers = append(getContainers(vaultConfig, containerEnvVars, containerVolMounts), pod.Spec.Containers...)
 
 		logger.Debugf("Successfully appended pod containers to spec")
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New feature?    | yes 
| API breaks?     | no 
| Deprecations?   | no 
| Related tickets | fixes #663 
| License         | Apache 2.0


### What's in this PR?

Attempting to address the situation where PSPs are being enforced for running containers without a root user.  This takes a slightly different approach than other PRs.  Instead of introducing a new annotation, it relies on the user just leveraging the Pod Spec.  

### Additional context
The `PodSecurityContext` (https://godoc.org/k8s.io/api/core/v1#PodSecurityContext) and `SecurityContext` (https://godoc.org/k8s.io/api/core/v1#SecurityContext) types share some attributes, but not all.  One such attribute is the `RunAsUser`, which is fairly important for PSP policies. 


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
I'm not clear how far we want to take this - I don't see an acceptance test exercising the current `SecurityContext` within the webhook managed containers for `AllowPrivilegeEscalation`, but we might want to add a PSP policy, service account, and ClusterRole/RoleBinding (for the SA) to exercise the complete flow here.  Any advice around this would be welcome.

<!-- (Please remove this section if you don't need it.) -->
- [] Add a specific acceptance test
