### PR TITLE
webhook: fix for kubectl DockerHub address format

### DIFF
--- a/cmd/vault-secrets-webhook/registry/registry.go
+++ b/cmd/vault-secrets-webhook/registry/registry.go
@@ -198,6 +198,14 @@ func (k *ContainerInfo) parseDockerConfig(dockerCreds DockerCreds) (bool, error)
 			registryName = strings.TrimPrefix(registryName, "https://")
 		}
 
+		// kubectl create secret docker-registry for DockerHub creates
+		// registry credentials with API version suffixes, trim it!
+		if strings.HasSuffix(registryName, "/v1/") {
+			registryName = strings.TrimSuffix(registryName, "/v1/")
+		} else if strings.HasSuffix(registryName, "/v2/") {
+			registryName = strings.TrimSuffix(registryName, "/v2/")
+		}
+
 		registryName = strings.TrimSuffix(registryName, "/")
 
 		if strings.HasPrefix(k.Image, registryName) {


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/banzaicloud/bank-vaults/issues/764, fixes https://github.com/banzaicloud/bank-vaults/issues/761
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
kubectl appends a specific (and archaic) `/v1/` to the registry address for DockerHub when creating a `docker-registry` type Secret. We detected the matching imagePullSecret for images because of this.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


