### PR TITLE
fix Client.Close() state handling

### DIFF
--- a/pkg/sdk/vault/client.go
+++ b/pkg/sdk/vault/client.go
@@ -347,8 +347,9 @@ func (client *Client) Close() {
 	client.mu.Lock()
 	defer client.mu.Unlock()
 
+	client.closed = true
+
 	if client.tokenRenewer != nil {
-		client.closed = true
 		client.tokenRenewer.Stop()
 	}
 


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
If the connection never happened to Vault the `client.Close()` function didn't work properly and the connection loop never stopped.