### PR TITLE
add objecSelector in case of k8s version is above 1.15

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.6.1
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.6.2
+version: 0.6.3
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -16,6 +16,8 @@
 {{- $tlsKey = required "Required when certificate.generate is false" .Values.certificate.server.tls.key }}
 {{- $caCrt = required "Required when certificate.generate is false" .Values.certificate.ca.crt }}
 {{- end }}
+{{- $major := .Capabilities.KubeVersion.Major -}}
+{{- $minor := .Capabilities.KubeVersion.Minor -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -62,6 +64,17 @@ webhooks:
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
+{{- if and (eq (int $major) 1) (ge (int $minor) 15) }}
+  objectSelector:
+    matchExpressions:
+    {{- if .Values.objectSelector.matchExpressions }}
+{{ toYaml .Values.objectSelector.matchExpressions | indent 4 }}
+    {{- end }}
+    - key: security.banzaicloud.io/mutate
+      operator: NotIn
+      values:
+      - skip
+{{- end }}
 - name: secrets.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
   clientConfig:
     service:

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "vault-secrets-webhook.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        security.banzaicloud.io/mutate: skip
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/apiservice-webhook.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -92,6 +92,14 @@ namespaceSelector:
   # matchLabels:
   #   vault-injection: enabled
 
+# In case of the K8s cluster version is above 1.15 objectSelector is usable
+objectSelector: {}
+  # matchExpressions:
+  # - key: security.banzaicloud.io/mutate
+  #   operator: NotIn
+  #   values:
+  #   - skip
+
 podDisruptionBudget:
   enabled: true
   minAvailable: 1


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | partially #742 
| License         | Apache 2.0


### What's in this PR?
This PR adds objectSelector in case of K8s version is above 1.15

### Why?
With this feature, we can skip mutating specified labeled pods.
