### PR TITLE
Add seal check to vault init

### DIFF
--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -102,7 +102,11 @@ from one of the followings:
 
 			initialized, err := v.RaftInitialized()
 			if err != nil {
-				logrus.Fatalf("error checking if vault is initialized: %s", err.Error())
+				sealed, sErr := v.Sealed()
+				if sErr != nil || sealed {
+					logrus.Fatalf("error checking if vault is initialized: %s", err.Error())
+				}
+				logrus.Warnf("error checking if vault is initialized, but vault is unsealed so continuing: %s", err.Error())
 			}
 
 			// If this is the first instance we have to init it, this happens once in the clusters lifetime


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1029 
| License         | Apache 2.0


### What's in this PR?
This change adds some additional logic to the vault init check.


### Why?
This addresses the use case in the related ticket so we can have vault unsealed by transit, but restrict access to the root token.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

