### PR TITLE
Use string for tlsExpiryTreshold in spec instead of duration

### DIFF
--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -61,6 +61,9 @@ spec:
   # If it is set, generating certificate will be disabled
   # existingTlsSecretName: selfsigned-cert-tls
 
+  # Specify treshold for renewing certificates. Valid time units are "ns", "us", "ms", "s", "m", "h".
+  # tlsExpiryThreshold: 168h
+
   # Request an Ingress controller with the default configuration
   ingress:
     # Specify Ingress object annotations here, if TLS is enabled (which is by default)

--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -61,7 +61,7 @@ spec:
   # If it is set, generating certificate will be disabled
   # existingTlsSecretName: selfsigned-cert-tls
 
-  # Specify treshold for renewing certificates. Valid time units are "ns", "us", "ms", "s", "m", "h".
+  # Specify threshold for renewing certificates. Valid time units are "ns", "us", "ms", "s", "m", "h".
   # tlsExpiryThreshold: 168h
 
   # Request an Ingress controller with the default configuration

--- a/operator/pkg/apis/vault/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/vault/v1alpha1/zz_generated.deepcopy.go
@@ -19,8 +19,6 @@
 package v1alpha1
 
 import (
-	time "time"
-
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -518,11 +516,6 @@ func (in *VaultSpec) DeepCopyInto(out *VaultSpec) {
 		in, out := &in.Ingress, &out.Ingress
 		*out = new(Ingress)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.TLSExpiryThreshold != nil {
-		in, out := &in.TLSExpiryThreshold, &out.TLSExpiryThreshold
-		*out = new(time.Duration)
-		**out = **in
 	}
 	if in.TLSAdditionalHosts != nil {
 		in, out := &in.TLSAdditionalHosts, &out.TLSAdditionalHosts


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/bank-vaults-docs/pull/17
| License         | Apache 2.0


### What's in this PR?

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
