### PR TITLE
Existing root CA startup k8s secret to PKI engine

### DIFF
--- a/operator/deploy/cr-k8s-startup-secret.yaml
+++ b/operator/deploy/cr-k8s-startup-secret.yaml
@@ -147,6 +147,7 @@ spec:
           - name: urls
             issuing_certificates: https://vault.default:8200/v1/pki/ca
             crl_distribution_points: https://vault.default:8200/v1/pki/crl
+          # In case of using existing root certificate, the root/generate section below isn't necessary.
           root/generate:
           - name: internal
             common_name: vault.default
@@ -180,6 +181,16 @@ spec:
           data:
             MYSQL_ROOT_PASSWORD: s3cr3t
             MYSQL_PASSWORD: 3xtr3ms3cr3t
+      # Import an existing root certificate from a k8s secret to the pki secret engine.
+      # In case of using pki startup secret, in the secret configuration the root/generate section isn't necessary
+      # - type: pki
+      #   path: pki/config/ca
+      #   data:
+      #     secretKeyRef:
+      #       - name: external-cert
+      #         key: ca.crt
+      #       - name: external-cert
+      #         key: ca.key
 
   vaultEnvsConfig:
     - name: VAULT_LOG_LEVEL


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #835 , partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
We can define a K8s secret, contains a CA certificate and key, for importing to Vault PKI engine.