### PR TITLE
operator: PVC diff fix

### DIFF
--- a/operator/deploy/cr-raft.yaml
+++ b/operator/deploy/cr-raft.yaml
@@ -77,6 +77,7 @@ spec:
         # storageClassName: ""
         accessModes:
           - ReadWriteOnce
+        volumeMode: Filesystem
         resources:
           requests:
             storage: 1Gi

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -460,6 +460,16 @@ func (spec *VaultSpec) GetStatsDImage() string {
 	return spec.StatsDImage
 }
 
+// GetVolumeClaimTemplates fixes the "status diff" in PVC templates
+func (spec *VaultSpec) GetVolumeClaimTemplates() []v1.PersistentVolumeClaim {
+	var pvcs []v1.PersistentVolumeClaim
+	for _, pvc := range spec.VolumeClaimTemplates {
+		pvc.Status.Phase = v1.ClaimPending
+		pvcs = append(pvcs, pvc)
+	}
+	return pvcs
+}
+
 // GetWatchedSecretsLabels returns the set of labels for secrets to watch in the vault namespace
 func (spec *VaultSpec) GetWatchedSecretsLabels() []map[string]string {
 	if spec.WatchedSecretsLabels == nil {

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1312,7 +1312,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 				},
 				Spec: podSpec,
 			},
-			VolumeClaimTemplates: v.Spec.VolumeClaimTemplates,
+			VolumeClaimTemplates: v.Spec.GetVolumeClaimTemplates(),
 		},
 	}, nil
 }

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -169,11 +169,11 @@ func createOrUpdateObjectWithClient(c client.Client, o runtime.Object) error {
 		}
 
 		if !result.IsEmpty() {
-			log.V(1).Info("resource diffs",
+			log.V(1).Info(fmt.Sprintf("Resource update for object %s:%s", o.GetObjectKind(), o.(metav1.ObjectMetaAccessor).GetObjectMeta().GetName()),
 				"patch", string(result.Patch),
-				"original", string(result.Original),
-				"modified", string(result.Modified),
-				"current", string(result.Current),
+				// "original", string(result.Original),
+				// "modified", string(result.Modified),
+				// "current", string(result.Current),
 			)
 
 			err := patch.DefaultAnnotator.SetLastAppliedAnnotation(o)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Remove always changing statefulset PVC via volumeClaimTemplates baceuse the `status.phase` is part of the diff always.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
It looks pretty ugly in the logs and causes unnecessary updates.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


