### PR TITLE
ci: use checkout@v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         go-version: 1.13
 
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Start kind cluster
       run: kind create cluster


### PR DESCRIPTION
Otherwise, checkout breaks for external PRs.