### PR TITLE
Implement vault-agent templating support

### DIFF
--- a/cmd/vault-secrets-webhook/main_test.go
+++ b/cmd/vault-secrets-webhook/main_test.go
@@ -19,6 +19,7 @@ import (
 
 	cmp "github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes"
 	fake "k8s.io/client-go/kubernetes/fake"
 
@@ -298,6 +299,355 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 			}
 			if !cmp.Equal(tt.args.containers, tt.wantedContainers) {
 				t.Errorf("mutatingWebhook.mutateContainers() = diff %v", cmp.Diff(tt.args.containers, tt.wantedContainers))
+			}
+		})
+	}
+}
+
+func Test_mutatingWebhook_mutatePod(t *testing.T) {
+
+	type fields struct {
+		k8sClient kubernetes.Interface
+		registry  registry.ImageRegistry
+	}
+	type args struct {
+		pod         *corev1.Pod
+		vaultConfig internal.VaultConfig
+		ns          string
+	}
+	defaultMode := int32(420)
+	runAsUser := int64(100)
+	initContainerSecurityContext := &corev1.SecurityContext{
+		RunAsUser:                &runAsUser,
+		AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
+	}
+
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		wantErr   bool
+		wantedPod *corev1.Pod
+	}{
+		{name: "Will mutate pod with ct-configmap annotations",
+			fields: fields{
+				k8sClient: fake.NewSimpleClientset(),
+				registry: &MockRegistry{
+					Image: imagev1.ImageConfig{},
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							corev1.Container{
+								Name:    "MyContainer",
+								Image:   "myimage",
+								Command: []string{"/bin/bash"},
+								Args:    nil,
+							},
+						},
+					},
+				},
+				vaultConfig: internal.VaultConfig{
+					CtConfigMap:    "config-map-test",
+					ConfigfilePath: "/vault/secrets",
+					Addr:           "test",
+					SkipVerify:     "false",
+					CtCPU:          resource.MustParse("50m"),
+					CtMemory:       resource.MustParse("128Mi"),
+				},
+			},
+			wantedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						corev1.Container{
+							Name:            "vault-agent",
+							Image:           "vault:latest",
+							Command:         []string{"vault", "agent", "-config=/vault/agent/config.hcl"},
+							ImagePullPolicy: "IfNotPresent",
+							Env: []corev1.EnvVar{
+								corev1.EnvVar{
+									Name:  "VAULT_ADDR",
+									Value: "test",
+								},
+								corev1.EnvVar{
+									Name:  "VAULT_SKIP_VERIFY",
+									Value: "false",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							},
+							SecurityContext: initContainerSecurityContext,
+							VolumeMounts: []corev1.VolumeMount{
+								corev1.VolumeMount{
+									Name:      "vault-env",
+									MountPath: "/vault/",
+								},
+								corev1.VolumeMount{},
+								corev1.VolumeMount{
+									Name:      "vault-agent-config",
+									MountPath: "/vault/agent/",
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name: "consul-template",
+							Args: []string{"-config", "/vault/ct-config/config.hcl"},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+							},
+							Env: []corev1.EnvVar{
+								corev1.EnvVar{
+									Name:  "VAULT_ADDR",
+									Value: "test",
+								},
+								corev1.EnvVar{
+									Name:  "VAULT_SKIP_VERIFY",
+									Value: "false",
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								corev1.VolumeMount{
+									Name:      "vault-env",
+									MountPath: "/vault/",
+								},
+								corev1.VolumeMount{
+									Name:      "ct-secrets",
+									MountPath: "/vault/secrets",
+								},
+								corev1.VolumeMount{
+									Name:      "vault-env",
+									MountPath: "/home/consul-template",
+								},
+								corev1.VolumeMount{
+									Name:      "ct-configmap",
+									ReadOnly:  true,
+									MountPath: "/vault/ct-config/config.hcl",
+									SubPath:   "config.hcl",
+								},
+							},
+						},
+						corev1.Container{
+							Name:    "MyContainer",
+							Image:   "myimage",
+							Command: []string{"/bin/bash"},
+							Args:    nil,
+							VolumeMounts: []corev1.VolumeMount{
+								corev1.VolumeMount{
+									Name:      "ct-secrets",
+									MountPath: "/vault/secrets",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						corev1.Volume{
+							Name: "vault-env",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium: corev1.StorageMediumMemory,
+								},
+							},
+						},
+						corev1.Volume{
+							Name: "vault-agent-config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "-vault-agent-config",
+									},
+								},
+							},
+						},
+						corev1.Volume{
+							Name: "ct-secrets",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium: corev1.StorageMediumMemory,
+								},
+							},
+						},
+						corev1.Volume{
+							Name: "ct-configmap",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "config-map-test",
+									},
+									Items: []corev1.KeyToPath{
+										corev1.KeyToPath{
+											Key:  "config.hcl",
+											Path: "config.hcl",
+										},
+									},
+									DefaultMode: &defaultMode,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{name: "Will mutate pod with va-configmap annotations",
+			fields: fields{
+				k8sClient: fake.NewSimpleClientset(),
+				registry: &MockRegistry{
+					Image: imagev1.ImageConfig{},
+				},
+			},
+			args: args{
+				pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							corev1.Container{
+								Name:    "MyContainer",
+								Image:   "myimage",
+								Command: []string{"/bin/bash"},
+								Args:    nil,
+							},
+						},
+					},
+				},
+				vaultConfig: internal.VaultConfig{
+					VaConfigMap:    "config-map-test",
+					ConfigfilePath: "/vault/secrets",
+					Addr:           "test",
+					SkipVerify:     "false",
+					VaCPU:          resource.MustParse("50m"),
+					VaMemory:       resource.MustParse("128Mi"),
+				},
+			},
+			wantedPod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{},
+					Containers: []corev1.Container{
+						corev1.Container{
+							Name: "vault-agent",
+							Args: []string{"agent", "-config", "/vault/va-config/config.hcl"},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+							},
+							Env: []corev1.EnvVar{
+								corev1.EnvVar{
+									Name:  "VAULT_ADDR",
+									Value: "test",
+								},
+								corev1.EnvVar{
+									Name:  "VAULT_SKIP_VERIFY",
+									Value: "false",
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{
+										"IPC_LOCK",
+									},
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								corev1.VolumeMount{
+									Name:      "vault-env",
+									MountPath: "/vault/",
+								},
+								corev1.VolumeMount{}, // ServiceAccountMount
+								corev1.VolumeMount{
+									Name:      "va-secrets",
+									MountPath: "/vault/secrets",
+								},
+								corev1.VolumeMount{
+									Name:      "va-configmap",
+									ReadOnly:  true,
+									MountPath: "/vault/va-config/config.hcl",
+									SubPath:   "config.hcl",
+								},
+							},
+						},
+						corev1.Container{
+							Name:    "MyContainer",
+							Image:   "myimage",
+							Command: []string{"/bin/bash"},
+							Args:    nil,
+							VolumeMounts: []corev1.VolumeMount{
+								corev1.VolumeMount{
+									Name:      "va-secrets",
+									MountPath: "/vault/secrets",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						corev1.Volume{
+							Name: "vault-env",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium: corev1.StorageMediumMemory,
+								},
+							},
+						},
+						corev1.Volume{
+							Name: "va-secrets",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium: corev1.StorageMediumMemory,
+								},
+							},
+						},
+						corev1.Volume{
+							Name: "va-configmap",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "config-map-test",
+									},
+									Items: []corev1.KeyToPath{
+										corev1.KeyToPath{
+											Key:  "config.hcl",
+											Path: "config.hcl",
+										},
+									},
+									DefaultMode: &defaultMode,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mw := &mutatingWebhook{
+				k8sClient: tt.fields.k8sClient,
+				registry:  tt.fields.registry,
+			}
+			err := mw.mutatePod(tt.args.pod, tt.args.vaultConfig, tt.args.ns, false)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mutatingWebhook.mutatePod() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !cmp.Equal(tt.args.pod, tt.wantedPod) {
+				t.Errorf("mutatingWebhook.mutatePod() = diff %v", cmp.Diff(tt.args.pod, tt.wantedPod))
 			}
 		})
 	}

