### PR TITLE
webhook: allow to pass data in write request

### DIFF
--- a/internal/injector/inejctor.go
+++ b/internal/injector/inejctor.go
@@ -85,7 +85,7 @@ func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inj
 		// decrypts value with Vault Transit Secret Engine
 		if i.client.Transit.IsEncrypted(value) {
 			if len(i.config.TransitKeyID) == 0 {
-				return errors.NewWithDetails("found encrypted variable, but transit key ID is empty:", name)
+				return errors.Errorf("found encrypted variable, but transit key ID is empty: %s", name)
 			}
 
 			if v, ok := transitCache[value]; ok {
@@ -96,7 +96,7 @@ func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inj
 			out, err := i.client.Transit.Decrypt(i.config.TransitPath, i.config.TransitKeyID, []byte(value))
 			if err != nil {
 				if !i.config.IgnoreMissingSecrets {
-					return errors.WrapWithDetails(err, "failed to decrypt variable:", name)
+					return errors.Wrapf(err, "failed to decrypt variable: %s", name)
 				}
 				i.logger.Errorln("failed to decrypt variable:", name, err)
 				continue
@@ -110,10 +110,11 @@ func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inj
 		split := strings.SplitN(valuePath, "#", 3)
 		valuePath = split[0]
 
-		var key string
-		if len(split) > 1 {
-			key = split[1]
+		if len(split) < 2 {
+			return errors.New("secret data key not defined")
 		}
+
+		key := split[1]
 
 		versionOrData := "-1"
 		if update {
@@ -138,18 +139,12 @@ func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inj
 
 				secret, err = i.client.RawClient().Logical().Write(valuePath, data)
 				if err != nil {
-					return errors.WrapWithDetails(err, "failed to write secret to path:", valuePath)
+					return errors.Wrapf(err, "failed to write secret to path: %s", valuePath)
 				}
-				secretCache[secretCacheKey] = secret
 			} else {
 				secret, err = i.client.RawClient().Logical().ReadWithData(valuePath, map[string][]string{"version": {versionOrData}})
 				if err != nil {
-					if !i.config.IgnoreMissingSecrets {
-						return errors.WrapWithDetails(err, "failed to read secret from path:", valuePath)
-					}
-					i.logger.Errorln("failed to read secret from path:", valuePath, err.Error())
-				} else {
-					secretCache[secretCacheKey] = secret
+					return errors.Wrapf(err, "failed to read secret from path: %s", valuePath)
 				}
 			}
 
@@ -165,12 +160,18 @@ func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inj
 
 		if secret == nil {
 			if !i.config.IgnoreMissingSecrets {
-				return errors.NewWithDetails("path not found:", valuePath)
+				return errors.Errorf("path not found: %s", valuePath)
 			}
 
 			i.logger.Errorln("path not found:", valuePath)
 			continue
 		}
+
+		for _, warning := range secret.Warnings {
+			i.logger.Warnf("%s: %s", valuePath, warning)
+		}
+
+		secretCache[secretCacheKey] = secret
 
 		var data map[string]interface{}
 		v2Data, ok := secret.Data["data"]
@@ -196,7 +197,7 @@ func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inj
 		if templater.IsGoTemplate(key) {
 			value, err := templater.Template(key, data)
 			if err != nil {
-				return errors.WrapWithDetails(err, "failed to interpolate template key with vault data:", key)
+				return errors.Wrapf(err, "failed to interpolate template key with vault data: %s", key)
 			}
 			inject(name, value.String())
 		} else {
@@ -207,7 +208,7 @@ func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inj
 				}
 				inject(name, value)
 			} else {
-				return errors.NewWithDetails("key not found:", key)
+				return errors.Errorf("key '%s' not found under path: %s", key, valuePath)
 			}
 		}
 	}

--- a/internal/injector/inejctor.go
+++ b/internal/injector/inejctor.go
@@ -111,7 +111,7 @@ func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inj
 		valuePath = split[0]
 
 		if len(split) < 2 {
-			return errors.New("secret data key not defined")
+			return errors.New("secret data key or template not defined") // nolint:goerr113
 		}
 
 		key := split[1]

--- a/internal/injector/inejctor_test.go
+++ b/internal/injector/inejctor_test.go
@@ -18,6 +18,7 @@ package injector
 
 import (
 	"encoding/base64"
+	"os"
 	"testing"
 
 	vaultapi "github.com/hashicorp/vault/api"
@@ -28,6 +29,8 @@ import (
 )
 
 func TestSecretInjector(t *testing.T) {
+	os.Setenv("VAULT_ADDR", "http://localhost:8200")
+
 	client, err := vault.NewClientFromConfig(vaultapi.DefaultConfig())
 	assert.NoError(t, err)
 

--- a/internal/injector/inejctor_test.go
+++ b/internal/injector/inejctor_test.go
@@ -1,0 +1,66 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build integration
+
+package injector
+
+import (
+	"testing"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
+	"github.com/sirupsen/logrus"
+)
+
+func TestSecretInjector(t *testing.T) {
+	client, err := vault.NewClientFromConfig(vaultapi.DefaultConfig())
+	assert.NoError(t, err)
+
+	_, err = client.RawClient().Logical().Write("secret/data/account", vault.NewData(0, map[string]interface{}{"password": "secret"}))
+	assert.NoError(t, err)
+
+	defer func() {
+		_, err := client.RawClient().Logical().Delete("secret/metadata/account")
+		assert.NoError(t, err)
+	}()
+
+	injector := NewSecretInjector(Config{}, client, nil, logrus.New())
+
+	// test correct path but missing secret
+	// references := map[string]string{
+	// 	"SECRET": "vault:secret/data/get/data#data",
+	// }
+
+	// test incorrect kv2 path
+	// references := map[string]string{
+	// 	"SECRET": "vault:secret/get/data#data",
+	// }
+
+	references := map[string]string{
+		"ACCOUNT_PASSWORD": "vault:secret/data/account#password",
+	}
+
+	results := map[string]string{}
+	injectFunc := func(key, value string) {
+		results[key] = value
+	}
+
+	err = injector.InjectSecretsFromVault(references, injectFunc)
+	assert.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"ACCOUNT_PASSWORD": "secret"}, results)
+}

--- a/pkg/sdk/vault/transit.go
+++ b/pkg/sdk/vault/transit.go
@@ -25,7 +25,7 @@ import (
 var (
 	// Example: vault:v1:8SDd3WHDOjf7mq69CyCqYjBXAiQQAVZRkFM13ok481zoCmHnSeDX9vyf7w==
 	// ref: https://www.vaultproject.io/docs/secrets/transit/index.html#usage
-	transitEncryptedVariable = regexp.MustCompile(`vault:v\d+:.+`)
+	transitEncryptedVariable = regexp.MustCompile(`^vault:v\d+:.+$`)
 )
 
 // Transit is a wrapper for Transit Secret Engine


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #977
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Design and implement the sending of write parameters and document the feature with examples.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
It is already possible to request dynamic secrets from Vault with "write" requests.

However, this feature is undeservedly underdocumented and incomplete since it is not possible to add data to those write requests.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)

