### PR TITLE
fix image tag if omitted from values

### DIFF
--- a/charts/vault-secrets-webhook/templates/_helpers.tpl
+++ b/charts/vault-secrets-webhook/templates/_helpers.tpl
@@ -51,5 +51,5 @@ Create chart name and version as used by the chart label.
 Overrideable version for container image tags.
 */}}
 {{- define "bank-vaults.version" -}}
-{{- .Values.image.tag | default (printf "%s" .Chart.AppVersion) -}}
+{{- .Values.image.tag | default .Chart.AppVersion -}}
 {{- end -}}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| License         | Apache 2.0


### What's in this PR?
chart breaks if image.tag is not defined, since no vx.x.x images are published on dockerhub

before:
banzaicloud/vault-secrets-webhook:v1.3.3

after:
banzaicloud/vault-secrets-webhook:1.3.3

https://hub.docker.com/r/banzaicloud/vault-secrets-webhook/tags