### PR TITLE
Implement the ability for a CA to persist when the Server certificate needs to be regenerated

### DIFF
--- a/pkg/sdk/tls/tls.go
+++ b/pkg/sdk/tls/tls.go
@@ -235,7 +235,7 @@ func (cc *CertificateManager) LoadCA(caCertBytes []byte, caKeyBytes []byte, expi
 		return errors.Wrap(err, "unable to get the CA expiration date")
 	}
 
-	if tlsExpiration.Sub(time.Now()) < expirationThreshold {
+	if time.Until(tlsExpiration) < expirationThreshold {
 		return ExpiredCAError
 	}
 
@@ -395,4 +395,20 @@ func (c *CertificateManager) GeneratePeer() error {
 	c.Chain.PeerKey = string(peerCert.Key)
 	c.Chain.PeerCert = string(peerCert.Certificate)
 	return nil
+}
+
+// GenerateTLS generates ca, server, client and peer TLS certificates.
+// hosts: Comma-separated hostnames and IPs to generate a certificate for
+// validity: Duration that certificate is valid for, in Go Duration format
+func GenerateTLS(hosts string, validity string) (*CertificateChain, error) {
+	cm, err := NewCertificateManager(hosts, validity)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = cm.NewChain(); err != nil {
+		return nil, err
+	}
+
+	return cm.Chain, nil
 }

--- a/pkg/sdk/tls/tls.go
+++ b/pkg/sdk/tls/tls.go
@@ -40,7 +40,48 @@ const (
 	defaultKeyBits  = 2048
 )
 
-var InvalidHostNameError = errors.New("invalid host name, this has been already covered by the wildcard")
+var (
+	// InvalidHostNameError is thrown when you have a hostname that has already been covered by a wildcard hostname
+	InvalidHostNameError = errors.New("invalid host name, this has been already covered by the wildcard")
+
+	// InvalidCAError will be thrown if the provided CA is invalid
+	InvalidCAError = errors.New("the CA provided is not valid")
+)
+
+// CertificateManager contains a certificate chain and methods to generate certificates on that chain
+type CertificateManager struct {
+	caCertTemplate *x509.Certificate
+	caKey          *rsa.PrivateKey
+
+	sHosts *separatedCertHosts
+
+	notBefore        time.Time
+	validityDuration time.Duration
+	notAfter         time.Time
+
+	Chain *CertificateChain
+}
+
+// NewCertificateManager will return a new instance of the CertificateManager
+func NewCertificateManager(hosts string, validity string) (*CertificateManager, error) {
+	cm := CertificateManager{
+		Chain: &CertificateChain{},
+	}
+
+	var err error
+	cm.notBefore, cm.validityDuration, cm.notAfter, err = getTimes(validity)
+	if err != nil {
+		return nil, err
+	}
+
+	cm.sHosts = NewSeparatedCertHosts(hosts)
+	err = cm.sHosts.validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return &cm, nil
+}
 
 // CertificateChain represents a full certificate chain with a root CA, a server, client and peer certificate
 // All values are in PEM format
@@ -99,130 +140,44 @@ func (sh *separatedCertHosts) validate() error {
 	return nil
 }
 
-// GenerateTLS generates ca, server, client and peer TLS certificates.
+func getTimes(validity string) (notBefore time.Time, validityDuration time.Duration, notAfter time.Time, err error) {
+	notBefore = time.Now()
+
+	validityDuration, err = time.ParseDuration(validity)
+	if err != nil {
+		err = errors.WithStack(err)
+		return
+	}
+
+	notAfter = notBefore.Add(validityDuration)
+	return
+}
+
+// NewChain generates ca, server, client and peer TLS certificates.
 // hosts: Comma-separated hostnames and IPs to generate a certificate for
 // validity: Duration that certificate is valid for, in Go Duration format
-func GenerateTLS(hosts string, validity string) (*CertificateChain, error) {
-	notBefore := time.Now()
-	validityDuration, err := time.ParseDuration(validity)
+func (cc *CertificateManager) NewChain() error {
+	err := cc.GenerateCA()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return errors.Wrap(err, "error generating new certificate authority")
 	}
 
-	notAfter := notBefore.Add(validityDuration)
-
-	sHosts := NewSeparatedCertHosts(hosts)
-
-	err = sHosts.validate()
+	err = cc.GenerateServer()
 	if err != nil {
-		return nil, err
+		return errors.Wrap(err, "error generating new server certificate")
 	}
 
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	err = cc.GenerateClient()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return errors.Wrap(err, "error generating new server certificate")
 	}
 
-	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	err = cc.GeneratePeer()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return errors.Wrap(err, "error generating new server certificate")
 	}
 
