### PR TITLE
operator: fix hardcoded https schemes in case of raft

### DIFF
--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -496,6 +496,14 @@ func (spec *VaultSpec) GetTLSDisable() bool {
 	return cast.ToBool(tcpSpecs["tls_disable"])
 }
 
+// GetAPIScheme returns if Vault's API address should be called on http or https
+func (spec *VaultSpec) GetAPIScheme() string {
+	if spec.GetTLSDisable() {
+		return "http"
+	}
+	return "https"
+}
+
 // GetTLSExpiryThreshold returns the Vault TLS certificate expiration threshold
 func (spec *VaultSpec) GetTLSExpiryThreshold() time.Duration {
 	if spec.TLSExpiryThreshold == "" {

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1243,7 +1243,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 			raftLeaderAddress = v.Spec.RaftLeaderAddress
 		}
 
-		unsealCommand = append(unsealCommand, "--raft", "--raft-leader-address", "https://"+raftLeaderAddress+":8200")
+		unsealCommand = append(unsealCommand, "--raft", "--raft-leader-address", v.Spec.GetAPIScheme()+"://"+raftLeaderAddress+":8200")
 
 		if v.Spec.RaftLeaderAddress != "" {
 			unsealCommand = append(unsealCommand, "--raft-secondary")
@@ -1636,7 +1636,7 @@ func withClusterAddr(v *vaultv1alpha1.Vault, service *corev1.Service, envs []cor
 	if value != "" {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "VAULT_CLUSTER_ADDR",
-			Value: "https://" + value + ":8201",
+			Value: v.Spec.GetAPIScheme() + "://" + value + ":8201",
 		})
 		// envs = append(envs, corev1.EnvVar{
 		// 	Name:  "VAULT_API_ADDR",

--- a/pkg/sdk/vault/operator_client.go
+++ b/pkg/sdk/vault/operator_client.go
@@ -387,19 +387,22 @@ func (v *vault) RaftJoin(leaderAPIAddr string) error {
 		return nil
 	}
 
+	request := api.RaftJoinRequest{
+		LeaderAPIAddr: leaderAPIAddr,
+	}
+
 	raftCacertFile := os.Getenv("VAULT_RAFT_CACERT")
 	if raftCacertFile == "" {
 		raftCacertFile = os.Getenv(api.EnvVaultCACert)
 	}
 
-	leaderCACert, err := ioutil.ReadFile(raftCacertFile)
-	if err != nil {
-		return errors.Wrap(err, "error reading vault raft CA certificate")
-	}
+	if raftCacertFile != "" {
+		leaderCACert, err := ioutil.ReadFile(raftCacertFile)
+		if err != nil {
+			return errors.Wrap(err, "error reading vault raft CA certificate")
+		}
 
-	request := api.RaftJoinRequest{
-		LeaderAPIAddr: leaderAPIAddr,
-		LeaderCACert:  string(leaderCACert),
+		request.LeaderCACert = string(leaderCACert)
 	}
 
 	response, err := v.cl.Sys().RaftJoin(&request)


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
In some cases for example RAFT the https scheme was hardcoded and was not configurable via the Vault config flag: `tls_disable: true`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
