### PR TITLE
vault-env: add daemon mode with dynamic secret renewal

### DIFF
--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -21,12 +21,13 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/banzaicloud/bank-vaults/internal/configuration"
-	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
-
+	"emperror.dev/errors"
 	vaultapi "github.com/hashicorp/vault/api"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cast"
+
+	"github.com/banzaicloud/bank-vaults/internal/configuration"
+	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
 )
 
 // The special value for VAULT_ENV which marks that the login token needs to be passed through to the application
@@ -61,6 +62,7 @@ var (
 		"VAULT_ENV_PASSTHROUGH":        true,
 		"VAULT_JSON_LOG":               true,
 		"VAULT_REVOKE_TOKEN":           true,
+		"VAULT_ENV_DAEMON":             true,
 	}
 
 	logger *log.Logger
@@ -89,8 +91,22 @@ func (environ *sanitizedEnviron) append(name string, value string) {
 	}
 }
 
+func startSecretRenewal(client *vault.Client, secret *vaultapi.Secret) error {
+	renewerInput := vaultapi.RenewerInput{Secret: secret}
+	secretRenewer, err := client.RawClient().NewRenewer(&renewerInput)
+	if err != nil {
+		return errors.Wrap(err, "failed to create secret renewer")
+	}
+
+	go secretRenewer.Renew()
+
+	return nil
+}
+
 func main() {
 	enableJSONLog := os.Getenv("VAULT_JSON_LOG")
+
+	daemonMode := cast.ToBool(os.Getenv("VAULT_ENV_DAEMON"))
 
 	logger = log.New()
 	// Add additional fields to all log messages
@@ -241,6 +257,14 @@ func main() {
 					secretCache[secretCacheKey] = secret
 				}
 			}
+
+			if daemonMode && secret.Renewable && secret.LeaseDuration > 0 {
+				log.Infof("secret %q has a lease duration of %ds, starting renewal", valuePath, secret.LeaseDuration)
+				err = startSecretRenewal(client, secret)
+				if err != nil {
+					logger.Fatalln("secret renewal can't be established", err)
+				}
+			}
 		}
 
 		if secret == nil {
@@ -298,10 +322,24 @@ func main() {
 			// Do not exit on error, token revoking can be denied by policy
 			logger.Warnln("failed to revoke token")
 		}
+		client.Close()
 	}
 
-	err = syscall.Exec(binary, entrypointCmd, sanitized)
+	logger.Infoln("spawning process:", entrypointCmd)
+
+	if daemonMode {
+		logger.Infoln("in daemon mode...")
+		cmd := exec.Command(binary, entrypointCmd[1:]...)
+		cmd.Env = append(os.Environ(), sanitized...)
+		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		err = cmd.Run()
+	} else {
+		err = syscall.Exec(binary, entrypointCmd, sanitized)
+	}
+
 	if err != nil {
-		logger.Fatalln("failed to exec process", binary, entrypointCmd, err.Error())
+		logger.Fatalln("failed to exec process", entrypointCmd, err.Error())
 	}
 }

--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -280,7 +280,7 @@ func main() {
 				}
 			}
 
