### PR TITLE
Make unseal cmd platform-agnostic

### DIFF
--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -102,7 +102,7 @@ from one of the followings:
 
 			initialized, err := v.RaftInitialized()
 			if err != nil {
-				logrus.Fatalf("error checking if vault is initalized: %s", err.Error())
+				logrus.Fatalf("error checking if vault is initialized: %s", err.Error())
 			}
 
 			// If this is the first instance we have to init it, this happens once in the clusters lifetime

--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"os"
-	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -101,9 +100,13 @@ from one of the followings:
 		if unsealConfig.proceedInit && unsealConfig.raft {
 			logrus.Info("joining leader vault...")
 
-			podName := os.Getenv("POD_NAME")
+			initialized, err := v.isInit()
+			if err != nil {
+				logrus.Fatalf("error checking if vault is initalized: %s", err.Error())
+			}
+
 			// If this is the first instance we have to init it, this happens once in the clusters lifetime
-			if strings.HasSuffix(podName, "-0") && !unsealConfig.raftSecondary {
+			if !initialized && !unsealConfig.raftSecondary {
 				logrus.Info("initializing vault...")
 				if err := v.Init(); err != nil {
 					logrus.Fatalf("error initializing vault: %s", err.Error())

--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -100,7 +100,7 @@ from one of the followings:
 		if unsealConfig.proceedInit && unsealConfig.raft {
 			logrus.Info("joining leader vault...")
 
-			initialized, err := v.isInit()
+			initialized, err := v.RaftInitialized()
 			if err != nil {
 				logrus.Fatalf("error checking if vault is initalized: %s", err.Error())
 			}

--- a/pkg/sdk/vault/operator_client.go
+++ b/pkg/sdk/vault/operator_client.go
@@ -358,6 +358,10 @@ func (v *vault) Init() error {
 func (v *vault) RaftInitialized() (bool, error) {
 	rootToken, err := v.keyStore.Get(v.rootTokenKey())
 	if err != nil {
+		if e, ok := err.(notFoundError); ok && e.NotFound() {
+			return false, nil
+		}
+
 		return false, fmt.Errorf("unable to get key '%s': %s", v.rootTokenKey(), err.Error())
 	}
 

--- a/pkg/sdk/vault/operator_client.go
+++ b/pkg/sdk/vault/operator_client.go
@@ -358,7 +358,7 @@ func (v *vault) Init() error {
 func (v *vault) RaftInitialized() (bool, error) {
 	rootToken, err := v.keyStore.Get(v.rootTokenKey())
 	if err != nil {
-		return fmt.Errorf("unable to get key '%s': %s", v.rootTokenKey(), err.Error())
+		return false, fmt.Errorf("unable to get key '%s': %s", v.rootTokenKey(), err.Error())
 	}
 
 	if len(rootToken) > 0 {

--- a/pkg/sdk/vault/operator_client.go
+++ b/pkg/sdk/vault/operator_client.go
@@ -84,7 +84,7 @@ var _ Vault = &vault{}
 // a Vault server.
 type Vault interface {
 	Init() error
-	isInit() (bool, error)
+	RaftInitialized() (bool, error)
 	RaftJoin(string) error
 	Sealed() (bool, error)
 	Active() (bool, error)
@@ -355,7 +355,7 @@ func (v *vault) Init() error {
 }
 
 // in our case Vault is initialized when root key is stored in the Cloud KMS
-func (v *vault) isInit() (bool, error) {
+func (v *vault) RaftInitialized() (bool, error) {
 	rootToken, err := v.keyStore.Get(v.rootTokenKey())
 	if err != nil {
 		return fmt.Errorf("unable to get key '%s': %s", v.rootTokenKey(), err.Error())


### PR DESCRIPTION
Signed-off-by: Salvatore Mazzarino <dev@mazzarino.cz>

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #863 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

`bank-vaults` expects as env variable the `POD_NAME` and in case this is the first pod of a StatefulSet (in kubernetes this is suffixed with `-0`), it attempts to initialize.

`bank-vaults` could be used not only in a Kubernetes environment but also in the existing Vault cluster where is very useful to automate the Raft join of nodes.

In this scenario, as discussed with @bonifaido, we can verify if Vault is initialized by checking whether the keys stored in the configured Cloud KMS are in place. 


### Additional context
Does this PR break any existing cluster? I'd say no.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

