### PR TITLE
OCP 4.3: runAsUser in Vault Secrets webhook chart should be configurable

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 1.2.0
-version: 1.2.2
+version: 1.2.3
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -92,6 +92,13 @@ $ helm upgrade --namespace vswh --install vswh banzaicloud-stable/vault-secrets-
 
 **NOTE**: `--wait` is necessary because of Helm timing issues, please see [this issue](https://github.com/banzaicloud/banzai-charts/issues/888).
 
+### Openshift 4.3
+For security reasons, the runAsUser must be in the range between 1000570000 and 1000579999. By setting the value of securityContext.runAsUser to "", openshift chooses a valid User.
+
+```bash
+$ helm upgrade --namespace vswh --install vswh banzaicloud-stable/vault-secrets-webhook --set-string securityContext.runAsUser="" --wait
+```
+
 ### About GKE Private Clusters
 
 When Google configure the control plane for private clusters, they automatically configure VPC peering between your Kubernetes cluster’s network in a separate Google managed project.

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -77,7 +77,9 @@ spec:
 {{ toYaml .Values.volumeMounts | indent 12 }}
 {{- end }}
           securityContext:
-            runAsUser: 65534
+            {{- if .Values.securityContext.runAsUser }}
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            {{- end }}
             allowPrivilegeEscalation: false
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -46,6 +46,9 @@ metrics:
     tlsConfig:
       insecureSkipVerify: true
 
+securityContext:
+  runAsUser: 65534
+
 volumes: []
 # - name: vault-tls
 #   secret:


### PR DESCRIPTION
The userid 65534 is not an allowed user in openshift.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #994 
| License         | Apache 2.0

### What's in this PR?
Add the ability to use a custom runAsUser in the helm chart.

### Why?
When using the vault secrets webhook chart in OCP 4.3.x for security reasons the runAsUser must be in the range between 1000570000 and 1000579999 and not 65534.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)