### PR TITLE
operator: various fixes around transit unseal envs and mounts

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.6.1
+appVersion: 0.6.2
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.5.4
+version: 0.5.5
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/charts/vault-operator/values.yaml
+++ b/charts/vault-operator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: banzaicloud/vault-operator
-  tag: 0.6.1
+  tag: 0.6.2
   pullPolicy: IfNotPresent
 
 service:

--- a/operator/deploy/cr-transit-unseal.yaml
+++ b/operator/deploy/cr-transit-unseal.yaml
@@ -81,8 +81,8 @@ spec:
           # Allow every the tenant Vault Pod in the tenant namespace to use
           # its transit engine
           - name: tenant
-            bound_service_account_names: ["default", "vault-secrets-webhook"]
-            bound_service_account_namespaces: ["tenant","vswh"]
+            bound_service_account_names: ["vault", "vault-secrets-webhook"]
+            bound_service_account_namespaces: ["tenant", "vswh"]
             policies: allow_tenant_transit
             ttl: 1m
 
@@ -121,6 +121,45 @@ spec:
 ---
 
 # This Vault CR describes the setup of the Tenant Vault instance
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vault
+  namespace: tenant
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vault-secrets
+  namespace: tenant
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - "*"
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vault-secrets
+  namespace: tenant
+roleRef:
+  kind: Role
+  name: vault-secrets
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: vault
+
+---
+
 apiVersion: "vault.banzaicloud.com/v1alpha1"
 kind: "Vault"
 metadata:
@@ -131,13 +170,17 @@ spec:
   image: vault:1.2.3
   bankVaultsImage: banzaicloud/bank-vaults:latest
 
-  # We don't need any extra RBAC rules besides the default ones
-  serviceAccount: default
+  # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults
+  # configurer/unsealer will be running
+  serviceAccount: vault
 
   # Even if unsealing will be done via the Transit Auto-Unseal flow the root token
   # and recovery keys will be stored in Kubernetes Secrets if not defined otherwise,
   # not highly secure, but this is just an example, in production please use one of
   # the KMS based options.
+  # unsealConfig:
+  # ...
+
 
   # This is how the Bank-Vaults configurer should configure Vault to enable the
   # transit auto-unseal flow for the this instance, the seal stanza is the interesting


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fixing the transit unseal operator example.


### Why?
The transit unseal example got broken because of another change a few weeks ago and was reported by a community member @funkypenguin already on Slack. Also, the RBAC part was broken entirely (I have tested it on Docker for Mac - which has no RBAC, was a bad idea).


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