--- a/cmd/vault-secrets-webhook/main_test.go
+++ b/cmd/vault-secrets-webhook/main_test.go
@@ -345,6 +345,11 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 								Image:   "myimage",
 								Command: []string{"/bin/bash"},
 								Args:    nil,
+								VolumeMounts: []corev1.VolumeMount{
+									corev1.VolumeMount{
+										MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+									},
+								},
 							},
 						},
 					},
@@ -388,7 +393,9 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 									Name:      "vault-env",
 									MountPath: "/vault/",
 								},
-								corev1.VolumeMount{},
+								corev1.VolumeMount{
+									MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+								},
 								corev1.VolumeMount{
 									Name:      "vault-agent-config",
 									MountPath: "/vault/agent/",
@@ -446,6 +453,9 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 							Command: []string{"/bin/bash"},
 							Args:    nil,
 							VolumeMounts: []corev1.VolumeMount{
+								corev1.VolumeMount{
+									MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+								},
 								corev1.VolumeMount{
 									Name:      "ct-secrets",
 									MountPath: "/vault/secrets",
@@ -518,6 +528,11 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 								Image:   "myimage",
 								Command: []string{"/bin/bash"},
 								Args:    nil,
+								VolumeMounts: []corev1.VolumeMount{
+									corev1.VolumeMount{
+										MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+									},
+								},
 							},
 						},
 					},
