### PR TITLE
[webhook] Replaced stings.HasPrefix with strings.Contains 

### DIFF
--- a/cmd/vault-secrets-webhook/configmap.go
+++ b/cmd/vault-secrets-webhook/configmap.go
@@ -26,12 +26,12 @@ import (
 
 func configMapNeedsMutation(configMap *corev1.ConfigMap) bool {
 	for _, value := range configMap.Data {
-		if strings.HasPrefix(value, "vault:") {
+		if strings.Contains(value, "vault:") {
 			return true
 		}
 	}
 	for _, value := range configMap.BinaryData {
-		if strings.HasPrefix(string(value), "vault:") {
+		if strings.Contains(string(value), "vault:") {
 			return true
 		}
 	}
@@ -53,7 +53,7 @@ func mutateConfigMap(configMap *corev1.ConfigMap, vaultConfig internal.VaultConf
 	defer vaultClient.Close()
 
 	for key, value := range configMap.Data {
-		if strings.HasPrefix(value, "vault:") {
+		if strings.Contains(value, "vault:") {
 			data := map[string]string{
 				key: string(value),
 			}
@@ -65,7 +65,7 @@ func mutateConfigMap(configMap *corev1.ConfigMap, vaultConfig internal.VaultConf
 	}
 
 	for key, value := range configMap.BinaryData {
-		if strings.HasPrefix(string(value), "vault:") {
+		if strings.Contains(string(value), "vault:") {
 			binaryData := map[string]string{
 				key: string(value),
 			}

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -545,7 +545,7 @@ func (mw *mutatingWebhook) lookForEnvFrom(envFrom []corev1.EnvFromSource, ns str
 }
 
 func hasVaultPrefix(value string) bool {
-	return strings.HasPrefix(value, "vault:") || strings.HasPrefix(value, ">>vault:")
+	return strings.Contains(value, "vault:")
 }
 
 func (mw *mutatingWebhook) lookForValueFrom(env corev1.EnvVar, ns string) (*corev1.EnvVar, error) {

--- a/cmd/vault-secrets-webhook/secret.go
+++ b/cmd/vault-secrets-webhook/secret.go
@@ -191,8 +191,6 @@ func getDataFromVault(data map[string]string, vaultClient *vault.Client) (map[st
 func trimVaultPrefix(value string) string {
 	if strings.HasPrefix(value, "vault:") {
 		return strings.TrimPrefix(value, "vault:")
-	} else if strings.HasPrefix(value, ">>vault:") {
-		return strings.TrimPrefix(value, ">>vault:")
 	}
 	return value
 }


### PR DESCRIPTION

Signed-off-by: Volodymyr Moseichuk <moskitone@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Replaced stings.HasPrefix with strings.Contains to have ability to have data mutation in any position of configmap or secret.



### Why?
In vault-secrets-webhook:0.4.17-rc.4 was ability to put any JSON or XML or any other text into data field of K8s secret and configmap and mutation worked.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)

