### PR TITLE
add labels to k8s unseal Secret

### DIFF
--- a/cmd/bank-vaults/main.go
+++ b/cmd/bank-vaults/main.go
@@ -73,8 +73,13 @@ const cfgVaultToken = "vault-token"
 
 const cfgK8SNamespace = "k8s-secret-namespace"
 const cfgK8SSecret = "k8s-secret-name"
+const cfgK8SLabels = "k8s-secret-labels"
 
 const cfgFilePath = "file-path"
+
+// We need to pre-create a value and bind the the flag to this until
+// https://github.com/spf13/viper/issues/608 gets fixed.
+var k8sSecretLabels map[string]string
 
 var rootCmd = &cobra.Command{
 	Use:   "bank-vaults",
@@ -103,6 +108,11 @@ func configStringVar(key, defaultValue, description string) {
 
 func configStringSliceVar(key string, defaultValue []string, description string) {
 	rootCmd.PersistentFlags().StringSlice(key, defaultValue, description)
+	appConfig.BindPFlag(key, rootCmd.PersistentFlags().Lookup(key))
+}
+
+func configStringMapVar(key string, value *map[string]string, description string) {
+	rootCmd.PersistentFlags().StringToStringVar(value, key, nil, description)
 	appConfig.BindPFlag(key, rootCmd.PersistentFlags().Lookup(key))
 }
 
@@ -187,6 +197,7 @@ func init() {
 	// K8S Secret Storage flags
 	configStringVar(cfgK8SNamespace, "", "The namespace of the K8S Secret to store values in")
 	configStringVar(cfgK8SSecret, "", "The name of the K8S Secret to store values in")
+	configStringMapVar(cfgK8SLabels, &k8sSecretLabels, "The labels of the K8S Secret to store values in")
 
 	// File flags
 	configStringVar(cfgFilePath, "", "The path prefix of the files where to store values in")

--- a/cmd/bank-vaults/util.go
+++ b/cmd/bank-vaults/util.go
@@ -186,6 +186,7 @@ func kvStoreForConfig(cfg *viper.Viper) (kv.Service, error) {
 		k8s, err := k8s.New(
 			cfg.GetString(cfgK8SNamespace),
 			cfg.GetString(cfgK8SSecret),
+			k8sSecretLabels,
 		)
 
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
When using the K8S Secret unseal key storage mechanism now all the Vault CR related labels are applied as well to that Secret resource.

### Why?
To make all operator related component label-selectable.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
