### PR TITLE
Fixed replicaset and deployment RBAC issues for Kubernetes < 1.6

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.6.1
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.5.2
+version: 0.5.3
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.6.0
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.5.1
+version: 0.5.2
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/charts/vault-operator/requirements.yaml
+++ b/charts/vault-operator/requirements.yaml
@@ -1,0 +1,6 @@
+dependencies:
+
+- name: etcd-operator
+  version: 0.8.0
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: etcd-operator.enabled

--- a/charts/vault-operator/requirements.yaml
+++ b/charts/vault-operator/requirements.yaml
@@ -1,6 +1,0 @@
-dependencies:
-
-- name: etcd-operator
-  version: 0.8.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  condition: etcd-operator.enabled

--- a/charts/vault-operator/templates/role.yaml
+++ b/charts/vault-operator/templates/role.yaml
@@ -30,12 +30,14 @@ rules:
   - watch
 - apiGroups:
   - apps
+  - extensions
   resources:
   - replicasets
   verbs:
   - get
 - apiGroups:
   - apps
+  - extensions
   resources:
   - deployments
   - deployments/finalizers


### PR DESCRIPTION
**replicaset** and **deployment** objects in earlier Kubernetes versions were put under _extensions/_ api group not _/apps_, this causes the following errors:

```
"error":"failed to initialize service object for metrics: deployments.extensions \"vault-operator\" is forbidden
"error":"failed to initialize service object for metrics: replicasets.extensions \"vault-operator-588dcd9cb6\" is forbidden:
```

Official documentation:
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16

I think it is better to support both as it is a blocker in many older environments.

TEST:

```
(⎈ |minikube:default)MacBook-Pro-Piotr:charts piotrszwed$ kubectl get clusterrole solemn-crocodile-vault-operator -o yaml | grep -C 3 extensions |head -n 17
  - watch
- apiGroups:
  - apps
  - extensions
  resources:
  - replicasets
  verbs:
--
--
  - get
- apiGroups:
  - apps
  - extensions
  resources:
  - deployments
  - deployments/finalizers
```

Deployoment log (K8s version: **v1.10.11**):

```
{"level":"info","ts":1574083565.3331227,"logger":"cmd","msg":"Go Version: go1.13.4"}
{"level":"info","ts":1574083565.3331542,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1574083565.333161,"logger":"cmd","msg":"operator-sdk Version: v0.9.0"}
{"level":"info","ts":1574083565.3331723,"logger":"cmd","msg":"Watched namespace: "}
{"level":"info","ts":1574083565.333361,"logger":"leader","msg":"Trying to become the leader."}
{"level":"info","ts":1574083565.3334296,"logger":"cmd","msg":"Liveness probe listening on: 8080"}
{"level":"info","ts":1574083565.6366625,"logger":"leader","msg":"Found existing lock","LockOwner":"vault-operator-588dcd9cb6-p96ct"}
{"level":"info","ts":1574083565.7318213,"logger":"leader","msg":"Not the leader. Waiting."}
{"level":"info","ts":1574083566.8630428,"logger":"leader","msg":"Not the leader. Waiting."}
{"level":"info","ts":1574083569.2516124,"logger":"leader","msg":"Not the leader. Waiting."}
{"level":"info","ts":1574083573.795136,"logger":"leader","msg":"Not the leader. Waiting."}
{"level":"info","ts":1574083582.5146194,"logger":"leader","msg":"Not the leader. Waiting."}
{"level":"info","ts":1574083599.8892796,"logger":"leader","msg":"Not the leader. Waiting."}
{"level":"info","ts":1574083618.1314929,"logger":"leader","msg":"Became the leader."}
{"level":"info","ts":1574083618.2411208,"logger":"cmd","msg":"Registering Components."}
{"level":"info","ts":1574083618.450069,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"vault-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1574083618.6927426,"logger":"metrics","msg":"Metrics Service object created","Service.Name":"vault-operator-metrics","Service.Namespace":"vault-stage"}
{"level":"info","ts":1574083618.6927688,"logger":"cmd","msg":"Starting the Cmd."}
{"level":"info","ts":1574083618.831376,"logger":"kubebuilder.controller","msg":"Starting Controller","controller":"vault-controller"}
{"level":"info","ts":1574083618.931717,"logger":"kubebuilder.controller","msg":"Starting workers","controller":"vault-controller","worker count":1}
```