### PR TITLE
Prepend namespace name to ClusterRoleBinding for vault Helm Chart

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 1.2.1
+version: 1.2.2
 appVersion: 1.2.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/charts/vault/templates/rolebinding.yaml
+++ b/charts/vault/templates/rolebinding.yaml
@@ -6,7 +6,7 @@ items:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
-    name: {{ template "vault.fullname" . }}-auth-delegator
+    name: {{ .Release.Namespace }}-{{ template "vault.fullname" . }}-auth-delegator
     labels:
       helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
       app.kubernetes.io/name: {{ template "vault.name" . }}


### PR DESCRIPTION
Signed-off-by: Sam Weston <weston.sam@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #991 
| License         | Apache 2.0

### What's in this PR?
Prepends the namespace name to the ClusterRoleBinding name to allow for multiple releases with the same name in the same cluster (but different namespaces).

### Why?
Fixes #991