### PR TITLE
Remove explicit check for annotations

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -315,11 +315,10 @@ func (mw *mutatingWebhook) vaultSecretsMutator(ctx context.Context, obj metav1.O
 	switch v := obj.(type) {
 	case *corev1.Pod:
 		return false, mw.mutatePod(v, vaultConfig, whcontext.GetAdmissionRequest(ctx).Namespace, whcontext.IsAdmissionRequestDryRun(ctx))
+
 	case *corev1.Secret:
-		if _, ok := obj.GetAnnotations()["vault.security.banzaicloud.io/vault-addr"]; ok {
-			return false, mw.mutateSecret(v, vaultConfig)
-		}
-		return false, nil
+		return false, mw.mutateSecret(v, vaultConfig)
+
 	case *corev1.ConfigMap:
 		if _, ok := obj.GetAnnotations()["vault.security.banzaicloud.io/mutate-configmap"]; ok {
 			return false, mw.mutateConfigMap(v, vaultConfig)
@@ -327,10 +326,8 @@ func (mw *mutatingWebhook) vaultSecretsMutator(ctx context.Context, obj metav1.O
 		return false, nil
 
 	case *unstructured.Unstructured:
-		if _, ok := obj.GetAnnotations()["vault.security.banzaicloud.io/vault-addr"]; ok {
-			return false, mw.mutateObject(v, vaultConfig)
-		}
-		return false, nil
+		return false, mw.mutateObject(v, vaultConfig)
+
 	default:
 		return false, nil
 	}


### PR DESCRIPTION
Check for the addr annotation is duplicate here, because its already
covered by parseVaultConfig method.

Fixes #938

Signed-off-by: flozzone <flozzone@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #938
| License         | Apache 2.0


### What's in this PR?
Remove checks for the address annotation, because it is already done by the parseVaultConfig method.


### Why?
This allows Secrets and Unstructured configurations to be mutated even there is no explicit `vault.security.banzaicloud.io/vault-addr` annotation. It will use the default configuration value instead.


### Additional context
Testings with this fix showed that Secrets get mutated as expected. See docker.hub repository
https://hub.docker.com/repository/docker/florinzz/vault-secret-webhook with the `PR-remove-annotation-check`. I assume this will applies also to Unstructured configurations.


### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
