### PR TITLE
[charts/vault-secrets-webhook] Add option to use static certicates for vault-secrets-webhook helmchart.

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.1"
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.5.3
+version: 0.5.4
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -111,7 +111,7 @@ You can read more information on how to add firewall rules for the GKE control p
 The following tables lists configurable parameters of the vault-secrets-webhook chart and their default values:
 
 | Parameter                        | Description                                                                  | Default                             |
-| -------------------------------- | ---------------------------------------------------------------------------- | ----------------------------------- |
+|----------------------------------|------------------------------------------------------------------------------|-------------------------------------|
 | affinity                         | affinities to use                                                            | `{}`                                |
 | debug                            | debug logs for webhook                                                       | `false`                             |
 | image.pullPolicy                 | image pull policy                                                            | `IfNotPresent`                      |
@@ -136,3 +136,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | configMapMutation                | enable injecting values from Vault to ConfigMaps                             | `false`                             |
 | podDisruptionBudget.enabled      | enable PodDisruptionBudget                                                   | `false`                             |
 | podDisruptionBudget.minAvailable | represents the number of Pods that must be available (integer or percentage) | `1`                                 |
+| certificate.generate             | should a new CA and TLS certificate be generated for the webhook             | `true`                              |
+| certificate.ca.crt               | Base64 encoded CA certificate                                                | ``                                  |
+| certificate.server.tls.crt       | Base64 encoded TLS certificate signed by the CA                              | ``                                  |
+| certificate.server.tls.key       | Base64 encoded  private key of TLS certificate signed by the CA              | ``                                  |

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -1,123 +1,129 @@
-{{ $ca := genCA "svc-cat-ca" 3650 }}
-{{ $svcName := include "vault-secrets-webhook.fullname" . }}
-{{ $cn := printf "%s.%s.svc" $svcName .Release.Namespace }}
-{{ $altName1 := printf "%s.cluster.local" $cn }}
-{{ $altName2 := printf "%s" $cn }}
-{{ $server := genSignedCert $cn nil (list $altName1 $altName2) 365 $ca }}
-
-apiVersion: v1
-kind: List
-metadata:
-items:
-
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    name: {{ template "vault-secrets-webhook.fullname" . }}
-    namespace: {{ .Release.Namespace }}
-  data:
-    tls.crt: {{ b64enc $server.Cert }}
-    tls.key: {{ b64enc $server.Key }}
-    ca.crt:  {{ b64enc $ca.Cert }}
-
-- apiVersion: admissionregistration.k8s.io/v1beta1
-  kind: MutatingWebhookConfiguration
-  metadata:
-    name: {{ template "vault-secrets-webhook.fullname" . }}
-    namespace: {{ .Release.Namespace }}
-  webhooks:
-  - name: pods.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
-    clientConfig:
-      service:
-        namespace: {{ .Release.Namespace }}
-        name: {{ template "vault-secrets-webhook.fullname" . }}
-        path: /pods
-      caBundle: {{ b64enc $ca.Cert }}
-    rules:
-    - operations:
-      - CREATE
-      apiGroups:
-      - "*"
-      apiVersions:
-      - "*"
-      resources:
-      - pods
-    failurePolicy: {{ .Values.podsFailurePolicy }}
-    namespaceSelector:
-    {{- if .Values.namespaceSelector.matchLabels }}
-      matchLabels:
-{{ toYaml .Values.namespaceSelector.matchLabels | indent 8 }}
-    {{- end }}
-      matchExpressions:
-      {{- if .Values.namespaceSelector.matchExpressions }}
-{{ toYaml .Values.namespaceSelector.matchExpressions | indent 6 }}
-      {{- end }}
-      - key: name
-        operator: NotIn
-        values:
-        - {{ .Release.Namespace }}
-  - name: secrets.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
-    clientConfig:
-      service:
-        namespace: {{ .Release.Namespace }}
-        name: {{ template "vault-secrets-webhook.fullname" . }}
-        path: /secrets
-      caBundle: {{ b64enc $ca.Cert }}
-    rules:
-    - operations:
-      - CREATE
-      - UPDATE
-      apiGroups:
-      - "*"
-      apiVersions:
-      - "*"
-      resources:
-      - secrets
-    failurePolicy: {{ .Values.secretsFailurePolicy }}
-    namespaceSelector:
-    {{- if .Values.namespaceSelector.matchLabels }}
-      matchLabels:
-{{ toYaml .Values.namespaceSelector.matchLabels | indent 8 }}
-    {{- end }}
-      matchExpressions:
-      {{- if .Values.namespaceSelector.matchExpressions }}
-{{ toYaml .Values.namespaceSelector.matchExpressions | indent 6 }}
-      {{- end }}
-      - key: name
-        operator: NotIn
-        values:
-        - {{ .Release.Namespace }}
-{{- if .Values.configMapMutation }}
-  - name: configmaps.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
-    clientConfig:
-      service:
-        namespace: {{ .Release.Namespace }}
-        name: {{ template "vault-secrets-webhook.fullname" . }}
-        path: /configmaps
-      caBundle: {{ b64enc $ca.Cert }}
-    rules:
-      - operations:
-          - CREATE
-          - UPDATE
-        apiGroups:
-          - "*"
-        apiVersions:
-          - "*"
-        resources:
-          - configmaps
-    failurePolicy: {{ .Values.configmapFailurePolicy }}
-    namespaceSelector:
-    {{- if .Values.namespaceSelector.matchLabels }}
-      matchLabels:
-{{ toYaml .Values.namespaceSelector.matchLabels | indent 8 }}
-    {{- end }}
-      matchExpressions:
-    {{- if .Values.namespaceSelector.matchExpressions }}
-{{ toYaml .Values.namespaceSelector.matchExpressions | indent 6 }}
-    {{- end }}
-      - key: name
-        operator: NotIn
-        values:
-        - {{ .Release.Namespace }}
+{{- $tlsCrt := "" }}
+{{- $tlsKey := "" }}
+{{- $caCrt := "" }}
+{{- if .Values.certificate.generate }}
+{{- $ca := genCA "svc-cat-ca" 3650 }}
+{{- $svcName := include "vault-secrets-webhook.fullname" . }}
+{{- $cn := printf "%s.%s.svc" $svcName .Release.Namespace }}
+{{- $altName1 := printf "%s.cluster.local" $cn }}
+{{- $altName2 := printf "%s" $cn }}
+{{- $server := genSignedCert $cn nil (list $altName1 $altName2) 365 $ca }}
+{{- $tlsCrt = b64enc $server.Cert }}
+{{- $tlsKey = b64enc $server.Key }}
+{{- $caCrt =  b64enc $ca.Cert }}
+{{- else }}
+{{- $tlsCrt = required "Required when certificate.generate is false" .Values.certificate.server.tls.crt }}
+{{- $tlsKey = required "Required when certificate.generate is false" .Values.certificate.server.tls.key }}
+{{- $caCrt = required "Required when certificate.generate is false" .Values.certificate.ca.crt }}
 {{- end }}
