### PR TITLE
Don't add IPC_LOCK capability when disable_mlock is true in Vault config

### DIFF
--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -40,6 +40,7 @@ import (
 	monitorv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/hashicorp/vault/api"
 	"github.com/imdario/mergo"
+	"github.com/spf13/cast"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -1806,7 +1807,7 @@ func withNamespaceEnv(v *vaultv1alpha1.Vault, envs []corev1.EnvVar) []corev1.Env
 }
 
 func withContainerSecurityContext(v *vaultv1alpha1.Vault) *corev1.SecurityContext {
-	if disableMlock, ok := v.Spec.Config["disable_mlock"]; ok && disableMlock.(bool) {
+	if cast.ToBool(v.Spec.Config["disable_mlock"]) {
 		return &corev1.SecurityContext{}
 	}
 	return &corev1.SecurityContext{


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #889 
| License         | Apache 2.0


### What's in this PR?
If in the vault config section `disable_mlock` is set to true, the operator doesn't add the IPC_lock capability to `ContainerSecurityContext` of the Vault container.