### PR TITLE
charts: fix image tag by appVersion

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.3.3
-version: 1.3.3
-description: A Helm chart for banzaicloud/bank-vaults operator
 name: vault-operator
+version: 1.3.4
+appVersion: 1.3.3
+description: A Helm chart for banzaicloud/bank-vaults Vault operator
 home: https://banzaicloud.com/products/bank-vaults/
 sources:
   - https://github.com/hashicorp/vault

--- a/charts/vault-operator/templates/_helpers.tpl
+++ b/charts/vault-operator/templates/_helpers.tpl
@@ -47,5 +47,5 @@ If yes, it returns the string "helm3", otherwise it returns "".
 Overrideable version for container image tags.
 */}}
 {{- define "bank-vaults.version" -}}
-{{- .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
+{{- .Values.image.tag | default (printf "%s" .Chart.AppVersion) -}}
 {{- end -}}

--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,9 +1,11 @@
 apiVersion: v1
-version: 1.3.7
+name: vault-secrets-webhook
+version: 1.3.8
 appVersion: 1.3.3
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
-name: vault-secrets-webhook
 home: https://banzaicloud.com/products/bank-vaults/
+sources:
+  - https://github.com/banzaicloud/bank-vaults
 maintainers:
   - name: Banzai Cloud
     email: info@banzaicloud.com

--- a/charts/vault-secrets-webhook/templates/_helpers.tpl
+++ b/charts/vault-secrets-webhook/templates/_helpers.tpl
@@ -51,5 +51,5 @@ Create chart name and version as used by the chart label.
 Overrideable version for container image tags.
 */}}
 {{- define "bank-vaults.version" -}}
-{{- .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
+{{- .Values.image.tag | default (printf "%s" .Chart.AppVersion) -}}
 {{- end -}}

--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 1.3.5
+version: 1.3.6
 appVersion: 1.3.3
+description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/charts/vault/templates/_helpers.tpl
+++ b/charts/vault/templates/_helpers.tpl
@@ -35,5 +35,5 @@ Create chart name and version as used by the chart label.
 Overrideable version for container image tags.
 */}}
 {{- define "bank-vaults.version" -}}
-{{- .Values.unsealer.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
+{{- .Values.unsealer.image.tag | default (printf "%s" .Chart.AppVersion) -}}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1038 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fixes version image tag in charts calculated from Chart.AppVersion.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
It got messed up with an extra `v` prefix in the latest release.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
