### PR TITLE
Add oci authMethodType to gcp case to support configuring vault auth …

### DIFF
--- a/pkg/sdk/vault/operator_client.go
+++ b/pkg/sdk/vault/operator_client.go
@@ -667,22 +667,22 @@ func (v *vault) configureAuthMethods(config *viper.Viper) error {
 			if err != nil {
 				return fmt.Errorf("error configuring aws auth roles for vault: %s", err.Error())
 			}
-		case "gcp":
+		case "gcp","oci":
 			config, err := cast.ToStringMapE(authMethod["config"])
 			if err != nil {
-				return fmt.Errorf("error finding config block for gcp: %s", err.Error())
+				return fmt.Errorf("error finding config block for %s: %s", authMethodType, err.Error())
 			}
 			err = v.configureGenericAuthConfig(authMethodType, path, config)
 			if err != nil {
-				return fmt.Errorf("error configuring gcp auth for vault: %s", err.Error())
+				return fmt.Errorf("error configuring %s auth for vault: %s", authMethodType, err.Error())
 			}
 			roles, err := cast.ToSliceE(authMethod["roles"])
 			if err != nil {
-				return fmt.Errorf("error finding roles block for gcp: %s", err.Error())
+				return fmt.Errorf("error finding roles block for %s: %s", authMethodType, err.Error())
 			}
 			err = v.configureGenericAuthRoles(authMethodType, path, "role", roles)
 			if err != nil {
-				return fmt.Errorf("error configuring gcp auth roles for vault: %s", err.Error())
+				return fmt.Errorf("error configuring %s auth roles for vault: %s", authMethodType, err.Error())
 			}
 		case "approle":
 			roles, err := cast.ToSliceE(authMethod["roles"])


### PR DESCRIPTION
…roles

and Update error messages to output authMethodType rather than hardcoded "gcp"

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Needed operator to support configuring OCI auth method roles.  It fits the same pattern with GCP, with config and roles sections, and therefore is a very simple change.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ X] Logging code meets the guideline (TODO)