### PR TITLE
operator: remove owner reference setting from unseal secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ bin/*
 !/.idea/scopes/
 
 vault-config.yaml
+
+# goreleaser
+dist/

--- a/README.md
+++ b/README.md
@@ -59,16 +59,23 @@ Bank-Vaults is a core part of [Banzai Cloud Pipeline](https://banzaicloud.com/),
 </p>
 
 
-## Installing:
+## Installing
+
+You usually don't need to use the CLI directly, rather you should install the charts and create Vault instances with the operator and use the webhook inside Kubernetes.
+
+To grab the CLI binary go to the [releases](https://github.com/banzaicloud/bank-vaults/releases) page and download it.
+
+On macOs, you can directly Homebrew the CLI:
+
+```
+$ brew install banzaicloud/tap/bank-vaults
+```
+
+Alternatively, fetch the source and compile it using `go get`:
+
 ```shell
 go get github.com/banzaicloud/bank-vaults/cmd/bank-vaults
 go get github.com/banzaicloud/bank-vaults/cmd/vault-env
-```
-
-If compilation is failed, you should try to enable go modules:
-```shell
-GOPATH=/tmp/gopath-for-bank-vaults GO111MODULE=on go get github.com/banzaicloud/bank-vaults/cmd/bank-vaults
-GOPATH=/tmp/gopath-for-bank-vaults GO111MODULE=on go get github.com/banzaicloud/bank-vaults/cmd/vault-env
 ```
 
 Read more about usage of bank-vaults in [detailed documentation](docs/README.md)

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -61,6 +61,7 @@ waitfor kubectl get pod/vault-0
 waitfor kubectl get pod/vault-1
 kubectl wait --for=condition=ready pod/vault-0 --timeout=120s
 kubectl delete -f operator/deploy/cr-etcd-ha.yaml
+kubectl delete secret vault-unseal-keys
 kubectl wait --for=delete pod/vault-0 --timeout=120s || true
 kubectl wait --for=delete pod/vault-1 --timeout=120s || true
 
@@ -70,6 +71,7 @@ waitfor kubectl get pod/vault-0
 kubectl wait --for=condition=ready pod/vault-0 --timeout=120s
 test x`kubectl get pod vault-0 -o jsonpath='{.metadata.annotations.vault\.banzaicloud\.io/watched-secrets-sum}'` = "x"
 kubectl delete -f deploy/test-external-secrets-watch-deployment.yaml
+kubectl delete secret vault-unseal-keys
 kubectl wait --for=delete pod/vault-0 --timeout=120s || true
 
 kubectl apply -f deploy/test-external-secrets-watch-secrets.yaml
@@ -80,6 +82,7 @@ kubectl wait --for=condition=ready pod/vault-0 --timeout=120s
 test x`kubectl get pod vault-0 -o jsonpath='{.metadata.annotations.vault\.banzaicloud\.io/watched-secrets-sum}'` = "xbac8dfa8bdf03009f89303c8eb4a6c8f2fd80eb03fa658f53d6d65eec14666d4"
 kubectl delete -f deploy/test-external-secrets-watch-deployment.yaml
 kubectl delete -f deploy/test-external-secrets-watch-secrets.yaml
+kubectl delete secret vault-unseal-keys
 kubectl wait --for=delete pod/vault-0 --timeout=120s || true
 
 # Third test: single node cluster with defined PriorityClass via vaultPodSpec and vaultConfigurerPodSpec

--- a/pkg/kv/k8s/k8s.go
+++ b/pkg/kv/k8s/k8s.go
@@ -30,6 +30,7 @@ import (
 )
 
 // EnvK8SOwnerReference holds the environment variable name for passing in K8S owner refs
+// TODO: remove this in the next release.
 const EnvK8SOwnerReference = "K8S_OWNER_REFERENCE"
 
 type k8sStorage struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes https://github.com/banzaicloud/bank-vaults/issues/852
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
The Vault data is not removed when a Vault instance is deleted, the unseal keys shouldn't be removed either. This only affects the K8S backend.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