-	caKeyBytes, err := keyToBytes(caKey)
-	if err != nil {
-		return nil, err
-	}
-
-	caCertTemplate := x509.Certificate{
-		SerialNumber: serialNumber,
-		Subject: pkix.Name{
-			Organization: []string{"Banzai Cloud"},
-			CommonName:   "Banzai Cloud Generated Root CA",
-		},
-		NotBefore:             notBefore,
-		NotAfter:              notAfter,
-		KeyUsage:              x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-
-	caCert, err := x509.CreateCertificate(rand.Reader, &caCertTemplate, &caCertTemplate, &caKey.PublicKey, caKey)
-	if err != nil {
-		return nil, err
-	}
-	caCertBytes, err := certToBytes(caCert)
-	if err != nil {
-		return nil, err
-	}
-
-	serverCertRequest := ServerCertificateRequest{
-		Subject: pkix.Name{
-			Organization: []string{"Banzai Cloud"},
-			CommonName:   "Banzai Cloud Generated Server Cert",
-		},
-		Validity:  validityDuration,
-		notBefore: notBefore,
-	}
-	if len(sHosts.WildCardHosts) != 0 {
-		serverCertRequest.Subject.CommonName = sHosts.WildCardHosts[0]
-		serverCertRequest.DNSNames = append(serverCertRequest.DNSNames, sHosts.WildCardHosts...)
-	}
-	serverCertRequest.IPAddresses = append(serverCertRequest.IPAddresses, sHosts.IPs...)
-	serverCertRequest.DNSNames = append(serverCertRequest.DNSNames, sHosts.Hosts...)
-
-	serverCert, err := GenerateServerCertificate(serverCertRequest, &caCertTemplate, caKey)
-	if err != nil {
-		return nil, err
-	}
-
-	clientCertRequest := ClientCertificateRequest{
-		Subject: pkix.Name{
-			Organization: []string{"Banzai Cloud"},
-			CommonName:   "Banzai Cloud Generated Client Cert",
-		},
-		Validity:  validityDuration,
-		notBefore: notBefore,
-	}
-
-	clientCert, err := GenerateClientCertificate(clientCertRequest, &caCertTemplate, caKey)
-	if err != nil {
-		return nil, err
-	}
-
-	peerCertRequest := PeerCertificateRequest{
-		Subject: pkix.Name{
-			Organization: []string{"Banzai Cloud"},
-			CommonName:   "Banzai Cloud Generated Peer Cert",
-		},
-		Validity:  validityDuration,
-		notBefore: notBefore,
-	}
-
-	if len(sHosts.WildCardHosts) != 0 {
-		peerCertRequest.Subject.CommonName = sHosts.WildCardHosts[0]
-		peerCertRequest.DNSNames = append(peerCertRequest.DNSNames, sHosts.WildCardHosts...)
-	}
-	peerCertRequest.IPAddresses = append(peerCertRequest.IPAddresses, sHosts.IPs...)
-	peerCertRequest.DNSNames = append(peerCertRequest.DNSNames, sHosts.Hosts...)
-
-	peerCert, err := GeneratePeerCertificate(peerCertRequest, &caCertTemplate, caKey)
-	if err != nil {
-		return nil, err
-	}
-
-	cc := CertificateChain{
-		CAKey:      string(caKeyBytes),
-		CACert:     string(caCertBytes),
-		ServerKey:  string(serverCert.Key),
-		ServerCert: string(serverCert.Certificate),
-		ClientKey:  string(clientCert.Key),
-		ClientCert: string(clientCert.Certificate),
-		PeerKey:    string(peerCert.Key),
-		PeerCert:   string(peerCert.Certificate),
-	}
-
-	return &cc, nil
+	return nil
 }
 
 func keyToBytes(key *rsa.PrivateKey) ([]byte, error) {
@@ -245,4 +200,164 @@ func certToBytes(certBytes []byte) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+// LoadCA will load an existing certifiate authority into the CertificateManager and underlying chain
+func (c *CertificateManager) LoadCA(caCertBytes []byte, caKeyBytes []byte) error {
+	caCertPem, _ := pem.Decode(caCertBytes)
+	if caCertPem == nil {
+		return errors.Wrap(InvalidCAError, "no PEM encoded CA certificate could be found")
+	}
+	caKeyPem, _ := pem.Decode(caKeyBytes)
+	if caKeyPem == nil {
+		return errors.Wrap(InvalidCAError, "no PEM encoded CA key could be found")
+	}
+
+	if caCertPem.Type != "CERTIFICATE" {
+		return errors.Wrap(InvalidCAError, "the CA certificate was not of type CERTIFICATE")
+	}
+
+	if caKeyPem.Type != "RSA PRIVATE KEY" {
+		return errors.Wrap(InvalidCAError, "the CA certificate was not of type RSA PRIVATE KEY")
+	}
+
+	caCert, err := x509.ParseCertificate(caCertPem.Bytes)
+	if err != nil {
+		return errors.Wrap(InvalidCAError, "the CA certificate was not not x509 parsable")
+	}
+
+	caKey, err := x509.ParsePKCS1PrivateKey(caKeyPem.Bytes)
+	if err != nil {
+		return errors.Wrap(InvalidCAError, "the CA key was not not PKCS1 parsable")
+	}
+
+	c.caCertTemplate = caCert
+	c.caKey = caKey
+	c.Chain.CACert = string(caCertBytes)
+	c.Chain.CAKey = string(caKeyBytes)
+	return nil
+}
+
+// GenerateCA will generate a new certificate authority
+func (c *CertificateManager) GenerateCA() error {
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	caKeyBytes, err := keyToBytes(caKey)
+	if err != nil {
+		return err
+	}
+
+	caCertTemplate := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Banzai Cloud"},
+			CommonName:   "Banzai Cloud Generated Root CA",
+		},
+		NotBefore:             c.notBefore,
+		NotAfter:              c.notAfter,
+		KeyUsage:              x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	caCert, err := x509.CreateCertificate(rand.Reader, &caCertTemplate, &caCertTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		return err
+	}
+	caCertBytes, err := certToBytes(caCert)
+	if err != nil {
+		return err
+	}
+
+	c.caCertTemplate = &caCertTemplate
+	c.caKey = caKey
+
+	c.Chain.CACert = string(caCertBytes)
+	c.Chain.CAKey = string(caKeyBytes)
+	return nil
+}
+
+// GenerateServer will generate a new server TLS certificate signed by the CA within the chain
+func (c *CertificateManager) GenerateServer() error {
+	serverCertRequest := ServerCertificateRequest{
+		Subject: pkix.Name{
+			Organization: []string{"Banzai Cloud"},
+			CommonName:   "Banzai Cloud Generated Server Cert",
+		},
+		Validity:  c.validityDuration,
+		notBefore: c.notBefore,
+	}
+	if len(c.sHosts.WildCardHosts) != 0 {
+		serverCertRequest.Subject.CommonName = c.sHosts.WildCardHosts[0]
+		serverCertRequest.DNSNames = append(serverCertRequest.DNSNames, c.sHosts.WildCardHosts...)
+	}
+	serverCertRequest.IPAddresses = append(serverCertRequest.IPAddresses, c.sHosts.IPs...)
+	serverCertRequest.DNSNames = append(serverCertRequest.DNSNames, c.sHosts.Hosts...)
+
+	serverCert, err := GenerateServerCertificate(serverCertRequest, c.caCertTemplate, c.caKey)
+	if err != nil {
+		return err
+	}
+
+	c.Chain.ServerKey = string(serverCert.Key)
+	c.Chain.ServerCert = string(serverCert.Certificate)
+	return nil
+}
+
+// GenerateClient will generate a new client TLS certificate signed by the CA within the chain
+func (c *CertificateManager) GenerateClient() error {
+	clientCertRequest := ClientCertificateRequest{
+		Subject: pkix.Name{
+			Organization: []string{"Banzai Cloud"},
+			CommonName:   "Banzai Cloud Generated Client Cert",
+		},
+		Validity:  c.validityDuration,
+		notBefore: c.notBefore,
+	}
+
+	clientCert, err := GenerateClientCertificate(clientCertRequest, c.caCertTemplate, c.caKey)
+	if err != nil {
+		return err
+	}
+
+	c.Chain.ClientKey = string(clientCert.Key)
+	c.Chain.ClientCert = string(clientCert.Certificate)
+	return nil
+}
+
+// GeneratePeer will generate a new peer TLS certificate signed by the CA within the chain
+func (c *CertificateManager) GeneratePeer() error {
+	peerCertRequest := PeerCertificateRequest{
+		Subject: pkix.Name{
+			Organization: []string{"Banzai Cloud"},
+			CommonName:   "Banzai Cloud Generated Peer Cert",
+		},
+		Validity:  c.validityDuration,
+		notBefore: c.notBefore,
+	}
+
+	if len(c.sHosts.WildCardHosts) != 0 {
+		peerCertRequest.Subject.CommonName = c.sHosts.WildCardHosts[0]
+		peerCertRequest.DNSNames = append(peerCertRequest.DNSNames, c.sHosts.WildCardHosts...)
+	}
+	peerCertRequest.IPAddresses = append(peerCertRequest.IPAddresses, c.sHosts.IPs...)
+	peerCertRequest.DNSNames = append(peerCertRequest.DNSNames, c.sHosts.Hosts...)
+
+	peerCert, err := GeneratePeerCertificate(peerCertRequest, c.caCertTemplate, c.caKey)
+	if err != nil {
+		return err
+	}
+
+	c.Chain.PeerKey = string(peerCert.Key)
+	c.Chain.PeerCert = string(peerCert.Certificate)
+	return nil
 }

