### PR TITLE
Add alias to vault-configfile-path and update docs

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -399,6 +399,8 @@ func parseVaultConfig(obj metav1.Object) internal.VaultConfig {
 	}
 	if val, ok := annotations["vault.security.banzaicloud.io/vault-configfile-path"]; ok {
 		vaultConfig.ConfigfilePath = val
+	} else if val, ok := annotations["vault.security.banzaicloud.io/vault-ct-secrets-mount-path"]; ok {
+		vaultConfig.ConfigfilePath = val
 	} else {
 		vaultConfig.ConfigfilePath = "/vault/secrets"
 	}

--- a/docs/mutating-webhook/consul-template.md
+++ b/docs/mutating-webhook/consul-template.md
@@ -99,7 +99,8 @@ vault.security.banzaicloud.io/vault-ct-share-process-namespace|Same as VAULT_CT_
 vault.security.banzaicloud.io/vault-ct-cpu|"100m"|Specify the consul-template container CPU resource limit|
 vault.security.banzaicloud.io/vault-ct-memory|"128Mi"|Specify the consul-template container memory resource limit|
 vault.security.banzaicloud.io/vault-ignore-missing-secrets|"false"|When enabled will only log warnings when Vault secrets are missing|
-vault.security.banzaicloud.io/vault-env-passthrough|""|Comma seprated list of `VAULT_*` related environment variables to pass through to main process. E.g.`VAULT_ADDR,VAULT_ROLE`.
+vault.security.banzaicloud.io/vault-env-passthrough|""|Comma seprated list of `VAULT_*` related environment variables to pass through to main process. E.g.`VAULT_ADDR,VAULT_ROLE`.|
+vault.security.banzaicloud.io/vault-ct-secrets-mount-path|"/vault/secret"|Mount path of Consul template rendered files|
 
 ### How to enable consul template in the webhook?
 For the webhook to detect that it will need to mutate or change a PodSpec, it must have the annotation `vault.security.banzaicloud.io/vault-ct-configmap` otherwise the PodSpec will be ignored for configuration with Consul Template.


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no


### What's in this PR?
Add a new annotation that defines the mount path of Consul template rendered files.

### Why?
This annotation naming is more exact.

- [x] User guide and development docs updated (if needed)

