### PR TITLE
operator/chart: support for Helm v3

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 0.9.0
-version: 0.6.5
+version: 0.6.7
 description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
 home: https://www.vaultproject.io/
@@ -12,3 +12,4 @@ sources:
 maintainers:
 - name: Banzai Cloud
   email: info@banzaicloud.com
+type: application

--- a/charts/vault-operator/crds/crd.yaml
+++ b/charts/vault-operator/crds/crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: vaults.vault.banzaicloud.com
+spec:
+  group: vault.banzaicloud.com
+  names:
+    kind: Vault
+    listKind: VaultList
+    plural: vaults
+    singular: vault
+  scope: Namespaced
+  version: v1alpha1

--- a/charts/vault-operator/templates/_helpers.tpl
+++ b/charts/vault-operator/templates/_helpers.tpl
@@ -30,3 +30,15 @@ Create chart name and version as used by the chart label.
 {{- define "vault-operator.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Determines if the current executing Helm environment is v3 or not.
+If yes, it returns the string "helm3", otherwise it returns "".
+*/}}
+{{- define "isHelm3" -}}
+{{- if hasKey (toJson .Chart | fromJson) "type" -}}
+{{- "helm3" -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/vault-operator/templates/crd.yaml
+++ b/charts/vault-operator/templates/crd.yaml
@@ -1,3 +1,4 @@
+{{- if not (include "isHelm3" .) }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -18,3 +19,4 @@ spec:
     singular: vault
   scope: Namespaced
   version: v1alpha1
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #908 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Support for the Helm 3 `crds` directory way of installing CRDs.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To use the Helm 3 CRD installing on Helm 3 and leave the old method for Helm 2.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Uses the `Chart` built-in-object to detect if we are running on Helm 3 (Chart `"type"` is defined only in Helm 3). See: https://helm.sh/docs/topics/charts/#chart-types

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Related Helm chart(s) updated (if needed)
