### PR TITLE
Chart: ability to add optional serviceaccount labels and annotations

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.3.9
+version: 1.3.10
 appVersion: 1.3.3
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/templates/webhook-rbac.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-rbac.yaml
@@ -3,6 +3,14 @@ kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "vault-secrets-webhook.fullname" . }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}  
+  {{- if .Values.serviceAccount.labels }}
+  labels:
+{{ toYaml .Values.serviceAccount.labels | indent 4 }}
+  {{- end }}
 ---
 {{- if .Values.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -27,6 +27,13 @@ service:
   externalPort: 443
   internalPort: 8443
 
+serviceAccount:
+  labels: {}
+  #  useful: label
+  annotations: {}
+  # Enables GKE workload identity
+  #  iam.gke.io/gcp-service-account: gsa@project.iam.gserviceaccount.com
+
 env:
   VAULT_image: vault:1.4.2
   # VAULT_ENV_IMAGE: banzaicloud/vault-env:1.3.2


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?

Adds the ability to specify vault-secrets-webhook Kubernetes serviceAccount optional labels and annotations from the Helm chart.

### Why?

To be able to use implicit GCR authentication through GKE workload identity, the Kubernetes serviceAccount must have specific annotations. Labels are just an extended plus.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
