### PR TITLE
Do not just overwrite the annotations for the updated service

### DIFF
--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -147,8 +147,12 @@ func createOrUpdateObjectWithClient(c client.Client, o runtime.Object) error {
 			svc := o.(*corev1.Service)
 			// Preserve the ClusterIP when updating the service
 			svc.Spec.ClusterIP = currentSvc.Spec.ClusterIP
-			// Preserve the annotation when updating the service
-			svc.Annotations = currentSvc.Annotations
+			// Preserve the annotation when updating the service, ensure any updated annotation is preserved
+			for key, value := range currentSvc.Annotations {
+				if _, present := svc.Annotations[key]; !present {
+					svc.Annotations[key] = value
+				}
+			}
 
 			if svc.Spec.Type == corev1.ServiceTypeNodePort || svc.Spec.Type == corev1.ServiceTypeLoadBalancer {
 				for i := range svc.Spec.Ports {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #892 
| License         | Apache 2.0


### What's in this PR?
Change the way that annotations on the current `vault service` are handled when updating the service object.


### Why?
To be able to update service annotation while , at the same time, keep the dynamic annotation on the updated service as well

### Additional context

* Locally tested to ensure that not just the "last-applied" but also any other annotation added out of the operator persist when the service is updated 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
