### PR TITLE
Restore Operator leader election

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.7.0
+appVersion: 0.7.1
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
-version: 0.6.0
+version: 0.6.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/charts/vault-operator/README.md
+++ b/charts/vault-operator/README.md
@@ -47,7 +47,7 @@ The following tables lists the configurable parameters of the vault chart and th
 |-----------------------------|-------------------------------------|-----------------------------------------------------|
 | `image.pullPolicy`          | Container pull policy               | `IfNotPresent`                                      |
 | `image.repository`          | Container image to use              | `banzaicloud/vault-operator`                        |
-| `image.tag`                 | Container image tag to deploy       | `0.7.0`                                             |
+| `image.tag`                 | Container image tag to deploy       | `0.7.1`                                             |
 | `replicaCount`              | k8s replicas                        | `1`                                                 |
 | `resources.requests.cpu`    | Container requested CPU             | `100m`                                              |
 | `resources.requests.memory` | Container requested memory          | `128Mi`                                             |

--- a/charts/vault-operator/templates/role.yaml
+++ b/charts/vault-operator/templates/role.yaml
@@ -14,6 +14,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
   - pods
   - services
   - configmaps

--- a/charts/vault-operator/values.yaml
+++ b/charts/vault-operator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: banzaicloud/vault-operator
-  tag: 0.7.0
+  tag: 0.7.1
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes and no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
The Operator leader election feature was removed during the removal of operator-sdk but it is now put back with the controller-runtime implementation.