### PR TITLE
WIP: [webhook] Allow disable cache or cache only images with digest

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -915,6 +915,8 @@ func init() {
 	viper.SetDefault("registry_skip_verify", "false")
 	viper.SetDefault("debug", "false")
 	viper.SetDefault("enable_json_log", "false")
+	viper.SetDefault("registry_cache_storage", "inmemory")
+	viper.SetDefault("registry_cache_opts_digest_only", "false")
 	viper.AutomaticEnv()
 
 	logger = log.New()

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -916,7 +916,7 @@ func init() {
 	viper.SetDefault("debug", "false")
 	viper.SetDefault("enable_json_log", "false")
 	viper.SetDefault("registry_cache_storage", "inmemory")
-	viper.SetDefault("registry_cache_opts_digest_only", "false")
+	viper.SetDefault("registry_cache_digest_only", "false")
 	viper.AutomaticEnv()
 
 	logger = log.New()

--- a/cmd/vault-secrets-webhook/registry/image_cache_test.go
+++ b/cmd/vault-secrets-webhook/registry/image_cache_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package registry
 
 import "testing"

--- a/cmd/vault-secrets-webhook/registry/image_cache_test.go
+++ b/cmd/vault-secrets-webhook/registry/image_cache_test.go
@@ -1,0 +1,23 @@
+package registry
+
+import "testing"
+
+func TestNewImageCache(t *testing.T) {
+	tests := []string{
+		"none",
+		"inmemory",
+		"redis",
+		"memcache",
+	}
+	for _, test := range tests {
+		cache := NewImageCache(test, nil)
+		if cache == nil {
+			t.Errorf("NewImageCache(%s, nil) == nil", test)
+		}
+		opts := &ImageCacheOptions{}
+		cache = NewImageCache(test, opts)
+		if cache == nil {
+			t.Errorf("NewImageCache(%s, %v) == nil", test, opts)
+		}
+	}
+}

--- a/cmd/vault-secrets-webhook/registry/inmemory_image_cache.go
+++ b/cmd/vault-secrets-webhook/registry/inmemory_image_cache.go
@@ -1,0 +1,69 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"sync"
+
+	imagev1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// InMemoryImageCache Concrete mutex-guarded cache
+type InMemoryImageCache struct {
+	opts  *ImageCacheOptions
+	mutex sync.Mutex
+	cache map[string]imagev1.ImageConfig
+}
+
+// NewInMemoryImageCache return new mutex guarded cache
+func NewInMemoryImageCache(opts *ImageCacheOptions) ImageCache {
+	return &InMemoryImageCache{
+		opts:  opts,
+		cache: map[string]imagev1.ImageConfig{},
+	}
+}
+
+// isAllowToCache check that we can cache imformation about image
+func (c *InMemoryImageCache) isAllowToCache(image string) bool {
+	if !c.opts.DigestOnly {
+		return true
+	}
+	return IsImageNameWithDigest(image)
+}
+
+// Get image from cache
+func (c *InMemoryImageCache) Get(image string) *imagev1.ImageConfig {
+	if !c.isAllowToCache(image) {
+		return nil
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if imageConfig, ok := c.cache[image]; ok {
+		return &imageConfig
+	}
+	return nil
+}
+
+// Put image into cache
+func (c *InMemoryImageCache) Put(image string, imageConfig *imagev1.ImageConfig) {
+	if !c.isAllowToCache(image) {
+		return
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.cache[image] = *imageConfig
+}

--- a/cmd/vault-secrets-webhook/registry/none_image_cache.go
+++ b/cmd/vault-secrets-webhook/registry/none_image_cache.go
@@ -1,0 +1,35 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	imagev1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// NoneImageCache without cache
+type NoneImageCache struct{}
+
+// NewNoneImageCache return new cache without storage
+func NewNoneImageCache() ImageCache {
+	return &NoneImageCache{}
+}
+
+// Get image from cache
+func (c *NoneImageCache) Get(image string) *imagev1.ImageConfig {
+	return nil
+}
+
+// Put image into cache
+func (c *NoneImageCache) Put(image string, imageConfig *imagev1.ImageConfig) {}

--- a/cmd/vault-secrets-webhook/registry/none_image_cache_test.go
+++ b/cmd/vault-secrets-webhook/registry/none_image_cache_test.go
@@ -1,0 +1,37 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"testing"
+
+	imagev1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestNoneImageCache_PutGet(t *testing.T) {
+	cache := NewNoneImageCache()
+	images := []string{
+		"foobar:latest",
+		"foobar@sha256:ABCD",
+	}
+	for _, image := range images {
+		cache.Put(image, &imagev1.ImageConfig{
+			Cmd: []string{"/bin/bash"},
+		})
+		if ic := cache.Get(image); ic != nil {
+			t.Error("NoneImageCache.Get() != nil")
+		}
+	}
+}

--- a/cmd/vault-secrets-webhook/registry/registry.go
+++ b/cmd/vault-secrets-webhook/registry/registry.go
@@ -58,7 +58,7 @@ func NewRegistry() ImageRegistry {
 
 	imageCacheStorage := viper.GetString("registry_cache_storage")
 	r.imageCache = NewImageCache(imageCacheStorage, &ImageCacheOptions{
-		DigestOnly: viper.GetBool("registry_cache_opts_digest_only"),
+		DigestOnly: viper.GetBool("registry_cache_digest_only"),
 	})
 	return r
 }

--- a/cmd/vault-secrets-webhook/registry/registry_test.go
+++ b/cmd/vault-secrets-webhook/registry/registry_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package registry
 
 import (

--- a/cmd/vault-secrets-webhook/registry/registry_test.go
+++ b/cmd/vault-secrets-webhook/registry/registry_test.go
@@ -1,0 +1,82 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseContainerImage(t *testing.T) {
+	tests := []struct {
+		image, name, ref string
+	}{
+		{
+			image: "foobar",
+			name:  "foobar",
+			ref:   "latest",
+		},
+		{
+			image: "foobar:latest",
+			name:  "foobar",
+			ref:   "latest",
+		},
+		{
+			image: "foobar@sha256:ABCD",
+			name:  "foobar",
+			ref:   "sha256:ABCD",
+		},
+	}
+	for _, test := range tests {
+		name, ref := ParseContainerImage(test.image)
+		if !cmp.Equal(name, test.name) {
+			t.Errorf("ParseContainerImage().Name != Want \n %v", cmp.Diff(name, test.name))
+		}
+		if !cmp.Equal(ref, test.ref) {
+			t.Errorf("ParseContainerImage().Reference != Want \n %v", cmp.Diff(ref, test.ref))
+		}
+	}
+}
+
+func TestContainerInfo_FixDockerHubImage(t *testing.T) {
+	tests := []struct {
+		image, wantImage string
+		info, wantInfo   *ContainerInfo
+	}{
+		{
+			image:     "eu.gcr.io/project/application:latest",
+			wantImage: "eu.gcr.io/project/application:latest",
+			info:      &ContainerInfo{},
+			wantInfo:  &ContainerInfo{},
+		},
+		{
+			image:     "redis:latest",
+			wantImage: "index.docker.io/library/redis:latest",
+			info:      &ContainerInfo{},
+			wantInfo: &ContainerInfo{
+				RegistryAddress: "https://index.docker.io",
+				RegistryName:    "index.docker.io",
+			},
+		},
+		{
+			image:     "hashicorp/consul:latest",
+			wantImage: "index.docker.io/hashicorp/consul:latest",
+			info:      &ContainerInfo{},
+			wantInfo: &ContainerInfo{
+				RegistryAddress: "https://index.docker.io",
+				RegistryName:    "index.docker.io",
+			},
+		},
+	}
+	for _, test := range tests {
+		fixedImage := test.info.FixDockerHubImage(test.image)
+		if fixedImage != test.wantImage {
+			t.Errorf("FixDockerHubImage() != Want \n %v", cmp.Diff(fixedImage, test.wantImage))
+		}
+		if !cmp.Equal(test.info.RegistryAddress, test.wantInfo.RegistryAddress) {
+			t.Errorf("FixDockerHubImage().RegistryAddress != Want \n %v", cmp.Diff(test.info.RegistryAddress, test.wantInfo.RegistryAddress))
+		}
+		if !cmp.Equal(test.info.RegistryName, test.wantInfo.RegistryName) {
+			t.Errorf("FixDockerHubImage().RegistryName != Want \n %v", cmp.Diff(test.info.RegistryName, test.wantInfo.RegistryName))
+		}
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?

Now cache type are configurable, cache options contains option to disable caching tagged Docker-images, some tests for it.

### Why?

- In some cases no need to cache information about Docker-image (currently storages works without TTL)
- In some cases images with same tag contains different entrypoints

### Checklist

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
