### PR TITLE
Add registry address to cache key

### DIFF
--- a/cmd/vault-secrets-webhook/registry/registry.go
+++ b/cmd/vault-secrets-webhook/registry/registry.go
@@ -369,7 +369,7 @@ func (k *ContainerInfo) Collect(container *corev1.Container, podSpec *corev1.Pod
 			logger.Infof("trying to request AWS credentials for ECR registry %s", k.RegistryAddress)
 
 			var data string
-			cachedToken, usingCache := credentialsCache.Get(ecrCredentialsKey)
+			cachedToken, usingCache := credentialsCache.Get(ecrCredentialsKey + k.RegistryAddress)
 			if usingCache {
 				data = cachedToken.(string)
 				logger.Infof("Using cached AWS ECR Token for registry %s", k.RegistryAddress)
@@ -401,7 +401,7 @@ func (k *ContainerInfo) Collect(container *corev1.Container, podSpec *corev1.Pod
 				}
 
 				expiration := authData.ExpiresAt.Sub(time.Now().Add(5 * time.Minute))
-				credentialsCache.Set(ecrCredentialsKey, data, expiration)
+				credentialsCache.Set(ecrCredentialsKey + k.RegistryAddress, data, expiration)
 				logger.Infof("Caching ECR token with expiration in %+v", expiration)
 			}
 

--- a/cmd/vault-secrets-webhook/registry/registry.go
+++ b/cmd/vault-secrets-webhook/registry/registry.go
@@ -369,7 +369,8 @@ func (k *ContainerInfo) Collect(container *corev1.Container, podSpec *corev1.Pod
 			logger.Infof("trying to request AWS credentials for ECR registry %s", k.RegistryAddress)
 
 			var data string
-			cachedToken, usingCache := credentialsCache.Get(ecrCredentialsKey + k.RegistryAddress)
+			cacheKey := ecrCredentialsKey + k.RegistryAddress
+			cachedToken, usingCache := credentialsCache.Get(cacheKey)
 			if usingCache {
 				data = cachedToken.(string)
 				logger.Infof("Using cached AWS ECR Token for registry %s", k.RegistryAddress)
@@ -401,7 +402,7 @@ func (k *ContainerInfo) Collect(container *corev1.Container, podSpec *corev1.Pod
 				}
 
 				expiration := authData.ExpiresAt.Sub(time.Now().Add(5 * time.Minute))
-				credentialsCache.Set(ecrCredentialsKey + k.RegistryAddress, data, expiration)
+				credentialsCache.Set(cacheKey, data, expiration)
 				logger.Infof("Caching ECR token with expiration in %+v", expiration)
 			}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Change the cache key of the ECR token to use ECR registry URL.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
When using ECR images from multiple regions, the ECR key would be the same, causing an authentication problem, because the previously generated token was created for only one region

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
