### PR TITLE
[webhook] mutate any kind of k8s resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ operator-down:
 webhook-forward: ## Install the webhook chart and kurun to port-forward the local webhook into Kubernetes
 	kubectl create namespace vault-infra --dry-run -o yaml | kubectl apply -f -
 	kubectl label namespaces vault-infra name=vault-infra --overwrite
-	helm upgrade --wait --install vault-secrets-webhook charts/vault-secrets-webhook --namespace vault-infra --set replicaCount=0 --set podsFailurePolicy=Fail --set secretsFailurePolicy=Fail
+	helm upgrade --install vault-secrets-webhook charts/vault-secrets-webhook --namespace vault-infra --set replicaCount=0 --set podsFailurePolicy=Fail --set secretsFailurePolicy=Fail
 	kurun port-forward localhost:8443 --namespace vault-infra --servicename vault-secrets-webhook --tlssecret vault-secrets-webhook
 
 .PHONY: webhook-run ## Run run the webhook locally

--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 0.9.0
-version: 0.8.0
+version: 0.9.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
 maintainers:

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -149,6 +149,50 @@ webhooks:
       values:
       - {{ .Release.Namespace }}
 {{- end }}
+{{- if .Values.customResourceMutations }}
+- name: objects.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ template "vault-secrets-webhook.fullname" . }}
+      path: /objects
+    caBundle: {{ $caCrt }}
+  rules:
+  - operations:
+    - CREATE
+    - UPDATE
+    apiGroups:
+    - "*"
+    apiVersions:
+    - "*"
+    resources:
+{{ toYaml .Values.customResourceMutations | indent 6 }}
+  failurePolicy: {{ .Values.customResourcesFailurePolicy }}
+  namespaceSelector:
+  {{- if .Values.namespaceSelector.matchLabels }}
+    matchLabels:
+{{ toYaml .Values.namespaceSelector.matchLabels | indent 6 }}
+  {{- end }}
+    matchExpressions:
+    {{- if .Values.namespaceSelector.matchExpressions }}
+{{ toYaml .Values.namespaceSelector.matchExpressions | indent 4 }}
+    {{- end }}
+    - key: name
+      operator: NotIn
+      values:
+      - {{ .Release.Namespace }}
+{{- if and (eq (int $major) 1) (ge (int $minor) 15) }}
+  objectSelector:
+    matchExpressions:
+    {{- if .Values.objectSelector.matchExpressions }}
+{{ toYaml .Values.objectSelector.matchExpressions | indent 4 }}
+    {{- end }}
+    - key: security.banzaicloud.io/mutate
+      operator: NotIn
+      values:
+      - skip
+{{- end }}
+{{- end }}
 {{- if and (ge (int $major) 1) (ge (int $minor) 12) }}
   sideEffects: {{ .Values.apiSideEffectValue }}
 {{- end }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -75,6 +75,12 @@ rbac:
   psp:
     enabled: false
 
+# A list of Kubernetes resource types to mutate as well:
+# Example: ["ingresses", "servicemonitors"] 
+customResourceMutations: []
+
+customResourcesFailurePolicy: Ignore
+
 # This can cause issues when used with Helm, so it is not enabled by default
 configMapMutation: false
 

--- a/cmd/vault-secrets-webhook/configmap.go
+++ b/cmd/vault-secrets-webhook/configmap.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -27,19 +26,19 @@ import (
 
 func configMapNeedsMutation(configMap *corev1.ConfigMap) bool {
 	for _, value := range configMap.Data {
-		if strings.HasPrefix(value, "vault:") {
+		if hasVaultPrefix(value) {
 			return true
 		}
 	}
 	for _, value := range configMap.BinaryData {
-		if strings.HasPrefix(string(value), "vault:") {
+		if hasVaultPrefix(string(value)) {
 			return true
 		}
 	}
 	return false
 }
 
-func mutateConfigMap(configMap *corev1.ConfigMap, vaultConfig internal.VaultConfig, _ string) error {
+func mutateConfigMap(configMap *corev1.ConfigMap, vaultConfig internal.VaultConfig) error {
 	// do an early exit and don't construct the Vault client if not needed
 	if !configMapNeedsMutation(configMap) {
 		return nil
@@ -53,7 +52,7 @@ func mutateConfigMap(configMap *corev1.ConfigMap, vaultConfig internal.VaultConf
 	defer vaultClient.Close()
 
 	for key, value := range configMap.Data {
-		if strings.HasPrefix(value, "vault:") {
+		if hasVaultPrefix(value) {
 			data := map[string]string{
 				key: value,
 			}
@@ -65,7 +64,7 @@ func mutateConfigMap(configMap *corev1.ConfigMap, vaultConfig internal.VaultConf
 	}
 
 	for key, value := range configMap.BinaryData {
-		if strings.HasPrefix(string(value), "vault:") {
+		if hasVaultPrefix(string(value)) {
 			binaryData := map[string]string{
 				key: string(value),
 			}

--- a/cmd/vault-secrets-webhook/object.go
+++ b/cmd/vault-secrets-webhook/object.go
@@ -1,0 +1,123 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	internal "github.com/banzaicloud/bank-vaults/internal/configuration"
+	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
+)
+
+type element interface {
+	Set(v interface{})
+	Get() interface{}
+}
+
+type iterator <-chan element
+
+type mapElement struct {
+	m map[string]interface{}
+	k string
+}
+
+func (e *mapElement) Set(v interface{}) {
+	e.m[e.k] = v
+}
+
+func (e *mapElement) Get() interface{} {
+	return e.m[e.k]
+}
+
+type sliceElement struct {
+	s []interface{}
+	i int
+}
+
+func (e *sliceElement) Set(v interface{}) {
+	e.s[e.i] = v
+}
+
+func (e *sliceElement) Get() interface{} {
+	return e.s[e.i]
+}
+
+func mapIterator(m map[string]interface{}) iterator {
+	c := make(chan element, len(m))
+	for k := range m {
+		c <- &mapElement{k: k, m: m}
+	}
+	close(c)
+	return c
+}
+
+func sliceIterator(s []interface{}) iterator {
+	c := make(chan element, len(s))
+	for i := range s {
+		c <- &sliceElement{i: i, s: s}
+	}
+	close(c)
+	return c
+}
+
+func traverseObject(o interface{}, vaultClient *vault.Client) error {
+	var iterator iterator
+
+	switch value := o.(type) {
+	case map[string]interface{}:
+		iterator = mapIterator(value)
+	case []interface{}:
+		iterator = sliceIterator(value)
+	default:
+		return nil
+	}
+
+	for e := range iterator {
+		switch s := e.Get().(type) {
+		case string:
+			if hasVaultPrefix(s) {
+				dataFromVault, err := getDataFromVault(map[string]string{"data": s}, vaultClient)
+				if err != nil {
+					return err
+				}
+
+				e.Set(dataFromVault["data"])
+			}
+		case map[string]interface{}, []interface{}:
+			err := traverseObject(e.Get(), vaultClient)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func mutateObject(object *unstructured.Unstructured, vaultConfig internal.VaultConfig) error {
+	logger.Infof("mutating object: %s.%s", object.GetNamespace(), object.GetName())
+	logger.Infof("object: %+v", object.Object)
+
+	vaultClient, err := newVaultClient(vaultConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create vault client: %v", err)
+	}
+
+	defer vaultClient.Close()
+
+	return traverseObject(object.Object, vaultClient)
+}

--- a/cmd/vault-secrets-webhook/secret.go
+++ b/cmd/vault-secrets-webhook/secret.go
@@ -39,7 +39,7 @@ func secretNeedsMutation(secret *corev1.Secret) bool {
 	return false
 }
 
-func mutateSecret(secret *corev1.Secret, vaultConfig internal.VaultConfig, _ string) error {
+func mutateSecret(secret *corev1.Secret, vaultConfig internal.VaultConfig) error {
 	// do an early exit and don't construct the Vault client if not needed
 	if !secretNeedsMutation(secret) {
 		return nil

--- a/deploy/test-custom-resource.yaml
+++ b/deploy/test-custom-resource.yaml
@@ -1,0 +1,46 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: "pod-policy.example.com"
+  annotations:
+    vault.security.banzaicloud.io/vault-addr: "https://vault.default:8200"
+    vault.security.banzaicloud.io/vault-role: "default"
+    vault.security.banzaicloud.io/vault-skip-verify: "true"
+    vault.security.banzaicloud.io/vault-path: "kubernetes"
+webhooks:
+- name: "pod-policy.example.com"
+  rules:
+  - apiGroups:   [""]
+    apiVersions: ["v1"]
+    operations:  ["CREATE"]
+    resources:   ["pods"]
+    scope:       "Namespaced"
+  clientConfig:
+    service:
+      namespace: "example-namespace"
+      name: "example-service"
+    # base64-encoded PEM bundle containing the CA that signed the webhook's serving certificate
+    caBundle: "dmF1bHQ6cGtpL2NlcnQvMToyOjM6NCNjYQ==" # "vault:pki/cert/1:2:3:4#ca"
+  admissionReviewVersions: ["v1beta1"]
+  timeoutSeconds: 5
+
+---
+
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: test-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    vault.security.banzaicloud.io/vault-addr: "https://vault.default:8200"
+    vault.security.banzaicloud.io/vault-role: "default"
+    vault.security.banzaicloud.io/vault-skip-verify: "true"
+    vault.security.banzaicloud.io/vault-path: "kubernetes"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        backend:
+          serviceName: test
+          servicePort: 80


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #900 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Mutation functionality for custom resources, namely any kind of Kubernetes resources with the help of the Unstructured API.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To support injection, for example, CA certificates to resources from Vault, but other use cases are possible as well.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)
