### PR TITLE
Add first unit tests to vault-secrets-webhook

### DIFF
--- a/cmd/vault-secrets-webhook/configmap.go
+++ b/cmd/vault-secrets-webhook/configmap.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	internal "github.com/banzaicloud/bank-vaults/internal/configuration"
 	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -37,7 +38,7 @@ func configMapNeedsMutation(configMap *corev1.ConfigMap) bool {
 	return false
 }
 
-func mutateConfigMap(configMap *corev1.ConfigMap, vaultConfig vaultConfig, ns string) error {
+func mutateConfigMap(configMap *corev1.ConfigMap, vaultConfig internal.VaultConfig, ns string) error {
 
 	// do an early exit and don't construct the Vault client if not needed
 	if !configMapNeedsMutation(configMap) {

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -85,7 +85,7 @@ auto_auth {
 }`
 
 type mutatingWebhook struct {
-	k8sClient *kubernetes.Clientset
+	k8sClient kubernetes.Interface
 }
 
 // If the original Pod contained a Volume "vault-tls", for example Vault instances provisioned by the Operator
@@ -741,7 +741,7 @@ func newVaultClient(vaultConfig vaultConfig) (*vault.Client, error) {
 	)
 }
 
-func newK8SClient() (*kubernetes.Clientset, error) {
+func newK8SClient() (kubernetes.Interface, error) {
 	kubeConfig, err := kubernetesConfig.GetConfig()
 	if err != nil {
 		return nil, err

--- a/cmd/vault-secrets-webhook/main_test.go
+++ b/cmd/vault-secrets-webhook/main_test.go
@@ -1,0 +1,163 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	cmp "github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	fake "k8s.io/client-go/kubernetes/fake"
+
+	internal "github.com/banzaicloud/bank-vaults/internal/configuration"
+)
+
+var vaultConfig = internal.VaultConfig{
+	Addr:                 "addr",
+	SkipVerify:           "skipVerify",
+	Path:                 "path",
+	Role:                 "role",
+	IgnoreMissingSecrets: "ignoreMissingSecrets",
+	VaultEnvPassThrough:  "vaultEnvPassThrough",
+	EnableJSONLog:        "enableJSONLog",
+}
+
+func Test_mutatingWebhook_mutateContainers(t *testing.T) {
+
+	type fields struct {
+		k8sClient kubernetes.Interface
+	}
+	type args struct {
+		containers  []corev1.Container
+		podSpec     *corev1.PodSpec
+		vaultConfig internal.VaultConfig
+		ns          string
+	}
+	tests := []struct {
+		name             string
+		fields           fields
+		args             args
+		mutated          bool
+		wantErr          bool
+		wantedContainers []corev1.Container
+	}{
+		{name: "Will mutate container with command, no args",
+			fields: fields{
+				k8sClient: fake.NewSimpleClientset(),
+			},
+			args: args{
+				containers: []corev1.Container{
+					corev1.Container{
+						Name:    "MyContainer",
+						Image:   "myimage",
+						Command: []string{"/bin/bash"},
+						Args:    nil,
+						Env: []corev1.EnvVar{
+							{
+								Name:  "myvar",
+								Value: "vault:secrets",
+							},
+						},
+					},
+				},
+				vaultConfig: vaultConfig,
+			},
+			wantedContainers: []corev1.Container{
+				corev1.Container{
+					Name:         "MyContainer",
+					Image:        "myimage",
+					Command:      []string{"/vault/vault-env"},
+					Args:         []string{"/bin/bash"},
+					VolumeMounts: []corev1.VolumeMount{{Name: "vault-env", MountPath: "/vault/"}},
+					Env: []corev1.EnvVar{
+						{Name: "myvar", Value: "vault:secrets"},
+						{Name: "VAULT_ADDR", Value: "addr"},
+						{Name: "VAULT_SKIP_VERIFY", Value: "skipVerify"},
+						{Name: "VAULT_PATH", Value: "path"},
+						{Name: "VAULT_ROLE", Value: "role"},
+						{Name: "VAULT_IGNORE_MISSING_SECRETS", Value: "ignoreMissingSecrets"},
+						{Name: "VAULT_ENV_PASSTHROUGH", Value: "vaultEnvPassThrough"},
+						{Name: "VAULT_JSON_LOG", Value: "enableJSONLog"},
+					},
+				},
+			},
+			mutated: true,
+			wantErr: false,
+		},
+		{name: "Will mutate container with command, other syntax",
+			fields: fields{
+				k8sClient: fake.NewSimpleClientset(),
+			},
+			args: args{
+				containers: []corev1.Container{
+					corev1.Container{
+						Name:    "MyContainer",
+						Image:   "myimage",
+						Command: []string{"/bin/bash"},
+						Args:    nil,
+						Env: []corev1.EnvVar{
+							{
+								Name:  "myvar",
+								Value: ">>vault:secrets",
+							},
+						},
+					},
+				},
+				vaultConfig: vaultConfig,
+			},
+			wantedContainers: []corev1.Container{
+				corev1.Container{
+					Name:         "MyContainer",
+					Image:        "myimage",
+					Command:      []string{"/vault/vault-env"},
+					Args:         []string{"/bin/bash"},
+					VolumeMounts: []corev1.VolumeMount{{Name: "vault-env", MountPath: "/vault/"}},
+					Env: []corev1.EnvVar{
+						{Name: "myvar", Value: ">>vault:secrets"},
+						{Name: "VAULT_ADDR", Value: "addr"},
+						{Name: "VAULT_SKIP_VERIFY", Value: "skipVerify"},
+						{Name: "VAULT_PATH", Value: "path"},
+						{Name: "VAULT_ROLE", Value: "role"},
+						{Name: "VAULT_IGNORE_MISSING_SECRETS", Value: "ignoreMissingSecrets"},
+						{Name: "VAULT_ENV_PASSTHROUGH", Value: "vaultEnvPassThrough"},
+						{Name: "VAULT_JSON_LOG", Value: "enableJSONLog"},
+					},
+				},
+			},
+			mutated: true,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mw := &mutatingWebhook{
+				k8sClient: tt.fields.k8sClient,
+			}
+			got, err := mw.mutateContainers(tt.args.containers, tt.args.podSpec, tt.args.vaultConfig, tt.args.ns)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mutatingWebhook.mutateContainers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.mutated {
+				t.Errorf("mutatingWebhook.mutateContainers() = %v, want %v", got, tt.mutated)
+			}
+			if !cmp.Equal(tt.args.containers, tt.wantedContainers) {
+				t.Errorf("mutatingWebhook.mutateContainers() = diff %v", cmp.Diff(tt.args.containers, tt.wantedContainers))
+			}
+		})
+	}
+}

--- a/cmd/vault-secrets-webhook/registry/registry.go
+++ b/cmd/vault-secrets-webhook/registry/registry.go
@@ -79,7 +79,7 @@ type DockerCreds struct {
 
 // GetImageConfig returns entrypoint and command of container
 func GetImageConfig(
-	clientset *kubernetes.Clientset,
+	clientset kubernetes.Interface,
 	namespace string,
 	container *corev1.Container,
 	podSpec *corev1.PodSpec) (*imagev1.ImageConfig, error) {
@@ -173,7 +173,7 @@ func parseContainerImage(image string) (string, string) {
 
 // K8s structure keeps information retrieved from POD definition
 type ContainerInfo struct {
-	clientset        *kubernetes.Clientset
+	clientset        kubernetes.Interface
 	Namespace        string
 	ImagePullSecrets string
 	RegistryAddress  string

--- a/cmd/vault-secrets-webhook/secret.go
+++ b/cmd/vault-secrets-webhook/secret.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/banzaicloud/bank-vaults/cmd/vault-secrets-webhook/registry"
+	internal "github.com/banzaicloud/bank-vaults/internal/configuration"
 	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
 	dockerTypes "github.com/docker/docker/api/types"
 	"github.com/spf13/cast"
@@ -37,7 +38,7 @@ func secretNeedsMutation(secret *corev1.Secret) bool {
 	return false
 }
 
-func mutateSecret(secret *corev1.Secret, vaultConfig vaultConfig, ns string) error {
+func mutateSecret(secret *corev1.Secret, vaultConfig internal.VaultConfig, ns string) error {
 
 	// do an early exit and don't construct the Vault client if not needed
 	if !secretNeedsMutation(secret) {

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/gin-gonic/gin v1.4.0
 	github.com/go-ini/ini v1.34.0 // indirect
+	github.com/google/go-cmp v0.3.0
 	github.com/google/martian v2.1.0+incompatible // indirect
 	github.com/googleapis/gax-go v2.0.0+incompatible // indirect
 	github.com/goph/emperror v0.17.2

--- a/internal/configuration/vaultConfig.go
+++ b/internal/configuration/vaultConfig.go
@@ -1,0 +1,44 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configuration
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// VaultConfig represents vault options
+type VaultConfig struct {
+	Addr                        string
+	Role                        string
+	Path                        string
+	SkipVerify                  string
+	TLSSecret                   string
+	UseAgent                    bool
+	CtConfigMap                 string
+	CtImage                     string
+	CtOnce                      bool
+	CtImagePullPolicy           corev1.PullPolicy
+	CtShareProcess              bool
+	CtShareProcessDefault       string
+	CtCPU                       resource.Quantity
+	CtMemory                    resource.Quantity
+	PspAllowPrivilegeEscalation bool
+	IgnoreMissingSecrets        string
+	VaultEnvPassThrough         string
+	ConfigfilePath              string
+	MutateConfigMap             bool
+	EnableJSONLog               string
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?       | yes 
| License         | Apache 2.0


### What's in this PR?
I've added two tests, during which I found one bug.
The tests can serve as a starting point for developing a full unit test suite.
Before I spend too much time on writing more tests, I would like some feedback on the style.

I've restructured the code a little bit to make it easier to write tests:
- Use `Kubernetes.Interface` instead of `Kubernetes.ClientSet` in `main.go` to allow mocking
- Moved `vaultConfig` to `internal` package to allow mocking it
- Extracted logic for determining if a env-var has `vault:` or `>>vault:` prefix into a function.

I also found that containers with a `>>vault:` prefix would not get mutated - which seemed strange to me, so I changed it. Let me know if this was intended behaviour.

Most of all I'm just looking for feedback on the PR, as I'm still quite new to writing Go :)