### PR TITLE
Operator: Support JSON-formatted Vault policies

### DIFF
--- a/pkg/sdk/vault/operator_client.go
+++ b/pkg/sdk/vault/operator_client.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/hcl"
 	hclPrinter "github.com/hashicorp/hcl/hcl/printer"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/helper/consts"
@@ -807,9 +808,19 @@ func (v *vault) configurePolicies(config *viper.Viper) error {
 
 	for _, policy := range policies {
 		policyName := policy["name"]
+
+		// Try to format rules (HCL only)
 		policyRules, err := hclPrinter.Format([]byte(policy["rules"]))
 		if err != nil {
-			return fmt.Errorf("error formatting %s policy rules: %s", policyName, err.Error())
+			// Check if rules parse (HCL or JSON)
+			_, parseErr := hcl.Parse(policy["rules"])
+			if parseErr != nil {
+				return fmt.Errorf("error parsing %s policy rules: %s", policyName, parseErr.Error())
+			}
+
+			// Policies are parsable but couldn't be HCL formatted (most likely JSON)
+			policyRules = []byte(policy["rules"])
+			logrus.Warnf("error HCL-formatting %s policy rules (ignore if rules are JSON-formatted): %s", policyName, err.Error())
 		}
 
 		err = v.cl.Sys().PutPolicy(policyName, string(policyRules))

--- a/pkg/sdk/vault/operator_client.go
+++ b/pkg/sdk/vault/operator_client.go
@@ -820,7 +820,7 @@ func (v *vault) configurePolicies(config *viper.Viper) error {
 
 			// Policies are parsable but couldn't be HCL formatted (most likely JSON)
 			policyRules = []byte(policy["rules"])
-			logrus.Warnf("error HCL-formatting %s policy rules (ignore if rules are JSON-formatted): %s", policyName, err.Error())
+			logrus.Debugf("error HCL-formatting %s policy rules (ignore if rules are JSON-formatted): %s", policyName, err.Error())
 		}
 
 		err = v.cl.Sys().PutPolicy(policyName, string(policyRules))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #979
| License         | Apache 2.0

### What's in this PR?
This adds support for Vault Policies to be provided as JSON strings, in addition to HCL-formatted strings. Current behaviour tries to use an HCL formatter to make it pretty, which won't work for JSON!

This change makes the operator attempt to parse the policy (with a Vault function which parses both JSON and HCL) and if it succeeds, applies it.

### Why?
Vault supports policies in both HCL and JSON format so the operator should too!

### Additional context
Our policies were becoming boilerplate-y and less maintainable so we decided to generate them via Jsonnet, where it's significantly easier to template JSON than HCL.

This has been tested with valid JSON and HCL policies and both are created successfully.

### Checklist
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
