### PR TITLE
fix notFoundError handling in raft

### DIFF
--- a/pkg/kv/kv.go
+++ b/pkg/kv/kv.go
@@ -14,7 +14,11 @@
 
 package kv
 
-import "fmt"
+import (
+	"fmt"
+
+	"emperror.dev/errors"
+)
 
 // NotFoundError represents an error when a key is not found
 type NotFoundError struct {
@@ -32,6 +36,14 @@ func NewNotFoundError(msg string, args ...interface{}) *NotFoundError {
 	return &NotFoundError{
 		msg: fmt.Sprintf(msg, args...),
 	}
+}
+
+func IsNotFoundError(err error) bool {
+	cause := errors.Cause(err)
+	if notFoundError, ok := cause.(*NotFoundError); ok && notFoundError.NotFound() {
+		return true
+	}
+	return false
 }
 
 // Service defines a basic key-value store. Implementations of this interface

--- a/pkg/kv/multi/multi.go
+++ b/pkg/kv/multi/multi.go
@@ -47,7 +47,7 @@ func (f *multi) Get(key string) ([]byte, error) {
 		val, err := service.Get(key)
 		if err != nil {
 			// Not found error means that they given object is not present, that is a hard error.
-			if notFoundError, ok := err.(*kv.NotFoundError); ok && notFoundError.NotFound() {
+			if kv.IsNotFoundError(err) {
 				return nil, err
 			}
 			logrus.Infof("error finding key %q in key/value Service, trying next one: %s", key, err)


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #1008, fixes #1009 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
For Raft the `notFoundError` handling was still broken for Google Cloud KMS unseal.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
