### PR TITLE
[webhook] Configurable transit path

### DIFF
--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -56,6 +56,7 @@ var (
 		"VAULT_ROLE":                   true,
 		"VAULT_PATH":                   true,
 		"VAULT_TRANSIT_KEY_ID":         true,
+		"VAULT_TRANSIT_PATH":           true,
 		"VAULT_IGNORE_MISSING_SECRETS": true,
 		"VAULT_ENV_PASSTHROUGH":        true,
 		"VAULT_JSON_LOG":               true,
@@ -144,6 +145,7 @@ func main() {
 	}
 
 	transitKeyID := os.Getenv("VAULT_TRANSIT_KEY_ID")
+	transitPath := os.Getenv("VAULT_TRANSIT_PATH")
 	transitCache := map[string][]byte{}
 
 	secretCache := map[string]*vaultapi.Secret{}
@@ -188,7 +190,7 @@ func main() {
 				sanitized.append(name, string(v))
 				continue
 			}
-			out, err := client.Transit.Decrypt(transitKeyID, []byte(value))
+			out, err := client.Transit.Decrypt(transitPath, transitKeyID, []byte(value))
 			if err != nil {
 				if !ignoreMissingSecrets {
 					logger.Fatalln("failed to decrypt variable:", name, err)

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -464,6 +464,10 @@ func parseVaultConfig(obj metav1.Object) internal.VaultConfig {
 		vaultConfig.TransitKeyID = val
 	}
 
+	if val, ok := annotations["vault.security.banzaicloud.io/transit-path"]; ok {
+		vaultConfig.TransitPath = val
+	}
+
 	return vaultConfig
 }
 
@@ -689,6 +693,15 @@ func (mw *mutatingWebhook) mutateContainers(containers []corev1.Container, podSp
 				{
 					Name:  "VAULT_TRANSIT_KEY_ID",
 					Value: vaultConfig.TransitKeyID,
+				},
+			}...)
+		}
+
+		if len(vaultConfig.TransitPath) > 0 {
+			container.Env = append(container.Env, []corev1.EnvVar{
+				{
+					Name:  "VAULT_TRANSIT_PATH",
+					Value: vaultConfig.TransitPath,
 				},
 			}...)
 		}

--- a/internal/configuration/vaultConfig.go
+++ b/internal/configuration/vaultConfig.go
@@ -28,6 +28,7 @@ type VaultConfig struct {
 	TLSSecret                   string
 	UseAgent                    bool
 	TransitKeyID                string
+	TransitPath                 string
 	CtConfigMap                 string
 	CtImage                     string
 	CtOnce                      bool

--- a/pkg/sdk/vault/transit.go
+++ b/pkg/sdk/vault/transit.go
@@ -41,9 +41,14 @@ func (t *Transit) IsEncrypted(value string) bool {
 
 // Decrypt decrypts the ciphertext into a plaintext
 // ref: https://www.vaultproject.io/api/secret/transit/index.html#decrypt-data
-func (t *Transit) Decrypt(keyID string, ciphertext []byte) ([]byte, error) {
+func (t *Transit) Decrypt(transitPath, keyID string, ciphertext []byte) ([]byte, error) {
+	if len(transitPath) == 0 {
+		// Rewrite to default if not defined, all examples from documentation
+		// uses `transit` path
+		transitPath = "transit"
+	}
 	out, err := t.client.Logical().Write(
-		path.Join("transit/decrypt", keyID),
+		path.Join(transitPath, "decrypt", keyID),
 		map[string]interface{}{
 			"ciphertext": string(ciphertext),
 		},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Makes transit path configurable by POD's annotation.

### Why?

Separating access to transit keys by prefix not so flexible as we want. To access to single transit key (encrypt and decrypt) from UI we needs give access to list all keys from transit secret engine.

We want to give full access to all secret engines created for teams.
