### PR TITLE
vault-env: fix signal subscription order

### DIFF
--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -230,6 +230,11 @@ func main() {
 
 		signal.Notify(sigs)
 
+		err = cmd.Start()
+		if err != nil {
+			logger.Fatalln("failed to start process", entrypointCmd, err.Error())
+		}
+
 		go func() {
 			sig := <-sigs
 			err := cmd.Process.Signal(sig)
@@ -240,7 +245,7 @@ func main() {
 			}
 		}()
 
-		err = cmd.Run()
+		err = cmd.Wait()
 
 		close(sigs)
 


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #934 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fixing the subscription to signals in case of unstarted processes.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To prevent nil pointer panic of unset `.Process` attribute.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
