### PR TITLE
Add support for custom hosts/IPs on the TLS certificates managed by vault-operator

### DIFF
--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -313,6 +313,10 @@ type VaultSpec struct {
 	// default: 168h
 	TLSExpiryThreshold *time.Duration `json:"tlsExpiryThreshold,omitempty"`
 
+	// TLSAdditionalHosts is a list of additional hostnames or IP addresses to add to the SAN on the automatically generated TLS certificate.
+	// default:
+	TLSAdditionalHosts []string `json:"tlsAdditionalHosts,omitempty"`
+
 	// CANamespaces define a list of namespaces where the generated CA certificate for Vault should be distributed,
 	// use ["*"] for all namespaces.
 	// default:

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1064,6 +1064,13 @@ func hostsAndIPsForVault(om *vaultv1alpha1.Vault, service *corev1.Service) []str
 		}
 	}
 
+	// Add additional TLS hosts from the Vault Spec
+	for _, additionalHost := range om.Spec.TLSAdditionalHosts {
+		if additionalHost != "" {
+			hostsAndIPs = append(hostsAndIPs, additionalHost)
+		}
+	}
+
 	return hostsAndIPs
 }
 


### PR DESCRIPTION


| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
Support for adding custom hostnames or IP addresses to the TLS certificates which the operator generates


### Why?
We wanted to use a load balancer with SSL passthrough but the TLS cert didn't have the hostname of the load balancer...

