### PR TITLE
bank-vaults: retrieve automatically Raft leader adress

### DIFF
--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -112,6 +112,14 @@ from one of the followings:
 					logrus.Fatalf("error initializing vault: %s", err.Error())
 				}
 			} else {
+				if unsealConfig.raftLeaderAddress == "" {
+					logrus.Info("retrieving raft leader IP address...")
+					unsealConfig.raftLeaderAddress, err = v.RaftLeaderAPIAddr()
+					if err != nil {
+						logrus.Fatalf("error retrieving raf leader IP address: %s", err.Error())
+					}
+				}
+
 				logrus.Info("joining raft cluster...")
 				if err := v.RaftJoin(unsealConfig.raftLeaderAddress); err != nil {
 					logrus.Fatalf("error joining leader vault: %s", err.Error())

--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -112,16 +112,18 @@ from one of the followings:
 					logrus.Fatalf("error initializing vault: %s", err.Error())
 				}
 			} else {
+				raftLeaderAddress := unsealConfig.raftLeaderAddress
 				if unsealConfig.raftLeaderAddress == "" {
 					logrus.Info("retrieving raft leader IP address...")
-					unsealConfig.raftLeaderAddress, err = v.RaftLeaderAPIAddr()
+					raftLeaderAddress, err = v.RaftLeaderAPIAddr()
+
 					if err != nil {
 						logrus.Fatalf("error retrieving raf leader IP address: %s", err.Error())
 					}
 				}
 
 				logrus.Info("joining raft cluster...")
-				if err := v.RaftJoin(unsealConfig.raftLeaderAddress); err != nil {
+				if err := v.RaftJoin(raftLeaderAddress); err != nil {
 					logrus.Fatalf("error joining leader vault: %s", err.Error())
 				}
 			}

--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -105,6 +105,8 @@ from one of the followings:
 				logrus.Fatalf("error checking if vault is initialized: %s", err.Error())
 			}
 
+			logrus.Info("Vault initialized", initialized)
+
 			// If this is the first instance we have to init it, this happens once in the clusters lifetime
 			if !initialized && !unsealConfig.raftSecondary {
 				logrus.Info("initializing vault...")

--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -105,7 +105,7 @@ from one of the followings:
 				logrus.Fatalf("error checking if vault is initialized: %s", err.Error())
 			}
 
-			logrus.Info("Vault initialized", initialized)
+			logrus.Info("Vault initialized: ", initialized)
 
 			// If this is the first instance we have to init it, this happens once in the clusters lifetime
 			if !initialized && !unsealConfig.raftSecondary {

--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -113,7 +113,7 @@ from one of the followings:
 				}
 			} else {
 				raftLeaderAddress := unsealConfig.raftLeaderAddress
-				if unsealConfig.raftLeaderAddress == "" {
+				if raftLeaderAddress == "" {
 					logrus.Info("retrieving raft leader IP address...")
 					raftLeaderAddress, err = v.RaftLeaderAPIAddr()
 

--- a/cmd/bank-vaults/util.go
+++ b/cmd/bank-vaults/util.go
@@ -46,6 +46,8 @@ func vaultConfigForConfig(_ *viper.Viper) (vault.Config, error) {
 		StoreRootToken: appConfig.GetBool(cfgStoreRootToken),
 
 		PreFlightChecks: appConfig.GetBool(cfgPreFlightChecks),
+
+		Raft: appConfig.GetBool(cfgRaft),
 	}, nil
 }
 

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -14,6 +14,8 @@ function finish {
     kubectl get pods
     kubectl describe pods
     kubectl logs deployment/vault-operator
+    echo "pod/vault-1 logs"
+    kubectl logs --all-containers pod/vault-1
     kubectl logs --all-containers statefulset/vault
     kubectl logs -n vswh deployment/vault-secrets-webhook
     kubectl describe deployment/hello-secrets

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -14,6 +14,8 @@ function finish {
     kubectl get pods
     kubectl describe pods
     kubectl logs deployment/vault-operator
+    kubectl get secret -n default
+    kubectl get secret -n default -oyaml vault-root
     echo "pod/vault-1 logs"
     kubectl logs --all-containers pod/vault-1
     kubectl logs --all-containers statefulset/vault

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -14,8 +14,7 @@ function finish {
     kubectl get pods
     kubectl describe pods
     kubectl logs deployment/vault-operator
-    kubectl get secret -n default
-    kubectl get secret -n default -oyaml vault-root
+    kubectl get secret -A
     echo "pod/vault-1 logs"
     kubectl logs --all-containers pod/vault-1
     kubectl logs --all-containers statefulset/vault

--- a/pkg/sdk/vault/operator_client.go
+++ b/pkg/sdk/vault/operator_client.go
@@ -377,8 +377,12 @@ func (v *vault) Init() error {
 // in our case Vault is initialized when root key is stored in the Cloud KMS
 func (v *vault) RaftInitialized() (bool, error) {
 	rootToken, err := v.keyStore.Get(v.rootTokenKey())
+
+	logrus.Info("Root token: ", rootToken)
+
 	if err != nil {
 		if e, ok := err.(notFoundError); ok && e.NotFound() {
+			logrus.Info("NotFound: ", e.NotFound())
 			return false, nil
 		}
 


### PR DESCRIPTION
Signed-off-by: Salvatore Mazzarino <dev@mazzarino.cz>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/bank-vaults/issues/871
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview of the implementation, which decisions were made and why. -->

During the `init` process store the Raft leader API address in the Cloud KMS and retrieve it before joining the cluster


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

This would increase the automation level and makes the tool avoid asking for the raft leader address as input.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
