### PR TITLE
operator: allow VAULT_ADDR to be overridden

### DIFF
--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -192,6 +192,18 @@ spec:
     - name: VAULT_STORAGE_FILE
       value: "/vault/file"
 
+  # If you are using a custom certificate and are setting the hostname in a custom way
+  # sidecarEnvsConfig:
+  #   - name: VAULT_ADDR
+  #     value: https://vault.local:8200
+
+  # # https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  # vaultPodSpec:
+  #   hostAliases:
+  #   - ip: "127.0.0.1"
+  #     hostnames:
+  #     - "vault.local"
+
   # Marks presence of Istio, which influences things like port namings
   istioEnabled: false
 

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -301,9 +301,13 @@ type VaultSpec struct {
 	// default:
 	VolumeClaimTemplates []v1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
 
-	// VaultEnvsConfig is a list of Kubernetes environment variable definitions that will be passed to Vault Pods.
+	// VaultEnvsConfig is a list of Kubernetes environment variable definitions that will be passed to the Vault container.
 	// default:
 	VaultEnvsConfig []v1.EnvVar `json:"vaultEnvsConfig"`
+
+	// SidecarEnvsConfig is a list of Kubernetes environment variable definitions that will be passed to Vault sidecar containers.
+	// default:
+	SidecarEnvsConfig []v1.EnvVar `json:"sidecarEnvsConfig"`
 
 	// Resources defines the resource limits for all the resources created by the operator.
 	// See the type for more details.

--- a/operator/pkg/apis/vault/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/vault/v1alpha1/zz_generated.deepcopy.go
@@ -507,6 +507,13 @@ func (in *VaultSpec) DeepCopyInto(out *VaultSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.SidecarEnvsConfig != nil {
+		in, out := &in.SidecarEnvsConfig, &out.SidecarEnvsConfig
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = new(Resources)

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1300,7 +1300,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 			Name:            "bank-vaults",
 			Command:         unsealCommand,
 			Args:            append(v.Spec.UnsealConfig.Options.ToArgs(), v.Spec.UnsealConfig.ToArgs(v)...),
-			Env: withTLSEnv(v, true, withCredentialsEnv(v, withCommonEnv(v, []corev1.EnvVar{
+			Env: withSidecarEnv(v, withTLSEnv(v, true, withCredentialsEnv(v, withCommonEnv(v, []corev1.EnvVar{
 				{
 					Name: "POD_NAME",
 					ValueFrom: &corev1.EnvVarSource{
@@ -1309,7 +1309,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 						},
 					},
 				},
-			}))),
+			})))),
 			Ports: []corev1.ContainerPort{{
 				Name:          "metrics",
 				ContainerPort: 9091,
@@ -1942,6 +1942,14 @@ func withVaultEnv(v *vaultv1alpha1.Vault, envs []corev1.EnvVar) []corev1.EnvVar 
 
 func withCommonEnv(v *vaultv1alpha1.Vault, envs []corev1.EnvVar) []corev1.EnvVar {
 	for _, env := range v.Spec.EnvsConfig {
+		envs = append(envs, env)
+	}
+
+	return envs
+}
+
+func withSidecarEnv(v *vaultv1alpha1.Vault, envs []corev1.EnvVar) []corev1.EnvVar {
+	for _, env := range v.Spec.SidecarEnvsConfig {
 		envs = append(envs, env)
 	}
 


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1049 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Adds the ability to pass in environment variables to the sidecar container, so Vault can be accessed on a different address for example, see example.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To be able to customize the sidecar only, for using custom certificates e.g..

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
