### PR TITLE
operaror: Automount ServiceAccount Token

### DIFF
--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1002,7 +1002,9 @@ func deploymentForConfigurer(v *vaultv1alpha1.Vault, configmaps corev1.ConfigMap
 	}
 
 	podSpec := corev1.PodSpec{
-		ServiceAccountName: v.Spec.GetServiceAccount(),
+		ServiceAccountName:           v.Spec.GetServiceAccount(),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
+
 		Containers: []corev1.Container{
 			{
 				Image:           v.Spec.GetBankVaultsImage(),
@@ -1332,7 +1334,9 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 			PodAntiAffinity: getPodAntiAffinity(v),
 			NodeAffinity:    getNodeAffinity(v),
 		},
-		ServiceAccountName: v.Spec.GetServiceAccount(),
+
+		ServiceAccountName:           v.Spec.GetServiceAccount(),
+		AutomountServiceAccountToken: pointer.BoolPtr(true),
 
 		InitContainers: withVaultInitContainers(v, []corev1.Container{
 			{


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1016 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add `automountServiceAccountToken: true` to Vault and Bank-Vaults pods.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
In some user clusters the service account token is not automatically mounted to pods (namespace/serviceAccount setting). This PR resolves the issue.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
