### PR TITLE
Added limit resources to initContainer

### DIFF
--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -58,6 +58,8 @@ spec:
           mountPath: /vault/raw-config/
         - name: vault-config
           mountPath: /vault/config/
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
         
       containers:
       - name: vault


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
This Pull Request extends initContainer definition with **resource limits** section.


### Why?
In some Kubernetes clusters it is forbidden to deploy Pods not having resource limits defined, eg: <br/>
`StatefulSet vault-server failed error: pods "vault-server-0" is forbidden: failed quota: mem-cpu: must specify limits.cpu, limits.memory, requests.cpu, requests.memory`<br/>
Which is quite a reasonable approach, **making the entire Kubernetes cluster more secure**. It is mandatory for initConainers to have the resource limits defined - otherwise it is not possible to deploy the chart to a such specific Kubernetes cluster.

### Test (helm template)
```
    spec:
      initContainers:
      - name: vault-config
        image: "jwilder/dockerize:latest"
        imagePullPolicy: IfNotPresent
        args:
          - "-delims"
          - "[[:]]"
          - "-template"
          - "/vault/raw-config/config.json:/vault/config/config.json"
          - "-template"
          - "/vault/raw-config/vault-config.yml:/vault/config/vault-config.yml"
        envFrom:
        env:
        volumeMounts:
        - name: vault-raw-config
          mountPath: /vault/raw-config/
        - name: vault-config
          mountPath: /vault/config/
        resources:
          {}
```




### Checklist

- [ x] Related Helm chart(s) updated (if needed)