-    sideEffects: NoneOnDryRun
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "vault-secrets-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+data:
+  tls.crt: {{ $tlsCrt }}
+  tls.key: {{ $tlsKey }}
+  ca.crt:  {{ $caCrt }}
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ template "vault-secrets-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+webhooks:
+- name: pods.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ template "vault-secrets-webhook.fullname" . }}
+      path: /pods
+    caBundle: {{ $caCrt }}
+  rules:
+  - operations:
+    - CREATE
+    apiGroups:
+    - "*"
+    apiVersions:
+    - "*"
+    resources:
+    - pods
+  failurePolicy: {{ .Values.podsFailurePolicy }}
+  namespaceSelector:
+  {{- if .Values.namespaceSelector.matchLabels }}
+    matchLabels:
+{{ toYaml .Values.namespaceSelector.matchLabels | indent 6 }}
+  {{- end }}
+    matchExpressions:
+    {{- if .Values.namespaceSelector.matchExpressions }}
+{{ toYaml .Values.namespaceSelector.matchExpressions | indent 4 }}
+    {{- end }}
+    - key: name
+      operator: NotIn
+      values:
+      - {{ .Release.Namespace }}
+- name: secrets.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ template "vault-secrets-webhook.fullname" . }}
+      path: /secrets
+    caBundle: {{ $caCrt }}
+  rules:
+  - operations:
+    - CREATE
+    - UPDATE
+    apiGroups:
+    - "*"
+    apiVersions:
+    - "*"
+    resources:
+    - secrets
+  failurePolicy: {{ .Values.secretsFailurePolicy }}
+  namespaceSelector:
+  {{- if .Values.namespaceSelector.matchLabels }}
+    matchLabels:
+{{ toYaml .Values.namespaceSelector.matchLabels | indent 6 }}
+  {{- end }}
+  matchExpressions:
+    {{- if .Values.namespaceSelector.matchExpressions }}
+{{ toYaml .Values.namespaceSelector.matchExpressions | indent 4 }}
+    {{- end }}
+    - key: name
+      operator: NotIn
+      values:
+      - {{ .Release.Namespace }}
+{{- if .Values.configMapMutation }}
+- name: configmaps.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ template "vault-secrets-webhook.fullname" . }}
+      path: /configmaps
+    caBundle: {{ $caCrt }}
+  rules:
+    - operations:
+        - CREATE
+        - UPDATE
+      apiGroups:
+        - "*"
+      apiVersions:
+        - "*"
+      resources:
+        - configmaps
+  failurePolicy: {{ .Values.configmapFailurePolicy }}
+  namespaceSelector:
+  {{- if .Values.namespaceSelector.matchLabels }}
+    matchLabels:
+{{ toYaml .Values.namespaceSelector.matchLabels | indent 6 }}
+  {{- end }}
+    matchExpressions:
+  {{- if .Values.namespaceSelector.matchExpressions }}
+{{ toYaml .Values.namespaceSelector.matchExpressions | indent 4 }}
+  {{- end }}
+    - key: name
+      operator: NotIn
+      values:
+      - {{ .Release.Namespace }}
+{{- end }}
+  sideEffects: NoneOnDryRun

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -6,6 +6,14 @@ replicaCount: 2
 
 debug: false
 
+certificate:
+    generate: true
+    server:
+        tls:
+            crt:
+            key:
+    ca:
+        crt:
 image:
   repository: banzaicloud/vault-secrets-webhook
   tag: 0.5.1


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Allow inserting static 64encoded CA and TLS certificates for the mutating webhook - off by default.
```
certificate:
    generate: true
    server:
        tls:
            crt:
            key:
    ca:
        crt:
```
I've also changed the helm chart so the top-level `List` object is no longer needed.

### Why?
The current implementation is causing us some troubles because we use git-ops via helmsman. 
Every time helmsman checks if there’s any changes to deploy (with helm-diff), helm will generate a new certificate and that will cause a redeploy.
