### PR TITLE
also remove ca.key

### DIFF
--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -2129,8 +2129,10 @@ func (r *ReconcileVault) distributeCACertificate(v *vaultv1alpha1.Vault, caSecre
 	} else {
 		delete(currentSecret.StringData, "server.crt")
 		delete(currentSecret.StringData, "server.key")
+		delete(currentSecret.StringData, "ca.key")
 		delete(currentSecret.Data, "server.crt")
 		delete(currentSecret.Data, "server.key")
+		delete(currentSecret.Data, "ca.key")
 	}
 
 	var namespaces []string


### PR DESCRIPTION
See issue [Distribute CA cert without key #1031](https://github.com/banzaicloud/bank-vaults/issues/1031)


### What's in this PR?
When distributing the ca cert to other namespaces, also remove the ca.key. This leaves the ca.crt as the only item in the secret.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)