### PR TITLE
Make client timeout configurable

### DIFF
--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -35,6 +35,7 @@ env:
   # an imagePullSecret
   # DEFAULT_IMAGE_PULL_SECRET:
   # DEFAULT_IMAGE_PULL_SECRET_NAMESPACE:
+  # VAULT_CLIENT_TIMEOUT: 10s
 
 metrics:
   enabled: false

--- a/cmd/vault-secrets-webhook/main_test.go
+++ b/cmd/vault-secrets-webhook/main_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	cmp "github.com/google/go-cmp/cmp"
 	imagev1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -36,6 +37,7 @@ var vaultConfig = VaultConfig{
 	IgnoreMissingSecrets: "ignoreMissingSecrets",
 	VaultEnvPassThrough:  "vaultEnvPassThrough",
 	EnableJSONLog:        "enableJSONLog",
+	ClientTimeout:        10 * time.Second,
 }
 
 type MockRegistry struct {
@@ -105,6 +107,7 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 						{Name: "VAULT_IGNORE_MISSING_SECRETS", Value: "ignoreMissingSecrets"},
 						{Name: "VAULT_ENV_PASSTHROUGH", Value: "vaultEnvPassThrough"},
 						{Name: "VAULT_JSON_LOG", Value: "enableJSONLog"},
+						{Name: "VAULT_CLIENT_TIMEOUT", Value: "10s"},
 					},
 				},
 			},
@@ -151,6 +154,7 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 						{Name: "VAULT_IGNORE_MISSING_SECRETS", Value: "ignoreMissingSecrets"},
 						{Name: "VAULT_ENV_PASSTHROUGH", Value: "vaultEnvPassThrough"},
 						{Name: "VAULT_JSON_LOG", Value: "enableJSONLog"},
+						{Name: "VAULT_CLIENT_TIMEOUT", Value: "10s"},
 					},
 				},
 			},
@@ -199,6 +203,7 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 						{Name: "VAULT_IGNORE_MISSING_SECRETS", Value: "ignoreMissingSecrets"},
 						{Name: "VAULT_ENV_PASSTHROUGH", Value: "vaultEnvPassThrough"},
 						{Name: "VAULT_JSON_LOG", Value: "enableJSONLog"},
+						{Name: "VAULT_CLIENT_TIMEOUT", Value: "10s"},
 					},
 				},
 			},
@@ -247,6 +252,7 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 						{Name: "VAULT_IGNORE_MISSING_SECRETS", Value: "ignoreMissingSecrets"},
 						{Name: "VAULT_ENV_PASSTHROUGH", Value: "vaultEnvPassThrough"},
 						{Name: "VAULT_JSON_LOG", Value: "enableJSONLog"},
+						{Name: "VAULT_CLIENT_TIMEOUT", Value: "10s"},
 					},
 				},
 			},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR adds a new environment variable `VAULT_CLIENT_TIMEOUT` that allows users to configure how long `vault-env` and `vault-secrets-webhook` keep trying to fetch secrets before failing. The current hard-coded behaviour is to wait for 10 seconds, so this is the default value set for this new configuration parameter.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

We are currently having pods injected with `vault-env` that are failing because the pod's Istio proxy sidecar sometimes takes more than 10 seconds to be ready. When that happens, `vault-env` fails to connect to Vault and the pod fails.

This PR, if merged, would allow us to make `vault-env` wait for longer.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

To test this implementation, I built custom `vault-secrets-webhook` and `vault-env` container images and deployed them to a Kubernetes cluster to test the new behaviour. Pods injected with `vault-env` worked as expected according to the `VAULT_CLIENT_TIMEOUT` variable.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
