### PR TITLE
add: labels to pods themselves, update README

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 1.3.0
-version: 1.3.2
+version: 1.3.3
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -122,6 +122,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | namespaceSelector                | namespace selector to use, will limit webhook scope                          | `{}`                                |
 | objectSelector                | object selector to use, will limit webhook scope (K8s version 1.15+)            | `{}`                                |
 | nodeSelector                     | node selector to use                                                         | `{}`                                |
+| labels                           | extra labels to add to the deployment and pods                               | `{}`                                |
 | podAnnotations                   | extra annotations to add to pod metadata                                     | `{}`                                |
 | replicaCount                     | number of replicas                                                           | `2`                                 |
 | resources                        | resources to request                                                         | `{}`                                |

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -24,6 +24,9 @@ spec:
         app.kubernetes.io/name: {{ template "vault-secrets-webhook.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         security.banzaicloud.io/mutate: skip
+        {{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/apiservice-webhook.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1002 
| License         | Apache 2.0


### What's in this PR?
Custom labels are added to pods themselves rather than only the deployment. The README was also updated with this undocumented value.


### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
