### PR TITLE
Fix trim to >> value

### DIFF
--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -160,7 +160,7 @@ func main() {
 		value := split[1]
 
 		var update bool
-		if strings.HasPrefix(value, ">>") {
+		if strings.HasPrefix(value, ">>vault:") {
 			value = strings.TrimPrefix(value, ">>")
 			update = true
 		} else {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix env that has the prefix: ">>" and not is related with Vault.

### Current issue:
When the sanitize check each environment, they check if they have a prefix ">>" to update that path. But if you send without vault: prefix, the prefix is trim anyway.

For example:
```sh
MY_ENV=">>test"
```
sanity to
```sh
MY_ENV="test" # Incorrect
```
