### PR TITLE
Bump helm orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,7 @@ workflows:
   helm-chart:
     jobs:
       - helm/lint-chart:
+          executor: helm/helm2
           charts-dir: charts
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  helm: banzaicloud/helm@0.0.5
+  helm: banzaicloud/helm@0.0.7
 
 jobs:
   check:


### PR DESCRIPTION
From now on, the default helm executor is helm3 (helm v3.1.1)