### PR TITLE
vault-secrets-webhook: Add cert-manager certficate capability

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 0.9.0
-version: 0.7.2
+version: 0.8.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
 maintainers:

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -137,8 +137,52 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | podDisruptionBudget.enabled      | enable PodDisruptionBudget                                                   | `false`                             |
 | podDisruptionBudget.minAvailable | represents the number of Pods that must be available (integer or percentage) | `1`                                 |
 | certificate.generate             | should a new CA and TLS certificate be generated for the webhook             | `true`                              |
+| certificate.useCertManager       | should request cert-manager for getting a new CA and TLS certificate         | `false`                             |
 | certificate.ca.crt               | Base64 encoded CA certificate                                                | ``                                  |
 | certificate.server.tls.crt       | Base64 encoded TLS certificate signed by the CA                              | ``                                  |
 | certificate.server.tls.key       | Base64 encoded  private key of TLS certificate signed by the CA              | ``                                  |
 | apiSideEffectValue               | Webhook sideEffect value                                                     | `NoneOnDryRun`                      |
+
+### Certificate options
+
+There are the following options for suppling the webhook with CA and TLS certificate.
+
+#### Generate (default)
+
+The default option is to let helm generate the CA and TLS certificates on deploy time.
+
+This will renew the certificates on each deployment.
+
+```
+certificate:
+    generate: true
+```
+
+#### Manually supplied
+
+Another option is to generate everything manually and specify the TLS `crt` and `key` plus the CA `crt` as values.
+These values needs to be base64 encoded x509 certificates.
+
+```
+certificate:
+  generate: false
+  server:
+    tls:
+      crt: LS0tLS1...
+      key: LS0tLS1...
+  ca:
+    crt: LS0tLS1...
+```
+
+#### Using cert-manager
+
+If you use cert-manager in you cluster, you can instruct cert-manager to manage everything.
+The following options will let cert-manager generate TLS `certificate` and `key` plus the CA `certificate`.
+
+
+```
+certificate:
+  generate: false
+  useCertManager: true
+```
 

--- a/charts/vault-secrets-webhook/templates/_helpers.tpl
+++ b/charts/vault-secrets-webhook/templates/_helpers.tpl
@@ -30,3 +30,19 @@ Create chart name and version as used by the chart label.
 {{- define "vault-secrets-webhook.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "vault-secrets-webhook.selfSignedIssuer" -}}
+{{ printf "%s-selfsign" (include "vault-secrets-webhook.fullname" .) }}
+{{- end -}}
+
+{{- define "vault-secrets-webhook.rootCAIssuer" -}}
+{{ printf "%s-ca" (include "vault-secrets-webhook.fullname" .) }}
+{{- end -}}
+
+{{- define "vault-secrets-webhook.rootCACertificate" -}}
+{{ printf "%s-ca" (include "vault-secrets-webhook.fullname" .) }}
+{{- end -}}
+
+{{- define "vault-secrets-webhook.servingCertificate" -}}
+{{ printf "%s-webhook-tls" (include "vault-secrets-webhook.fullname" .) }}
+{{- end -}}

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -11,6 +11,9 @@
 {{- $tlsCrt = b64enc $server.Cert }}
 {{- $tlsKey = b64enc $server.Key }}
 {{- $caCrt =  b64enc $ca.Cert }}
+{{- else if .Values.certificate.useCertManager }}
+{{/* do nothing with certs here. Cert-manager will handle it all */}}
+{{/* all clientConfig.caBundle will be overridden by cert-manager */}}
 {{- else }}
 {{- $tlsCrt = required "Required when certificate.generate is false" .Values.certificate.server.tls.crt }}
 {{- $tlsKey = required "Required when certificate.generate is false" .Values.certificate.server.tls.key }}
@@ -18,6 +21,8 @@
 {{- end }}
 {{- $major := .Capabilities.KubeVersion.Major -}}
 {{- $minor := .Capabilities.KubeVersion.Minor -}}
+
+{{- if (eq .Values.certificate.useCertManager false) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -27,12 +32,17 @@ data:
   tls.crt: {{ $tlsCrt }}
   tls.key: {{ $tlsKey }}
   ca.crt:  {{ $caCrt }}
+{{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "vault-secrets-webhook.fullname" . }}
   namespace: {{ .Release.Namespace }}
+{{- if .Values.certificate.useCertManager }}
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "vault-secrets-webhook.servingCertificate" . }}"
+{{- end }}
 webhooks:
 - name: pods.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
   clientConfig:

--- a/charts/vault-secrets-webhook/templates/warnings.tpl
+++ b/charts/vault-secrets-webhook/templates/warnings.tpl
@@ -1,0 +1,7 @@
+{{/* this file is for generating warnings about incorrect usage of the chart */}}
+
+{{- if .Values.certificate.generate  }}
+{{- if .Values.certificate.useCertManager }}
+    {{ fail "It is not allowed to both set certificate.generate=true and certificate.useCertManager=true."}}
+{{- end }}
+{{- end }}

--- a/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.certificate.useCertManager }}
+---
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: {{ include "vault-secrets-webhook.selfSignedIssuer" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "vault-secrets-webhook.name" . }}
+    chart: {{ include "vault-secrets-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selfSigned: {}
+
+---
+
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ include "vault-secrets-webhook.rootCACertificate" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "vault-secrets-webhook.name" . }}
+    chart: {{ include "vault-secrets-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  secretName: {{ include "vault-secrets-webhook.rootCACertificate" . }}
+  duration: 43800h # 5y
+  issuerRef:
+    name: {{ include "vault-secrets-webhook.selfSignedIssuer" . }}
+  commonName: "ca.vault-secrets-webhook.cert-manager"
+  isCA: true
+
+---
+
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: {{ include "vault-secrets-webhook.rootCAIssuer" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "vault-secrets-webhook.name" . }}
+    chart: {{ include "vault-secrets-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ca:
+    secretName: {{ include "vault-secrets-webhook.rootCACertificate" . }}
+
+---
+
+# Finally, generate a serving certificate for the webhook to use
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ include "vault-secrets-webhook.servingCertificate" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "vault-secrets-webhook.name" . }}
+    chart: {{ include "vault-secrets-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  secretName: {{ template "vault-secrets-webhook.fullname" . }}
+  duration: 8760h # 1y
+  issuerRef:
+    name: {{ include "vault-secrets-webhook.rootCAIssuer" . }}
+  dnsNames:
+  - {{ include "vault-secrets-webhook.fullname" . }}
+  - {{ include "vault-secrets-webhook.fullname" . }}.{{ .Release.Namespace }}
+  - {{ include "vault-secrets-webhook.fullname" . }}.{{ .Release.Namespace }}.svc
+
+{{- end }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -7,6 +7,7 @@ replicaCount: 2
 debug: false
 
 certificate:
+    useCertManager: false
     generate: true
     server:
         tls:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #867
| License         | Apache 2.0


### What's in this PR?

This PR allows vaults-secrets-webhook to get certificates from cert-manager.

Added `warnings.tpl`. This will validate that the user of the chart does not request an invalid configuration.

### Checklist

- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
