### PR TITLE
[webhook] Disable image caching for Policy=PullAlways and ref=latest

### DIFF
--- a/cmd/vault-secrets-webhook/registry/registry_test.go
+++ b/cmd/vault-secrets-webhook/registry/registry_test.go
@@ -1,0 +1,64 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestIsAllowedToCache(t *testing.T) {
+	tests := []struct {
+		container    *corev1.Container
+		allowToCache bool
+	}{
+		{
+			container: &corev1.Container{
+				Name:  "app",
+				Image: "foo:bar",
+			},
+			allowToCache: true,
+		},
+		{
+			container: &corev1.Container{
+				Name:  "app",
+				Image: "foo",
+			},
+			allowToCache: false,
+		},
+		{
+			container: &corev1.Container{
+				Name:  "app",
+				Image: "foo:latest",
+			},
+			allowToCache: false,
+		},
+		{
+			container: &corev1.Container{
+				Name:            "app",
+				Image:           "foo:bar",
+				ImagePullPolicy: corev1.PullAlways,
+			},
+			allowToCache: false,
+		},
+	}
+	for _, test := range tests {
+		allowToCache := IsAllowedToCache(test.container)
+		if test.allowToCache != allowToCache {
+			t.Errorf("IsAllowedToCache() != %v", test.allowToCache)
+		}
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Disabling cache for Docker images that tagged as `latest` and for images from containers with ImagePullPolicy `PullAlways`.

### Why?

With "latest" tag user says, that image can be changed and must be pulled every time; with "Pull Always" option user says, that image has static tag, but might be changed in any time.

### To Do

First step to done with #726.