### PR TITLE
Fix aws auth cross account sts role parameter name

### DIFF
--- a/docs/cli-tool/README.md
+++ b/docs/cli-tool/README.md
@@ -113,7 +113,7 @@ auth:
     # Add cross account number and role to assume in the cross account
     # https://www.vaultproject.io/api/auth/aws/index.html#create-sts-role
     - sts_account: 12345671234
-      sts_role_arn: arn:aws:iam::12345671234:role/crossaccountrole
+      sts_role: arn:aws:iam::12345671234:role/crossaccountrole
     roles:
     # Add roles for AWS instances or principals
     # See https://www.vaultproject.io/api/auth/aws/index.html#create-role

--- a/vault-config.yml
+++ b/vault-config.yml
@@ -83,7 +83,7 @@ auth:
     # Add cross account number and role to assume in the cross account
     # https://www.vaultproject.io/api/auth/aws/index.html#create-sts-role
     - sts_account: 12345671234
-      sts_role_arn: arn:aws:iam::12345671234:role/crossaccountrole
+      sts_role: arn:aws:iam::12345671234:role/crossaccountrole
     roles:
     # Add roles for AWS instances or principals
     # See https://www.vaultproject.io/api/auth/aws/index.html#create-role


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | https://github.com/banzaicloud/bank-vaults/pull/140
| License         | Apache 2.0


### What's in this PR?

Change documentation references for Vault AWS auth cross account configuration.
https://www.vaultproject.io/api/auth/aws/index.html#inlinecode-sts_role

It's a minor documentation update, but if it can save time to someone else...

### Why?
The documentation is using the wrong parameter name

### Additional context
If following documentation, bank-vault fails to update vault:

```
time="2020-02-06T11:37:37Z" level=error msg="error configuring vault: error configuring auth methods for vault: error configuring aws auth cross account roles for vault: error putting 12345671234 cross account aws role into vault: Error making API request.\n\nURL: PUT https://vault.example.com:8200/v1/auth/aws/config/sts/12345671234\nCode: 400. Errors:\n\n* missing sts role"
```


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)
