### PR TITLE
Added labels support to vault-operator and vault-secrets-webhook charts (same as like it is already done for vault)

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.6.0
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.5.0
+version: 0.5.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/charts/vault-operator/templates/deployment.yaml
+++ b/charts/vault-operator/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     app.kubernetes.io/name: {{ include "vault-operator.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+    {{- end }}
 spec:
   strategy:
     type: Recreate

--- a/charts/vault-operator/values.yaml
+++ b/charts/vault-operator/values.yaml
@@ -35,6 +35,9 @@ syncPeriod: "1m"
 #     operator: Equal
 #     value: custom_worker
 
+labels: {}
+  #  team: banzai
+
 resources:
   limits:
     cpu: 100m

--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.6.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.6.0
+version: 0.6.1
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: mutating-webhook
+    {{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -55,6 +55,9 @@ volumeMounts: []
 
 podAnnotations: {}
 
+labels: {}
+  #  team: banzai
+
 resources: {}
 
 nodeSelector: {}


### PR DESCRIPTION
As our internal OPA rejected **vault-operator** and **vault-secrets-webhook** charts deployment because of:

> admission webhook "webhook.openpolicyagent.org" denied the request: please set the costCenter label into the Deployment resource

I would like to add the following labels support:
https://github.com/banzaicloud/bank-vaults/blob/master/charts/vault/templates/statefulset.yaml#L10-L12
to the two other charts too.

I have already tested the change, new labels are visible as expected:

vault-secrets-webhook
```
(⎈ |minikube:default)MacBook-Pro-Piotr:charts piotrszwed$ kubectl describe deploymen estranged-antelope-vault-secrets-webhook
Name:                   estranged-antelope-vault-secrets-webhook
Namespace:              default
CreationTimestamp:      Thu, 14 Nov 2019 12:10:58 +0100
Labels:                 app.kubernetes.io/component=mutating-webhook
                        app.kubernetes.io/instance=estranged-antelope
                        app.kubernetes.io/managed-by=Tiller
                        app.kubernetes.io/name=vault-secrets-webhook
                        helm.sh/chart=vault-secrets-webhook-0.6.1
                        team=banzai
```

vault-operator
```
(⎈ |minikube:default)MacBook-Pro-Piotr:charts piotrszwed$ kubectl describe deployment calico-anteater-vault-operator
Name:               calico-anteater-vault-operator
Namespace:          default
CreationTimestamp:  Thu, 14 Nov 2019 12:09:00 +0100
Labels:             app.kubernetes.io/instance=calico-anteater
                    app.kubernetes.io/managed-by=Tiller
                    app.kubernetes.io/name=vault-operator
                    helm.sh/chart=vault-operator-0.5.1
                    team=banzai
```