--- a/pkg/sdk/tls/tls_integration_test.go
+++ b/pkg/sdk/tls/tls_integration_test.go
@@ -51,16 +51,21 @@ func TestWildCardValidation(t *testing.T) {
 }
 
 func TestGenerateTLS(t *testing.T) {
-	cc, err := GenerateTLS("localhost,127.0.0.1", "1h")
+	cm, err := NewCertificateManager("localhost,127.0.0.1", "1h")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cm.NewChain()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Load CA cert
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM([]byte(cc.CACert))
+	caCertPool.AppendCertsFromPEM([]byte(cm.Chain.CACert))
 
-	serverCert, err := tls.X509KeyPair([]byte(cc.ServerCert), []byte(cc.ServerKey))
+	serverCert, err := tls.X509KeyPair([]byte(cm.Chain.ServerCert), []byte(cm.Chain.ServerKey))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +90,110 @@ func TestGenerateTLS(t *testing.T) {
 	server.Start()
 
 	// Load client cert
-	clientCert, err := tls.X509KeyPair([]byte(cc.ClientCert), []byte(cc.ClientKey))
+	clientCert, err := tls.X509KeyPair([]byte(cm.Chain.ClientCert), []byte(cm.Chain.ClientKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup HTTPS client
+	clientTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      caCertPool,
+	}
+	clientTLSConfig.BuildNameToCertificate()
+	transport := &http.Transport{TLSClientConfig: clientTLSConfig}
+	client := &http.Client{Transport: transport}
+
+	tests := []string{
+		server.Listener.Addr().String(), // Should work with IP address as well
+		strings.Replace(server.Listener.Addr().String(), "127.0.0.1", "localhost", 1),
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(strings.Split(test, ":")[0], func(t *testing.T) {
+			req, err := http.NewRequest("GET", "https://"+test, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp.Body.Close()
+		})
+	}
+
+	server.Close()
+}
+
+func TestLoadAndRegenerateTLS(t *testing.T) {
+	cmTemp, err := NewCertificateManager("localhost,127.0.0.1", "1h")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cmTemp.NewChain()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cm, err := NewCertificateManager("localhost,127.0.0.1", "1h")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Load an existing certificate authority
+	err = cm.LoadCA([]byte(cmTemp.Chain.CACert), []byte(cmTemp.Chain.CAKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Load CA cert
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM([]byte(cm.Chain.CACert))
+
+	err = cm.GenerateServer()
+	// Generate the Server TLS certificate
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cm.GenerateClient()
+	// Generate the Client TLS certificate
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverCert, err := tls.X509KeyPair([]byte(cm.Chain.ServerCert), []byte(cm.Chain.ServerKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tlsConfig := &tls.Config{
+		ClientAuth:               tls.RequireAndVerifyClientCert,
+		ClientCAs:                caCertPool,
+		PreferServerCipherSuites: true,
+		MinVersion:               tls.VersionTLS12,
+		Certificates:             []tls.Certificate{serverCert},
+	}
+
+	tlsConfig.BuildNameToCertificate()
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte("This is an example TLS server.\n"))
+	}))
+
+	server.Listener = tls.NewListener(server.Listener, tlsConfig)
+
+	server.Start()
+
+	// Load client cert
+	clientCert, err := tls.X509KeyPair([]byte(cm.Chain.ClientCert), []byte(cm.Chain.ClientKey))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sdk/tls/tls_integration_test.go
+++ b/pkg/sdk/tls/tls_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestWildCardValidation(t *testing.T) {
@@ -147,7 +148,7 @@ func TestLoadAndRegenerateTLS(t *testing.T) {
 	}
 
 	// Load an existing certificate authority
-	err = cm.LoadCA([]byte(cmTemp.Chain.CACert), []byte(cmTemp.Chain.CAKey))
+	err = cm.LoadCA([]byte(cmTemp.Chain.CACert), []byte(cmTemp.Chain.CAKey), time.Minute*50)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no|
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
This PR implements the ability for Bank Vault's operator to use an existing automatically generated Certificate Authority when generating a new Server Certificate in the event of a new one being required.

It seems like etcd's CA was always replaced regardless of one already existing so I haven't implemented support for that as we don't have access to the secret at the point where we would need the CA/key to update the Server cert instead of generating a full chain

### Why?
We were having issues with our cross cluster CA certificate expiring when a LoadBalancer IP was changing and causing the Server Certificate to be renewed

### Additional context
https://community-banzaicloud.slack.com/archives/CFJJW9L94/p1585579074011400

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
