### PR TITLE
operator: add vault condition statuses

### DIFF
--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -733,8 +733,9 @@ func (vault *Vault) AsOwnerReference() metav1.OwnerReference {
 // VaultStatus defines the observed state of Vault
 type VaultStatus struct {
 	// Important: Run "make generate-code" to regenerate code after modifying this file
-	Nodes  []string `json:"nodes"`
-	Leader string   `json:"leader"`
+	Nodes      []string                `json:"nodes"`
+	Leader     string                  `json:"leader"`
+	Conditions []v1.ComponentCondition `json:"conditions"`
 }
 
 // UnsealConfig represents the UnsealConfig field of a VaultSpec Kubernetes object

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -735,7 +735,7 @@ type VaultStatus struct {
 	// Important: Run "make generate-code" to regenerate code after modifying this file
 	Nodes      []string                `json:"nodes"`
 	Leader     string                  `json:"leader"`
-	Conditions []v1.ComponentCondition `json:"conditions"`
+	Conditions []v1.ComponentCondition `json:"conditions,omitempty"`
 }
 
 // UnsealConfig represents the UnsealConfig field of a VaultSpec Kubernetes object

--- a/operator/pkg/apis/vault/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/vault/v1alpha1/zz_generated.deepcopy.go
@@ -555,6 +555,11 @@ func (in *VaultStatus) DeepCopyInto(out *VaultStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]v1.ComponentCondition, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #971 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Write standard Kubernetes Condition status to the Vault CR instance.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To be able to wait for healthy vault instance from deployments.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Can Vault CR status now can be tested with:
```bash
kubectl wait --for=condition=Healthy vault/vault
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
