### PR TITLE
Fix names of k8s resources in vault-secrets-webhook

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 1.3.2
-version: 1.3.5
+version: 1.3.6
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 name: vault-secrets-webhook
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -24,7 +24,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "vault-secrets-webhook.fullname" . }}
+  name: {{ include "vault-secrets-webhook.servingCertificate" . }}
   namespace: {{ .Release.Namespace }}
 data:
   tls.crt: {{ $tlsCrt }}

--- a/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
@@ -67,7 +67,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  secretName: {{ template "vault-secrets-webhook.fullname" . }}
+  secretName: {{ include "vault-secrets-webhook.servingCertificate" . }}
   duration: 8760h # 1y
   issuerRef:
     name: {{ include "vault-secrets-webhook.rootCAIssuer" . }}

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: serving-cert
           secret:
             defaultMode: 420
-            secretName: {{ template "vault-secrets-webhook.fullname" . }}
+            secretName: {{ include "vault-secrets-webhook.servingCertificate" . }}
 {{- if .Values.volumes }}
 {{ toYaml .Values.volumes | indent 8 }}
 {{- end }}

--- a/charts/vault-secrets-webhook/templates/webhook-pdb.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-pdb.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    app.kubernetes.io/name: {{ template "vault-secrets-webhook.fullname" . }}
+    app.kubernetes.io/name: {{ template "vault-secrets-webhook.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: mutating-webhook

--- a/charts/vault-secrets-webhook/templates/webhook-service.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    app.kubernetes.io/name: {{ template "vault-secrets-webhook.fullname" . }}
+    app.kubernetes.io/name: {{ template "vault-secrets-webhook.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: mutating-webhook


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix consistency of names in `vault-secrets-webhook`. I have noticed that not all `app.kubernetes.io/name` labels for Kubernetes resources were consistently named. I also noticed that `_helpers.tpl` defines `vault-secrets-webhook.servingCertificate` (by default same as `fullname`), but this value is then not used throughout the rest of the template.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Consistent names are essential to prevent issues if things get renamed. This also gets us one step closer to support multiple deployments of `vault-secrets-webhook` in a single Kubernetes cluster.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] Related Helm chart(s) updated (if needed)
