### PR TITLE
adding new parameters to control the sideEffect

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.6.3
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
-version: 0.6.4
+version: 0.6.5
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -140,3 +140,6 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | certificate.ca.crt               | Base64 encoded CA certificate                                                | ``                                  |
 | certificate.server.tls.crt       | Base64 encoded TLS certificate signed by the CA                              | ``                                  |
 | certificate.server.tls.key       | Base64 encoded  private key of TLS certificate signed by the CA              | ``                                  |
+| apiSideEffect                    | Enable or disable the Webhook sideEffect, sideEffect is not compatible with Kubernetes version < 1.12 | `true`     |
+| apiSideEffectValue               | Webhook sideEffect value                                                     | `NoneOnDryRun`                      |
+

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -140,6 +140,5 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | certificate.ca.crt               | Base64 encoded CA certificate                                                | ``                                  |
 | certificate.server.tls.crt       | Base64 encoded TLS certificate signed by the CA                              | ``                                  |
 | certificate.server.tls.key       | Base64 encoded  private key of TLS certificate signed by the CA              | ``                                  |
-| apiSideEffect                    | Enable or disable the Webhook sideEffect, sideEffect is not compatible with Kubernetes version < 1.12 | `true`     |
 | apiSideEffectValue               | Webhook sideEffect value                                                     | `NoneOnDryRun`                      |
 

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -139,6 +139,6 @@ webhooks:
       values:
       - {{ .Release.Namespace }}
 {{- end }}
-{{- if and (eq (int $major) 1) (ge (int $minor) 12) }}
+{{- if and (ge (int $major) 1) (ge (int $minor) 12) }}
   sideEffects: {{ .Values.apiSideEffectValue }}
 {{- end }}

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -139,6 +139,6 @@ webhooks:
       values:
       - {{ .Release.Namespace }}
 {{- end }}
-{{- if .Values.apiSideEffect }}
+{{- if and (eq (int $major) 1) (ge (int $minor) 12) }}
   sideEffects: {{ .Values.apiSideEffectValue }}
 {{- end }}

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -139,4 +139,6 @@ webhooks:
       values:
       - {{ .Release.Namespace }}
 {{- end }}
-  sideEffects: NoneOnDryRun
+{{- if .Values.apiSideEffect }}
+  sideEffects: {{ .Values.apiSideEffectValue }}
+{{- end }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -84,7 +84,7 @@ podsFailurePolicy: Ignore
 secretsFailurePolicy: Ignore
 
 # sideEffect is not compatible with Kubernetes < 1.12.x, set false in this case
-apiSideEffect: false
+apiSideEffect: true
 apiSideEffectValue: NoneOnDryRun
 
 namespaceSelector:

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -83,6 +83,10 @@ podsFailurePolicy: Ignore
 
 secretsFailurePolicy: Ignore
 
+# sideEffect is not compatible with Kubernetes < 1.12.x, set false in this case
+apiSideEffect: false
+apiSideEffectValue: NoneOnDryRun
+
 namespaceSelector:
   matchExpressions:
   - key: name

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -83,8 +83,6 @@ podsFailurePolicy: Ignore
 
 secretsFailurePolicy: Ignore
 
-# sideEffect is not compatible with Kubernetes < 1.12.x, set false in this case
-apiSideEffect: true
 apiSideEffectValue: NoneOnDryRun
 
 namespaceSelector:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
I'm using an old version of Kubernetes (1.10.11)  here in the company I'm working (shame on me) , and we're trying to update the vault-secrets-webhook and we got this issue:

```
Comparing vault-secrets-webhook banzaicloud-stable/vault-secrets-webhook
error validating "": error validating data: ValidationError(MutatingWebhookConfiguration.webhooks[1]): unknown field "sideEffects" in io.k8s.api.admissionregistration.v1beta1.Webhook
```
The reason behind this error is explained here:  https://github.com/linkerd/linkerd2/issues/2850


### Why?
This PR allows the user to choose between to active or not the sideEffects in the MutatingWebhookConfiguration.


### Additional context

### Checklist

- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do