### PR TITLE
webhook: add resource skip annotation

### DIFF
--- a/deploy/test-configmap.yaml
+++ b/deploy/test-configmap.yaml
@@ -7,7 +7,6 @@ metadata:
     vault.security.banzaicloud.io/vault-role: "default"
     vault.security.banzaicloud.io/vault-skip-verify: "true"
     vault.security.banzaicloud.io/vault-path: "kubernetes"
-    vault.security.banzaicloud.io/mutate-configmap: "true"
 data:
   aws-access-key-id: vault:secret/data/accounts/aws#AWS_ACCESS_KEY_ID
   aws-access-key-id-formatted: "vault:secret/data/accounts/aws#AWS key in base64: ${.AWS_ACCESS_KEY_ID | b64enc}"


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR introduces the resource level `vault.security.banzaicloud.io/mutate` annotation, which currently can have one possible value which is `"skip"` which prevents the mutation process (even on parsing level).

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To prevent some edge cases.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
