### PR TITLE
Support k8s downward api in vault chart environment variables

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault
-version: 1.3.6
+version: 1.3.7
 appVersion: 1.3.3
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/

--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -56,9 +56,8 @@ spec:
               name: {{ .secretName }}
               key: {{ .secretKey }}
         {{- end }}
-        {{- range .Values.vault.envs }}
-        - name: {{ .name }}
-          value: {{ .value}}
+        {{- if .Values.vault.envs }}
+{{ toYaml .Values.vault.envs | indent 8 }}
         {{- end }}
         volumeMounts:
         - name: vault-raw-config
@@ -84,10 +83,9 @@ spec:
           {{ else }}
           value: https://127.0.0.1:{{ .Values.service.port }}
           {{ end }}
-        {{- range .Values.vault.envs }}
-        - name: {{ .name }}
-          value: {{ .value}}
-        {{- end }}
+          {{- if .Values.vault.envs }}
+{{ toYaml .Values.vault.envs | indent 8 }}
+          {{- end }}
         envFrom:
         {{- range .Values.vault.customSecrets }}
         - secretRef:
@@ -161,9 +159,8 @@ spec:
               name: {{ .secretName }}
               key: {{ .secretKey }}
         {{- end }}
-        {{- range .Values.vault.envs }}
-        - name: {{ .name }}
-          value: {{ .value}}
+        {{- if .Values.vault.envs }}
+{{ toYaml .Values.vault.envs | indent 8 }}
         {{- end }}
         envFrom:
         {{- range .Values.vault.customSecrets }}
@@ -203,9 +200,8 @@ spec:
               name: {{ .secretName }}
               key: {{ .secretKey }}
         {{- end }}
-        {{- range .Values.vault.envs }}
-        - name: {{ .name }}
-          value: {{ .value}}
+        {{- if .Values.vault.envs }}
+{{ toYaml .Values.vault.envs | indent 8 }}
         {{- end }}
         envFrom:
         {{- range .Values.vault.customSecrets }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature? |   yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | None
| License         | Apache 2.0


### What's in this PR?
The vault chart expects environmental variables in the form of name/value pairs and will
remove variables using the [k8s downward api](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#the-downward-api).


### Why?
At the moment you cannot use environment variable like 
```      
env:
  - name: MY_NODE_NAME
    valueFrom:
      fieldRef:
        fieldPath: spec.nodeName
```
as they are not in the form of simple name/value pairs.
### Additional context
This is useful so that vault can access the downward api. It could be used to set the api_addr and cluster_addr and we would use also use it to set the node_ip for Datadog integration. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)

### To Do
Completed.