### PR TITLE
update consul-template default image

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -83,7 +83,7 @@ func init() {
 	viper.SetDefault("vault_image_pull_policy", string(corev1.PullIfNotPresent))
 	viper.SetDefault("vault_env_image", "banzaicloud/vault-env:latest")
 	viper.SetDefault("vault_env_image_pull_policy", string(corev1.PullIfNotPresent))
-	viper.SetDefault("vault_ct_image", "hashicorp/consul-template:0.19.6-dev-alpine")
+	viper.SetDefault("vault_ct_image", "hashicorp/consul-template:0.24.1-alpine")
 	viper.SetDefault("vault_addr", "https://vault:8200")
 	viper.SetDefault("vault_skip_verify", "false")
 	viper.SetDefault("vault_path", "kubernetes")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | no
| License         | Apache 2.0

### What's in this PR?

Update the consul-image to the 0.24.1-alpine.

### Why?

In the previous versions, there was a bug that caused issues with token renewal. Which could
result in a pod/container crash loop. I experienced this myself, after 30 days consul-template container went into a crash loop. See the additional context section.

### Additional context

https://github.com/hashicorp/consul-template/issues/1161

### Checklist

n/a
