### PR TITLE
webhook: fix parseContainerImage for special image format

### DIFF
--- a/cmd/vault-secrets-webhook/registry/registry.go
+++ b/cmd/vault-secrets-webhook/registry/registry.go
@@ -171,6 +171,10 @@ func parseContainerImage(image string) (string, string) {
 
 	if strings.Contains(image, "@") {
 		split = strings.SplitN(image, "@", 2)
+		subsplit := strings.SplitN(split[0], ":", 2)
+		if len(subsplit) > 1 {
+			split[0] = subsplit[0]
+		}
 	} else {
 		split = strings.SplitN(image, ":", 2)
 	}

--- a/cmd/vault-secrets-webhook/registry/registry_test.go
+++ b/cmd/vault-secrets-webhook/registry/registry_test.go
@@ -135,3 +135,38 @@ func TestParsingRegistryAddress(t *testing.T) {
 		assert.Equal(t, test.registryAddress, containerInfo.RegistryAddress)
 	}
 }
+
+func TestParseContainerImage(t *testing.T) {
+	tests := []struct {
+		image string
+		repo  string
+		tag   string
+	}{
+		{
+			image: "docker-repo.banana.xyz/testing/skaffold-python-example:508954f-dirty@sha256:96b77fc06c9cbd5227eb8538020c6e458a259d17ccb2ec1aea5fe8261a61fff7",
+			repo:  "docker-repo.banana.xyz/testing/skaffold-python-example",
+			tag:   "sha256:96b77fc06c9cbd5227eb8538020c6e458a259d17ccb2ec1aea5fe8261a61fff7",
+		},
+		{
+			image: "docker-repo.banana.xyz/testing/skaffold-python-example@sha256:96b77fc06c9cbd5227eb8538020c6e458a259d17ccb2ec1aea5fe8261a61fff7",
+			repo:  "docker-repo.banana.xyz/testing/skaffold-python-example",
+			tag:   "sha256:96b77fc06c9cbd5227eb8538020c6e458a259d17ccb2ec1aea5fe8261a61fff7",
+		},
+		{
+			image: "alpine:latest",
+			repo:  "alpine",
+			tag:   "latest",
+		},
+		{
+			image: "alpine",
+			repo:  "alpine",
+			tag:   "latest",
+		},
+	}
+
+	for _, test := range tests {
+		repo, tag := parseContainerImage(test.image)
+		assert.Equal(t, test.repo, repo, test.image)
+		assert.Equal(t, test.tag, tag, test.image)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #879 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix for #879 .