### PR TITLE
add the ability to apply additional labels to the vault statefulset 

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.8.3
+version: 0.8.4
 appVersion: 1.2.3
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/charts/vault/README.md
+++ b/charts/vault/README.md
@@ -137,7 +137,7 @@ The following tables lists the configurable parameters of the vault chart and th
 | `rbac.psp.enabled`      | Use pod security policy             | `false`                                             |
 | `nodeSelector`          | Node labels for pod assignment. https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector                                                           | `{}`        
 | `tolerations`           | List of node tolerations for the pods. https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/                                                           | `[]`        
-| `additionalLabels`      | Additonal labels to be applied to the Vault StatefulSet and Pods | `{}`
+| `labels`                | Additonal labels to be applied to the Vault StatefulSet and Pods | `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/vault/README.md
+++ b/charts/vault/README.md
@@ -136,7 +136,8 @@ The following tables lists the configurable parameters of the vault chart and th
 | `rbac.enabled`          | Use rbac                            | `true`                                              |
 | `rbac.psp.enabled`      | Use pod security policy             | `false`                                             |
 | `nodeSelector`          | Node labels for pod assignment. https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector                                                           | `{}`        
-| `tolerations`                                  | List of node tolerations for the pods. https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/                                                           | `[]`        
+| `tolerations`           | List of node tolerations for the pods. https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/                                                           | `[]`        
+| `additionalLabels`      | Additonal labels to be applied to the Vault StatefulSet and Pods | `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -7,6 +7,9 @@ metadata:
     app.kubernetes.io/name: {{ template "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.additionalLabels }}
+{{ toYaml .Values.additionalLabels | indent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   updateStrategy:
@@ -21,6 +24,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "vault.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.additionalLabels }}
+{{ toYaml .Values.additionalLabels | indent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{ toYaml .Values.podAnnotations | indent 8 }}

--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/name: {{ template "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if .Values.additionalLabels }}
-{{ toYaml .Values.additionalLabels | indent 4 }}
+    {{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
     {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
@@ -24,8 +24,8 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "vault.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- if .Values.additionalLabels }}
-{{ toYaml .Values.additionalLabels | indent 8 }}
+        {{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 8 }}
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -54,6 +54,10 @@ podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/path: "/metrics"
   prometheus.io/port: "9102"
+
+additionalLabels: 
+  #  team: banzai
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -55,7 +55,7 @@ podAnnotations:
   prometheus.io/path: "/metrics"
   prometheus.io/port: "9102"
 
-labels: 
+labels: {}
   #  team: banzai
 
 resources: {}

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -55,7 +55,7 @@ podAnnotations:
   prometheus.io/path: "/metrics"
   prometheus.io/port: "9102"
 
-additionalLabels: 
+labels: 
   #  team: banzai
 
 resources: {}


### PR DESCRIPTION
add the ability to apply additional labels to the vault statefulset  and pods addresses #729

Signed-off-by: Murphy, Kealan <kealan.murphy@aspect.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #729 
| License         | Apache 2.0


### What's in this PR?
This PR gives users the ability to define and apply additional labels to the Vault Statefulset and Pods, this has many use cases. The one use case in particular that would be of use is when using running Vault in Azure and you want to use the aad-pod-identity plugin to allow the vault pod to assume a Managed Identity.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
