### PR TITLE
docs: add comparision of Banzai Cloud and HashiCorp mutating webhook

### DIFF
--- a/docs/mutating-webhook/webhooks-comparision.md
+++ b/docs/mutating-webhook/webhooks-comparision.md
@@ -1,0 +1,16 @@
+# Comparision of Banzai Cloud and HashiCorp mutating webhook for Vault
+
+#### Legend:
+- √ - Implemented
+- O - Planned/In-progress
+
+| Feature    | Banzai Cloud Webhook | HashiCorp Webhook |
+|------------|----------------------|-------------------|
+| Automated Vault and K8S setup | √ (operator) |        |
+| vault-agent/consul-template sidecar injection| √ | √ |
+| Direct env var injection      | √ |   |
+| Injecting into K8S Secrets    | √ |   |
+| Injecting into K8S ConfigMaps | √ |   |
+| CSI Driver                    | O |   |
+| Native Kubernetes sidecar     | O |   |
+| Sidecar-less dynamic secrets  | O |   |


### PR DESCRIPTION
A lot of people were asking what is the difference and the relation between the two projects, we tried to collect the differences and compare the two projects with a small table.