### PR TITLE
makefile: webhook fix for helm3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,8 @@ operator-down:
 
 .PHONY: webhook-forward
 webhook-forward: ## Install the webhook chart and kurun to port-forward the local webhook into Kubernetes
-	helm init --wait
+	kubectl create namespace vault-infra --dry-run -o yaml | kubectl apply -f -
+	kubectl label namespaces vault-infra name=vault-infra --overwrite
 	helm upgrade --wait --install vault-secrets-webhook charts/vault-secrets-webhook --namespace vault-infra --set replicaCount=0 --set podsFailurePolicy=Fail --set secretsFailurePolicy=Fail
 	kurun port-forward localhost:8443 --namespace vault-infra --servicename vault-secrets-webhook --tlssecret vault-secrets-webhook
 


### PR DESCRIPTION
The namespace has to be created and labeled manually in case of Helm 3.