@@ -567,7 +582,9 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 									Name:      "vault-env",
 									MountPath: "/vault/",
 								},
-								corev1.VolumeMount{}, // ServiceAccountMount
+								corev1.VolumeMount{
+									MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+								},
 								corev1.VolumeMount{
 									Name:      "va-secrets",
 									MountPath: "/vault/secrets",
@@ -586,6 +603,9 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 							Command: []string{"/bin/bash"},
 							Args:    nil,
 							VolumeMounts: []corev1.VolumeMount{
+								corev1.VolumeMount{
+									MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+								},
 								corev1.VolumeMount{
 									Name:      "va-secrets",
 									MountPath: "/vault/secrets",

--- a/deploy/test-deploy-va.yaml
+++ b/deploy/test-deploy-va.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vault-agent-pki
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vault-agent-pki
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vault-agent-pki
+      annotations:
+        vault.security.banzaicloud.io/vault-addr: "https://vault:8200"
+        vault.security.banzaicloud.io/vault-tls-secret: vault-tls
+        vault.security.banzaicloud.io/vault-va-configmap: vault-agent-pki
+    spec:
+      containers:
+      - name: alpine
+        image: alpine
+        command: ["sh", "-c", "apk add openssl; while true; do openssl x509 -text -noout -in /vault/secrets/my-server.crt; echo; sleep 5; done"]
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vault-agent-pki
+  labels:
+    app.kubernetes.io/name: vault-agent-pki
+data:
+  config.hcl: |
+    vault {
+      auto_auth {
+        method "kubernetes" {
+          mount_path = "auth/kubernetes"
+          config = {
+            role = "my-role"
+          }
+        }
+        sink "file" {
+          config = {
+            path = "/vault/.vault-token"
+          }
+        }
+      }
+      retry {
+        backoff = "1s"
+      }
+    }
+    template {
+      contents = <<EOH
+      {{- with secret "pki/issue/default" "common_name=localhost" -}}
+      {{ .Data.certificate }}{{- end -}}
+      EOH
+      destination = "/vault/secrets/my-server.crt"
+    }

--- a/deploy/test-deploy-va.yaml
+++ b/deploy/test-deploy-va.yaml
@@ -14,7 +14,7 @@ spec:
       annotations:
         vault.security.banzaicloud.io/vault-addr: "https://vault:8200"
         vault.security.banzaicloud.io/vault-tls-secret: vault-tls
-        vault.security.banzaicloud.io/vault-va-configmap: vault-agent-pki
+        vault.security.banzaicloud.io/vault-agent-configmap: vault-agent-pki
     spec:
       containers:
       - name: alpine

--- a/docs/mutating-webhook/vault-agent-templating.md
+++ b/docs/mutating-webhook/vault-agent-templating.md
@@ -89,5 +89,5 @@ vault.security.banzaicloud.io/vault-agent-memory|"128Mi"|Specify the vault-agent
 vault.security.banzaicloud.io/vault-configfile-path|"/vault/secrets"|Mount path of Vault Agent rendered files|
 
 ### How to enable vault agent in the webhook?
-For the webhook to detect that it will need to mutate or change a PodSpec, it must have the annotation `vault.security.banzaicloud.io/vault-va-configmap` otherwise the PodSpec will be ignored for configuration with Vault Agent.
+For the webhook to detect that it will need to mutate or change a PodSpec, it must have the annotation `vault.security.banzaicloud.io/vault-agent-configmap` otherwise the PodSpec will be ignored for configuration with Vault Agent.
 

--- a/docs/mutating-webhook/vault-agent-templating.md
+++ b/docs/mutating-webhook/vault-agent-templating.md
@@ -18,7 +18,7 @@ This document assumes you have a working Kuberentes cluster which has a:
 
 ## Pre Configuration
 ### ShareProcessNamespace
-As of Kubernetes 1.10 you can [share](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) the process list of all containers in a pod, please check your Kuberentes API server FeatureGates configuration to find if it is on or not, it is default on in 1.12. The webhook will disable it by default in any version less than 1.12 and enable it by default for version 1.12 and above. You can override this confirguration using the `vault.security.banzaicloud.io/vault-va-share-process-namespace` annotation or webhook `vault_va_share_process_namespace` environment variable.
+As of Kubernetes 1.10 you can [share](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) the process list of all containers in a pod, please check your Kuberentes API server FeatureGates configuration to find if it is on or not, it is default on in 1.12. The webhook will disable it by default in any version less than 1.12 and enable it by default for version 1.12 and above. You can override this confirguration using the `vault.security.banzaicloud.io/vault-agent-share-process-namespace` annotation or webhook `vault_agent_share_process_namespace` environment variable.
 
 If you wish to use Vault TTLs you need a way that you can HUP your application on configuration file change, Vault Agent can be [configured](https://www.vaultproject.io/docs/agent/template/index.html) with a `command` attribute which it will run when it writes a new configuration file. You can find a basic example below which uses/requires the ShareProcessNamespace feature and the Kubernetes Auth:
 
@@ -70,23 +70,22 @@ There are two places to configure the Webhook, you can set some sane defaults in
 ### Defaults via environment variables:
 |Variable      |default     |Explanation|
 |--------------|------------|------------|
-|VAULT_VA_IMAGE|vault:latest| the vault image to use for the sidecar container|
+|VAULT_IMAGE|vault:latest| the vault image to use for the sidecar container|
+|VAULT_IMAGE_PULL_POLICY|IfNotPresent| The pull policy for the vault agent container|
 |VAULT_ADDR    |https://127.0.0.1:8200|Kubernetes service Vault endpoint URL|
 |VAULT_TLS_SECRET|""|supply a secret with the vault TLS CA so TLS can be verified|
-|VAULT_VA_SHARE_PROCESS_NAMESPACE|Kubernetes version <1.12 default off, 1.12 or higher default on|ShareProcessNamespace override|as above|
+|VAULT_AGENT_SHARE_PROCESS_NAMESPACE|Kubernetes version <1.12 default off, 1.12 or higher default on|ShareProcessNamespace override|as above|
 
 ### PodSpec annotations:
 |Annotation    |default     |Explanation|
 |--------------|------------|------------|
 vault.security.banzaicloud.io/vault-addr|Same as VAULT_ADDR above||
 vault.security.banzaicloud.io/vault-tls-secret|Same as VAULT_TLS_SECRET above||
-vault.security.banzaicloud.io/vault-va-configmap|""|A configmap name which holds the vault agent configuration|
-vault.security.banzaicloud.io/vault-va-image|""|Specify a custom image for vault agent|
-vault.security.banzaicloud.io/vault-va-once|false|do not run vault-agent in daemon mode, useful for kubernetes jobs|
-vault.security.banzaicloud.io/vault-va-pull-policy|IfNotPresent|the Pull policy for the vault agent container|
-vault.security.banzaicloud.io/vault-va-share-process-namespace|Same as VAULT_VA_SHARE_PROCESS_NAMESPACE above|
-vault.security.banzaicloud.io/vault-va-cpu|"100m"|Specify the vault-agent container CPU resource limit|
-vault.security.banzaicloud.io/vault-va-memory|"128Mi"|Specify the vault-agent container memory resource limit|
+vault.security.banzaicloud.io/vault-agent-configmap|""|A configmap name which holds the vault agent configuration|
+vault.security.banzaicloud.io/vault-agent-once|false|do not run vault-agent in daemon mode, useful for kubernetes jobs|
+vault.security.banzaicloud.io/vault-agent-share-process-namespace|Same as VAULT_AGENT_SHARE_PROCESS_NAMESPACE above|
+vault.security.banzaicloud.io/vault-agent-cpu|"100m"|Specify the vault-agent container CPU resource limit|
+vault.security.banzaicloud.io/vault-agent-memory|"128Mi"|Specify the vault-agent container memory resource limit|
 vault.security.banzaicloud.io/vault-configfile-path|"/vault/secrets"|Mount path of Vault Agent rendered files|
 
 ### How to enable vault agent in the webhook?

--- a/docs/mutating-webhook/vault-agent-templating.md
+++ b/docs/mutating-webhook/vault-agent-templating.md
@@ -1,0 +1,94 @@
+# Using Vault Agent Templating in the mutating webhook
+
+This document assumes you have a working Kuberentes cluster which has a:
+* Working install of Vault.
+* Working install of the mutating webhook via helm or manually.
+* That you have a working knowledge of Kubernetes.
+* That you have the ability to apply Deployments or PodSpec's to the cluster.
+* That you have the ability to change the configuration of the mutating webhook.
+
+## When to use vault-agent
+* You have an application or tool that requires to read its configuration from a file.
+* You wish to have secrets that have a TTL and expire.
+* You do not wish to be limited on which vault secrets backend you use.
+
+## General concept
+* Your pod starts up, the webhook will inject one container into the pods lifecycle.
+* The sidecar container is running Vault, using the [vault agent](https://www.vaultproject.io/docs/agent/) that accesses Vault using the configuration specified inside a configmap and writes a configuration file based on a pre configured template (written inside the same configmap) onto a temperary file system which your application can use.
+
+## Pre Configuration
+### ShareProcessNamespace
+As of Kubernetes 1.10 you can [share](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) the process list of all containers in a pod, please check your Kuberentes API server FeatureGates configuration to find if it is on or not, it is default on in 1.12. The webhook will disable it by default in any version less than 1.12 and enable it by default for version 1.12 and above. You can override this confirguration using the `vault.security.banzaicloud.io/vault-va-share-process-namespace` annotation or webhook `vault_va_share_process_namespace` environment variable.
+
+If you wish to use Vault TTLs you need a way that you can HUP your application on configuration file change, Vault Agent can be [configured](https://www.vaultproject.io/docs/agent/template/index.html) with a `command` attribute which it will run when it writes a new configuration file. You can find a basic example below which uses/requires the ShareProcessNamespace feature and the Kubernetes Auth:
+
+```
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: my-app
+    my-app.kubernetes.io/name: my-app-vault-agent
+    branches: "true"
+  name: my-app-vault-agent
+data:
+  config.hcl: |
+    vault {
+      retry {
+        backoff = "1s"
+      }
+      auto_auth {
+        method "kubernetes" {
+          mount_path = "auth/kubernetes"
+          config = {
+            role = "my-role"
+          }
+        }
+        sink "file" {
+          config = {
+            path = "/vault/.vault-token"
+          }
+        }
+      }
+    }
+    template {
+      contents = <<EOH
+        {{- with secret "database/creds/readonly" }}
+        username: {{ .Data.username }}
+        password: {{ .Data.password }}
+        {{ end }}
+      EOH
+      destination = "/etc/secrets/config"
+      command     = "/bin/sh -c \"kill -HUP $(pidof vault-demo-app) || true\""
+    }
+```
+
+## Configuration
+There are two places to configure the Webhook, you can set some sane defaults in the environment of the mutating webhook or you can configure it via annotations in your PodSpec.
+
+### Defaults via environment variables:
+|Variable      |default     |Explanation|
+|--------------|------------|------------|
+|VAULT_VA_IMAGE|vault:latest| the vault image to use for the sidecar container|
+|VAULT_ADDR    |https://127.0.0.1:8200|Kubernetes service Vault endpoint URL|
+|VAULT_TLS_SECRET|""|supply a secret with the vault TLS CA so TLS can be verified|
+|VAULT_VA_SHARE_PROCESS_NAMESPACE|Kubernetes version <1.12 default off, 1.12 or higher default on|ShareProcessNamespace override|as above|
+
+### PodSpec annotations:
+|Annotation    |default     |Explanation|
+|--------------|------------|------------|
+vault.security.banzaicloud.io/vault-addr|Same as VAULT_ADDR above||
+vault.security.banzaicloud.io/vault-tls-secret|Same as VAULT_TLS_SECRET above||
+vault.security.banzaicloud.io/vault-va-configmap|""|A configmap name which holds the vault agent configuration|
+vault.security.banzaicloud.io/vault-va-image|""|Specify a custom image for vault agent|
+vault.security.banzaicloud.io/vault-va-once|false|do not run vault-agent in daemon mode, useful for kubernetes jobs|
+vault.security.banzaicloud.io/vault-va-pull-policy|IfNotPresent|the Pull policy for the vault agent container|
+vault.security.banzaicloud.io/vault-va-share-process-namespace|Same as VAULT_VA_SHARE_PROCESS_NAMESPACE above|
+vault.security.banzaicloud.io/vault-va-cpu|"100m"|Specify the vault-agent container CPU resource limit|
+vault.security.banzaicloud.io/vault-va-memory|"128Mi"|Specify the vault-agent container memory resource limit|
+vault.security.banzaicloud.io/vault-configfile-path|"/vault/secrets"|Mount path of Vault Agent rendered files|
+
+### How to enable vault agent in the webhook?
+For the webhook to detect that it will need to mutate or change a PodSpec, it must have the annotation `vault.security.banzaicloud.io/vault-va-configmap` otherwise the PodSpec will be ignored for configuration with Vault Agent.
+

--- a/internal/configuration/vaultConfig.go
+++ b/internal/configuration/vaultConfig.go
@@ -43,12 +43,12 @@ type VaultConfig struct {
 	ConfigfilePath              string
 	MutateConfigMap             bool
 	EnableJSONLog               string
-	VaConfigMap                 string
-	VaImage                     string
-	VaOnce                      bool
-	VaImagePullPolicy           corev1.PullPolicy
-	VaShareProcess              bool
-	VaShareProcessDefault       string
-	VaCPU                       resource.Quantity
-	VaMemory                    resource.Quantity
+	AgentConfigMap              string
+	AgentOnce                   bool
+	AgentShareProcess           bool
+	AgentShareProcessDefault    string
+	AgentCPU                    resource.Quantity
+	AgentMemory                 resource.Quantity
+	AgentImage                  string
+	AgentImagePullPolicy        corev1.PullPolicy
 }

--- a/internal/configuration/vaultConfig.go
+++ b/internal/configuration/vaultConfig.go
@@ -43,4 +43,12 @@ type VaultConfig struct {
 	ConfigfilePath              string
 	MutateConfigMap             bool
 	EnableJSONLog               string
+	VaConfigMap                 string
+	VaImage                     string
+	VaOnce                      bool
+	VaImagePullPolicy           corev1.PullPolicy
+	VaShareProcess              bool
+	VaShareProcessDefault       string
+	VaCPU                       resource.Quantity
+	VaMemory                    resource.Quantity
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #804, fixes #464, fixes #302
| License         | Apache 2.0


### What's in this PR?
This PR is a WIP/POC to support vault-agent templating capabilities.

I have some open point I'd like to discuss, and something that still needs to be done to make this review-ready.


### Why?
Starting with Vault 1.3.0 Templating capabilities have been ported from consul-template to vault-agent. Therefore, we can replace consul-template sidecar with vault-agent.
There are several advantages to this:
- the init container (and its configmap) is no longer required, since vault-agent has auto_auth capabilities.
- https://github.com/banzaicloud/bank-vaults/issues/804 would be solved since the vault-agent-config configmap is not needed anymore 
- https://github.com/banzaicloud/bank-vaults/issues/464 should be solved since the token would be handled by vault-agent directly (I'm still testing this).
- https://github.com/banzaicloud/bank-vaults/issues/302 would be solved since the full configuration will have to be provided inside the configmap, therefore user will be able to use all auth methods provided by vault-agent to perform authentication.

### Additional context
#### Open Points
The approach I used is to declare an additional boolean parameter called "vault-agent-templating". While this is the easiest way to maintain old codebase, it leaves everything named as "ct"/"consul-template", and this may be misleading since consul-template is not involved anymore. Moreover, the config.hcl file the user provides inside the ConfigMap needs to be extended to contain auto_auth and sink stanzas (because the init container is and the `ct-image` must be different (vault-agent instead of consul-template). Therefore, one cannot simply add the `vault-agent-templating` annotation and be done with it.

One solution may be to define a new `vault-agent-configmap` that triggers the new handling so that it's clearer that "something is different" from an end-user point of view, but with this approach we would recycle the other `ct-...` parameters for a different use and this may be confusing.

A better solution would be to define a whole new set of parameters (eg. prefixed with `va-` instead of `ct-`) but this would yield to a lot of code duplication.

Some proably-non-backwards-compatible solutions are available as well, for example changing the prefix to a common name (`sidecar-...` or similar) and leaving only the specific ones with the appropriate prefixes.

I also stumbled upon vault-agent parameter that may be used for this ( https://github.com/banzaicloud/bank-vaults/issues/302 ).

Discussion and suggestions are highly welcome.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
- [x] Tests
- [x] Documentation

