### PR TITLE
[webhook] Fix resource parsing check

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -424,13 +424,13 @@ func parseVaultConfig(obj metav1.Object) internal.VaultConfig {
 		vaultConfig.CtOnce = false
 	}
 
-	if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-ct-cpu"]); err != nil {
+	if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-ct-cpu"]); err == nil {
 		vaultConfig.CtCPU = val
 	} else {
 		vaultConfig.CtCPU = resource.MustParse("100m")
 	}
 
-	if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-ct-memory"]); err != nil {
+	if val, err := resource.ParseQuantity(annotations["vault.security.banzaicloud.io/vault-ct-memory"]); err == nil {
 		vaultConfig.CtMemory = val
 	} else {
 		vaultConfig.CtMemory = resource.MustParse("128Mi")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Currently the default values for consul-template CPU and Memory are never used because the check is wrong. The value provided in the annotation should be used if the error is nil, not viceversa. This PR fixes this.

