### PR TITLE
operator: Unset owner references on synced TLS CA secrets

### DIFF
--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -2161,6 +2161,7 @@ func (r *ReconcileVault) distributeCACertificate(v *vaultv1alpha1.Vault, caSecre
 			currentSecret.SetNamespace(namespace)
 			currentSecret.SetResourceVersion("")
 			currentSecret.GetObjectMeta().SetUID("")
+			currentSecret.SetOwnerReferences(nil)
 
 			err = createOrUpdateObjectWithClient(r.nonNamespacedClient, &currentSecret)
 			if apierrors.IsNotFound(err) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | mentioned in #899 
| License         | Apache 2.0


### What's in this PR?
Unsets owner references on TLS CA secrets that are synced to the namespaces in `CANamespaces`


### Why?

As per the K8S garbage collector docs, cross-namespace owner references are
disallowed (https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/):
```
Note: Cross-namespace owner references are disallowed by design. This means:
1) Namespace-scoped dependents can only specify owners in the same namespace,
   and owners that are cluster-scoped.
2) Cluster-scoped dependents can only specify cluster-scoped owners, but not
   namespace-scoped owners.
```

The controller is namespace scoped and in a different namespace to the synced TLS
CA secrets, hence an owner reference cannot be set here as this would violate point 1.
After a K8S leadership election, it also causes the K8S garbage collector to delete
Vault resources that have their owner set to the Vault custom resource (related issue:
https://github.com/kubernetes/kubernetes/issues/65200)
 


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

