### PR TITLE
some fixes in multi dc raft example

### DIFF
--- a/operator/deploy/multi-dc/cr-primary.yaml
+++ b/operator/deploy/multi-dc/cr-primary.yaml
@@ -56,7 +56,7 @@ spec:
         tls_cert_file: /vault/tls/server.crt
         tls_key_file: /vault/tls/server.key
     api_addr: https://vault-primary.default:8200
-    # cluster_addr: "https://${.Env.POD_NAME}:8201"
+    cluster_addr: "https://${.Env.POD_NAME}:8201"
     telemetry:
       statsd_address: localhost:9125
     ui: true

--- a/operator/deploy/multi-dc/cr-secondary.yaml
+++ b/operator/deploy/multi-dc/cr-secondary.yaml
@@ -58,7 +58,7 @@ spec:
         tls_cert_file: /vault/tls/server.crt
         tls_key_file: /vault/tls/server.key
     api_addr: https://vault-secondary.default:8200
-    # cluster_addr: "https://${.Env.POD_NAME}:8201"
+    cluster_addr: "https://${.Env.POD_NAME}:8201"
     telemetry:
       statsd_address: localhost:9125
     ui: true

--- a/operator/deploy/multi-dc/cr-tertiary.yaml
+++ b/operator/deploy/multi-dc/cr-tertiary.yaml
@@ -58,7 +58,7 @@ spec:
         tls_cert_file: /vault/tls/server.crt
         tls_key_file: /vault/tls/server.key
     api_addr: https://vault-tertiary.default:8200
-    # cluster_addr: "https://${.Env.POD_NAME}:8201"
+    cluster_addr: "https://${.Env.POD_NAME}:8201"
     telemetry:
       statsd_address: localhost:9125
     ui: true

--- a/operator/deploy/multi-dc/multi-dc-raft.sh
+++ b/operator/deploy/multi-dc/multi-dc-raft.sh
@@ -96,7 +96,7 @@ if [ $COMMAND = "install" ]; then
         cat operator/deploy/multi-dc/cr-${INSTANCE}.yaml | envtpl | kubectl apply -f -
 
         echo "Waiting for for ${INSTANCE} vault instance..."
-        waitfor waitfor kubectl get pod/vault-${INSTANCE}-0
+        waitfor kubectl get pod/vault-${INSTANCE}-0
         kubectl wait --for=condition=ready pod/vault-${INSTANCE}-0 --timeout=120s
 
         fix_elb_healthcheck vault-${INSTANCE} $REGION


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
The `cluster_addr` parameter was made a mandatory setting in a recent version of Vault and it was not set in the multi-dc examples, because the operator overwrites that value in any cases. Setting an initial value fixes this issue.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
