### PR TITLE
[chart/webhook] fix Kubernetes version comparison

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 1.2.0
-version: 1.2.1
+version: 1.2.2
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -19,8 +19,6 @@
 {{- $tlsKey = required "Required when certificate.generate is false" .Values.certificate.server.tls.key }}
 {{- $caCrt = required "Required when certificate.generate is false" .Values.certificate.ca.crt }}
 {{- end }}
-{{- $major := .Capabilities.KubeVersion.Major -}}
-{{- $minor := .Capabilities.KubeVersion.Minor -}}
 
 {{- if (eq .Values.certificate.useCertManager false) }}
 apiVersion: v1
@@ -74,7 +72,7 @@ webhooks:
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
-{{- if and (eq (int $major) 1) (ge (int $minor) 15) }}
+{{- if semverCompare ">=1.15-0" .Capabilities.KubeVersion.GitVersion }}
   objectSelector:
     matchExpressions:
     {{- if .Values.objectSelector.matchExpressions }}
@@ -181,7 +179,7 @@ webhooks:
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
-{{- if and (eq (int $major) 1) (ge (int $minor) 15) }}
+{{- if semverCompare ">=1.15-0" .Capabilities.KubeVersion.GitVersion }}
   objectSelector:
     matchExpressions:
     {{- if .Values.objectSelector.matchExpressions }}
@@ -193,6 +191,6 @@ webhooks:
       - skip
 {{- end }}
 {{- end }}
-{{- if and (ge (int $major) 1) (ge (int $minor) 12) }}
+{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
   sideEffects: {{ .Values.apiSideEffectValue }}
 {{- end }}

--- a/charts/vault-secrets-webhook/templates/webhook-psp.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-psp.yaml
@@ -1,8 +1,5 @@
-{{- $major := .Capabilities.KubeVersion.Major -}}
-{{- $minor := .Capabilities.KubeVersion.Minor -}}
-
 {{- if and .Values.rbac.enabled .Values.rbac.psp.enabled}}
-{{- if and (eq (int $major) 1) (ge (int $minor) 16) }}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: policy/v1beta1
 {{- else  }}
 apiVersion: extensions/v1beta1
@@ -38,7 +35,7 @@ spec:
   - emptyDir
   - configMap
 ---
-{{- if and (eq (int $major) 1) (ge (int $minor) 16) }}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: policy/v1beta1
 {{- else  }}
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #986 
| License         | Apache 2.0


### What's in this PR?
This uses `semverCompare` helm template function instead of integer when comparing Kubernetes version.
It fixes #986.

### Why?
Using `.Capabilities.KubeVersion.Major` and `.Capabilities.KubeVersion.Minor` is error prone as the value may not always be integer values (like it's the case of some managed Kubernetes offers as AWS EKS).

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->