-			if daemonMode && secret.Renewable && secret.LeaseDuration > 0 {
+			if daemonMode && secret != nil && secret.Renewable && secret.LeaseDuration > 0 {
 				log.Infof("secret %s has a lease duration of %ds, starting renewal", valuePath, secret.LeaseDuration)
 				err = startSecretRenewal(client, valuePath, secret, sigs)
 				if err != nil {

--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -91,7 +91,7 @@ func (environ *sanitizedEnviron) append(name string, value string) {
 	}
 }
 
-func startSecretRenewal(client *vault.Client, secret *vaultapi.Secret) error {
+func startSecretRenewal(client *vault.Client, path string, secret *vaultapi.Secret) error {
 	renewerInput := vaultapi.RenewerInput{Secret: secret}
 	secretRenewer, err := client.RawClient().NewRenewer(&renewerInput)
 	if err != nil {
@@ -99,6 +99,18 @@ func startSecretRenewal(client *vault.Client, secret *vaultapi.Secret) error {
 	}
 
 	go secretRenewer.Renew()
+
+	go func() {
+		for {
+			select {
+			case renewOutput := <-secretRenewer.RenewCh():
+				log.Infof("secret %s renewed for %ds", path, renewOutput.Secret.LeaseDuration)
+			case doneError := <-secretRenewer.DoneCh():
+				log.WithField("error", doneError).Infof("secret renewal for %s has finished", path)
+				return
+			}
+		}
+	}()
 
 	return nil
 }
@@ -259,8 +271,8 @@ func main() {
 			}
 
 			if daemonMode && secret.Renewable && secret.LeaseDuration > 0 {
-				log.Infof("secret %q has a lease duration of %ds, starting renewal", valuePath, secret.LeaseDuration)
-				err = startSecretRenewal(client, secret)
+				log.Infof("secret %s has a lease duration of %ds, starting renewal", valuePath, secret.LeaseDuration)
+				err = startSecretRenewal(client, valuePath, secret)
 				if err != nil {
 					logger.Fatalln("secret renewal can't be established", err)
 				}

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -1098,7 +1098,7 @@ func (mw *mutatingWebhook) mutatePod(pod *corev1.Pod, vaultConfig internal.Vault
 func init() {
 	viper.SetDefault("vault_image", "vault:latest")
 	viper.SetDefault("vault_image_pull_policy", string(corev1.PullIfNotPresent))
-	viper.SetDefault("vault_env_image", "banzaicloud/vault-env:daemon")
+	viper.SetDefault("vault_env_image", "banzaicloud/vault-env:latest")
 	viper.SetDefault("vault_env_image_pull_policy", string(corev1.PullIfNotPresent))
 	viper.SetDefault("vault_ct_image", "hashicorp/consul-template:0.19.6-dev-alpine")
 	viper.SetDefault("vault_addr", "https://vault:8200")

--- a/deploy/test-dynamic-env-vars.yaml
+++ b/deploy/test-dynamic-env-vars.yaml
@@ -1,0 +1,35 @@
+#
+# NOTE: Use this example with operator/deploy/cr-mysql-ha.yaml Vault CR
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-secrets
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hello-secrets
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hello-secrets
+      annotations:
+        vault.security.banzaicloud.io/vault-addr: "https://vault:8200"
+        vault.security.banzaicloud.io/vault-tls-secret: vault-tls
+        vault.security.banzaicloud.io/vault-env-daemon: "true"
+    spec:
+      initContainers:
+      containers:
+      - name: mysql-client
+        image: mysql:5.7
+        command: ["sh", "-c", "echo mysql -h mysql -u ${MYSQL_USERNAME} -p${MYSQL_PASSWORD} && echo going to sleep... && sleep 10000"]
+        env:
+        - name: MYSQL_USERNAME
+          value: vault:database/creds/app#username
+        - name: MYSQL_PASSWORD
+          value: vault:database/creds/app#password
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "100m"

--- a/go.sum
+++ b/go.sum
@@ -559,6 +559,7 @@ github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkB
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7 h1:80VN+vGkqM773Br/uNNTSheo3KatTgV8IpjIKjvVLng=
 github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=

--- a/internal/configuration/vaultConfig.go
+++ b/internal/configuration/vaultConfig.go
@@ -27,6 +27,7 @@ type VaultConfig struct {
 	SkipVerify                  string
 	TLSSecret                   string
 	UseAgent                    bool
+	VaultEnvDaemon              bool
 	TransitKeyID                string
 	TransitPath                 string
 	CtConfigMap                 string

--- a/operator/deploy/cr-mysql-ha.yaml
+++ b/operator/deploy/cr-mysql-ha.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   size: 2
   image: vault:1.3.1
-  bankVaultsImage: banzaicloud/bank-vaults:daemon
+  bankVaultsImage: banzaicloud/bank-vaults:latest
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault

--- a/operator/deploy/cr-mysql-ha.yaml
+++ b/operator/deploy/cr-mysql-ha.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   size: 2
   image: vault:1.3.1
-  bankVaultsImage: banzaicloud/bank-vaults:latest
+  bankVaultsImage: banzaicloud/bank-vaults:daemon
 
   # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
   serviceAccount: vault
@@ -13,7 +13,9 @@ spec:
   # Unsealing will be done via Kubernetes Secrets if not defined otherwise (not highly secure, but this is just an example)
 
   # NOTE: you will need a MySQL instance, grab one with:
-  # helm upgrade --install mysql stable/mysql --set mysqlRootPassword=your-root-password --set mysqlDatabase=vault --set mysqlUser=vault --set mysqlPassword=secret
+  # helm upgrade --install mysql stable/mysql --set mysqlRootPassword=your-root-password --set mysqlDatabase=vault --set mysqlUser=vault --set mysqlPassword=secret --set 'initializationFiles.app-db\.sql=CREATE DATABASE IF NOT EXISTS app;'
+
+  # This example is best used together with deploy/test-daemon-mode.yaml to demonstrate the usage of dynamic credential renewal in vault-env daemon mode.
 
   # A YAML representation of a final vault config file, this config represents
   # a HA config with MySQL.
@@ -38,19 +40,20 @@ spec:
   # See: https://github.com/banzaicloud/bank-vaults#example-external-vault-configuration for more details.
   externalConfig:
     policies:
-      - name: allow_secrets
-        rules: path "secret/*" {
-          capabilities = ["create", "read", "update", "delete", "list"]
+      - name: allow_database
+        rules: path "database/creds/*" {
+          capabilities = ["read"]
           }
     auth:
       - type: kubernetes
         roles:
-          # Allow every pod in the default namespace to use the secret kv store
+          # Allow pods in the default namespace to request dynamic database credentials
           - name: default
             bound_service_account_names: default
             bound_service_account_namespaces: default
-            policies: allow_secrets
-            ttl: 1h
+            policies: allow_database
+            ttl: 2m
+            max_ttl: 5m
     secrets:
       - type: database
         description: MySQL Database secret engine.
@@ -65,10 +68,10 @@ spec:
               rotate: true # Ask bank-vaults to ask Vault to rotate the root credentials of MySQL
           roles:
             - name: app
-              db_name: app-db
+              db_name: my-mysql
               creation_statements: "CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}'; GRANT ALL ON `app\_%`.* TO '{{name}}'@'%';"
-              default_ttl: "10m"
-              max_ttl: "24h"
+              default_ttl: "2m"
+              max_ttl: "5m"
 
   vaultEnvsConfig:
     - name: MYSQL_VAULT_PASSWORD

--- a/operator/deploy/cr-mysql-ha.yaml
+++ b/operator/deploy/cr-mysql-ha.yaml
@@ -52,8 +52,8 @@ spec:
             bound_service_account_names: default
             bound_service_account_namespaces: default
             policies: allow_database
-            ttl: 2m
-            max_ttl: 5m
+            ttl: 1m
+            max_ttl: 2m
     secrets:
       - type: database
         description: MySQL Database secret engine.
@@ -71,7 +71,7 @@ spec:
               db_name: my-mysql
               creation_statements: "CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}'; GRANT ALL ON `app\_%`.* TO '{{name}}'@'%';"
               default_ttl: "2m"
-              max_ttl: "5m"
+              max_ttl: "10m"
 
   vaultEnvsConfig:
     - name: MYSQL_VAULT_PASSWORD

--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   size: 1
   image: vault:1.3.1
-  bankVaultsImage: banzaicloud/bank-vaults:latest
+  bankVaultsImage: banzaicloud/bank-vaults:master
 
   # Common annotations for all created resources
   annotations:

--- a/pkg/sdk/vault/client.go
+++ b/pkg/sdk/vault/client.go
@@ -280,12 +280,12 @@ func NewClientFromRawClient(rawClient *vaultapi.Client, opts ...ClientOption) (*
 					}
 
 					if secret == nil {
-						logger.Println("Received empty answer from Vault, retrying")
+						logger.Println("received empty answer from Vault, retrying")
 						time.Sleep(1 * time.Second)
 						continue
 					}
 
-					logger.Println("Received new Vault token")
+					logger.Println("received new Vault token")
 
 					// Set the first token from the response
 					rawClient.SetToken(secret.Auth.ClientToken)
@@ -298,7 +298,7 @@ func NewClientFromRawClient(rawClient *vaultapi.Client, opts ...ClientOption) (*
 					// Start the renewing process
 					tokenRenewer, err = rawClient.NewRenewer(&vaultapi.RenewerInput{Secret: secret})
 					if err != nil {
-						logger.Println("Failed to renew Vault token", err.Error())
+						logger.Println("failed to renew Vault token", err.Error())
 						continue
 					}
 
@@ -315,7 +315,7 @@ func NewClientFromRawClient(rawClient *vaultapi.Client, opts ...ClientOption) (*
 
 			select {
 			case <-initialTokenArrived:
-				logger.Println("Initial Vault token arrived")
+				logger.Println("initial Vault token arrived")
 
 			case <-time.After(initialTokenTimeout):
 				client.Close()
@@ -332,12 +332,12 @@ func runRenewChecker(tokenRenewer *vaultapi.Renewer) {
 		select {
 		case err := <-tokenRenewer.DoneCh():
 			if err != nil {
-				logger.Println("Vault token renewal error:", err.Error())
+				logger.Println("error in Vault token renewal:", err.Error())
 			}
 			return
 		case o := <-tokenRenewer.RenewCh():
 			ttl, _ := o.Secret.TokenTTL()
-			logger.Println("Renewed Vault token ttl =", ttl)
+			logger.Println("renewed Vault token ttl =", ttl)
 		}
 	}
 }

--- a/pkg/sdk/vault/client.go
+++ b/pkg/sdk/vault/client.go
@@ -335,8 +335,9 @@ func runRenewChecker(tokenRenewer *vaultapi.Renewer) {
 				logger.Println("Vault token renewal error:", err.Error())
 			}
 			return
-		case <-tokenRenewer.RenewCh():
-			logger.Printf("Renewed Vault Token")
+		case o := <-tokenRenewer.RenewCh():
+			ttl, _ := o.Secret.TokenTTL()
+			logger.Println("Renewed Vault token ttl =", ttl)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/banzaicloud/bank-vaults/issues/836
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add the functionality to start `vault-env` in a so-called daemon mode, so it doesn't replace itself with the user process after setting the environment variables, but executes it as a child-process and remains in memory, so it can renew the leases on Vault tokens and on dynamic secrets.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To be able to use dynamic secrets in long-running processes with `vault-env`.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
The functionality can be enabled with the `vault.security.banzaicloud.io/vault-env-daemon: "true"` annotation, the old functionality remains the default option.

**The current limitation is if the max_ttl of the Secret from Vault expires the renewal stops as well, so the Secrets get revoked.**

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] User guide and development docs updated (if needed)
