### PR TITLE
[charts/vault] Add option for headless service

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault
-version: 1.3.7
+version: 1.3.8
 appVersion: 1.3.3
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/

--- a/charts/vault/templates/service-headless.yaml
+++ b/charts/vault/templates/service-headless.yaml
@@ -1,28 +1,27 @@
+{{- if .Values.headlessService.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "vault.fullname" . }}
+  name: {{ template "vault.fullname" . }}-headless
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/name: {{ template "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
-    {{- range $key, $value := .Values.service.annotations }}
+    {{- range $key, $value := .Values.headlessService.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
-  type: {{ .Values.service.type }}
-  {{- if .Values.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
-  {{- end }}
+  clusterIP: None
   ports:
-  - port: {{ .Values.service.port }}
+  - port: {{ .Values.headlessService.port }}
     protocol: TCP
-    name: {{ .Values.service.name }}
-  - port: {{ add .Values.service.port 1 }}
+    name: {{ .Values.headlessService.name }}
+  - port: {{ add .Values.headlessService.port 1 }}
     protocol: TCP
-    name: {{ .Values.service.name }}-cluster
+    name: {{ .Values.headlessService.name }}-cluster
   selector:
     app.kubernetes.io/name: {{ template "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -17,6 +17,14 @@ service:
   # loadBalancerIP: 1.2.3.4
   # annotations:
   #   cloud.google.com/load-balancer-type: "Internal"
+
+headlessService:
+  enabled: false
+  name: vault
+  port: 8200
+  # annotations:
+  #   external-dns.alpha.kubernetes.io/hostname: vault.mydomain.com
+
 ingress:
   enabled: false
   # Used to create Ingress record (should used with service.type: ClusterIP).


### PR DESCRIPTION
Signed-off-by: Sam Weston <weston.sam@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0

### What's in this PR?
Adds the option to enable a headless service for Vault in addition to the normal service. Also fixes indentation for the annotations on the normal service.

### Why?
We wanted a headless service so we could expose Vault on Amazon EKS within our VPC without paying for a LoadBalancer.

### Checklist
- [N/A] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [N/A] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)