### PR TITLE
Add ability to configure azure auth

### DIFF
--- a/docs/cli-tool/README.md
+++ b/docs/cli-tool/README.md
@@ -206,7 +206,24 @@ auth:
       token_ttl: 20m
       token_max_ttl: 30m
       secret_id_num_uses: 40
-
+  # The azure auth method allows authentication against Vault using Azure Active Directory credentials. 
+  # See https://www.vaultproject.io/docs/auth/azure.html for more information.
+  - type: azure
+    config:
+      tenant_id: 00000000-0000-0000-0000-000000000000
+      resource: https://vault-dev.example.com
+      client_id: 00000000-0000-0000-0000-000000000000
+      client_secret: 00000000-0000-0000-0000-000000000000
+    roles:
+    # Add roles for azure identities
+    # See https://www.vaultproject.io/api/auth/azure/index.html#create-role
+      - name: dev-mi
+        policies: allow_secrets
+        bound_subscription_ids: 
+          - "00000000-0000-0000-0000-000000000000"
+        bound_service_principal_ids: 
+          - "00000000-0000-0000-0000-000000000000"
+          
 # Add environment variables. Please reference below `my-mysql` part for usage.
 # This is a list of K8S env. You can reference K8S document for detail
 # https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/

--- a/pkg/sdk/vault/operator_client.go
+++ b/pkg/sdk/vault/operator_client.go
@@ -749,6 +749,23 @@ func (v *vault) configureAuthMethods(config *viper.Viper) error {
 					}
 				}
 			}
+		case "azure":
+			config, err := cast.ToStringMapE(authMethod["config"])
+			if err != nil {
+				return fmt.Errorf("error finding config block for azure: %s", err.Error())
+			}
+			err = v.configureGenericAuthConfig(authMethodType, path, config)
+			if err != nil {
+				return fmt.Errorf("error configuring azure auth for vault: %s", err.Error())
+			}
+			roles, err := cast.ToSliceE(authMethod["roles"])
+			if err != nil {
+				return fmt.Errorf("error finding roles block for azure: %s", err.Error())
+			}
+			err = v.configureGenericAuthRoles(authMethodType, path, "role", roles)
+			if err != nil {
+				return fmt.Errorf("error configuring azure auth roles for vault: %s", err.Error())
+			}
 		}
 	}
 

--- a/vault-config.yml
+++ b/vault-config.yml
@@ -154,6 +154,24 @@ auth:
           -----END CERTIFICATE-----
         ttl: "3600"
 
+  # The azure auth method allows authentication against Vault using Azure Active Directory credentials. 
+  # See https://www.vaultproject.io/docs/auth/azure.html for more information.
+  - type: azure
+    config:
+      tenant_id: 00000000-0000-0000-0000-000000000000
+      resource: https://vault-dev.example.com
+      client_id: 00000000-0000-0000-0000-000000000000
+      client_secret: 00000000-0000-0000-0000-000000000000
+    roles:
+    # Add roles for azure identities
+    # See https://www.vaultproject.io/api/auth/azure/index.html#create-role
+      - name: dev-mi
+        policies: allow_secrets
+        bound_subscription_ids: 
+          - "00000000-0000-0000-0000-000000000000"
+        bound_service_principal_ids: 
+          - "00000000-0000-0000-0000-000000000000"
+
 # Allows configuring Secrets Engines in Vault (KV, Database and SSH is tested,
 # but the config is free form so probably more is supported).
 # See https://www.vaultproject.io/docs/secrets/index.html for more information.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #686 
| License         | Apache 2.0


### What's in this PR?
This PR addresses the lack of ability to configure the Azure Auth mechanism with bank-vaults. The change was a straight forward addition of a case for azure in operator_client.go using the generic Auth and Roles config methods. 


### Additional context
Please be warned I am a first time gopher! To test I ran the the operator locally (thank you @bonifaido for the help) and deployed to a local k8s cluster to ensure both the config and the roles for Azure could be parsed and written to Vault. 

### Checklist
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
