### PR TITLE
Operator: Etcd affinity

### DIFF
--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -246,6 +246,11 @@ type VaultSpec struct {
 	// default:
 	EtcdPVCSpec *v1.PersistentVolumeClaimSpec `json:"etcdPVCSpec,omitempty"`
 
+	// EtcdAffinity is a Kubernetes Affinity that will be used by the ETCD Pods.
+	// If not defined PodAntiAffinity will be use.  If both are empty no Affinity is used
+	// default:
+	EtcdAffinity *v1.Affinity `json:"etcdAffinity,omitempty"`
+
 	// ServiceType is a Kuberrnetes Service type of the Vault Service.
 	// default: ClusterIP
 	ServiceType string `json:"serviceType"`

--- a/operator/pkg/apis/vault/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/vault/v1alpha1/zz_generated.deepcopy.go
@@ -428,6 +428,11 @@ func (in *VaultSpec) DeepCopyInto(out *VaultSpec) {
 		*out = new(v1.PersistentVolumeClaimSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.EtcdAffinity != nil {
+		in, out := &in.EtcdAffinity, &out.EtcdAffinity
+		*out = new(v1.Affinity)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ServicePorts != nil {
 		in, out := &in.ServicePorts, &out.ServicePorts
 		*out = make(map[string]int32, len(*in))

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -670,7 +670,7 @@ func etcdForVault(v *vaultv1alpha1.Vault) (*etcdv1beta2.EtcdCluster, error) {
 		Resources:                 *getEtcdResource(v),
 		Annotations:               v.Spec.EtcdPodAnnotations,
 		BusyboxImage:              v.Spec.EtcdPodBusyBoxImage,
-		Affinity:                  getEtcdAffinity(v),
+		Affinity:                  getEtcdAffinity(v, etcdName),
 	}
 	etcdCluster.Spec.Version = v.Spec.GetEtcdVersion()
 	etcdCluster.Spec.TLS = &etcdv1beta2.TLSPolicy{
@@ -1722,7 +1722,7 @@ func getPodAntiAffinity(v *vaultv1alpha1.Vault) *corev1.PodAntiAffinity {
 	}
 }
 
-func getEtcdAffinity(v *vaultv1alpha1.Vault) *corev1.Affinity {
+func getEtcdAffinity(v *vaultv1alpha1.Vault, etcdName string) *corev1.Affinity {
 	if v.Spec.EtcdAffinity != nil {
 		return v.Spec.EtcdAffinity
 	}
@@ -1732,7 +1732,7 @@ func getEtcdAffinity(v *vaultv1alpha1.Vault) *corev1.Affinity {
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 					{
 						LabelSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"app": "etcd"},
+							MatchLabels: map[string]string{"app": "etcd", "etcd_cluster": etcdName},
 						},
 						TopologyKey: v.Spec.PodAntiAffinity,
 					},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #885 
| License         | Apache 2.0


### What's in this PR?
This PR adds the ability to define a Pod Affinity object to be passed through to the Etcd cluster object.  If EtcdAffinity is defined this is what will get passed through.  If that is empty but podAntiAffinity exists this will be used in the Affinity rules.  Otherwise this is not set


### Additional context
Have tested the main cases; explicitly defining pod affinity, using the podAntiAffinity config, and with nothing.


### Checklist
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)
