### PR TITLE
[charts/vault] Option to use cert-manager to generate certs

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault
-version: 1.3.8
+version: 1.3.9
 appVersion: 1.3.3
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/

--- a/charts/vault/templates/certificate.yaml
+++ b/charts/vault/templates/certificate.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.certManager.issuer.enabled -}}
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: {{ template "vault.fullname" . }}-server-tls
+spec:
+  selfSigned: {}
+{{- end }}
+---
+{{- if .Values.certManager.certificate.enabled -}}
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ template "vault.fullname" . }}-server-tls
+spec:
+  dnsNames: 
+    - {{ template "vault.fullname" . }}
+  {{- with .Values.certManager.certificate.additionalDomains }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ipAddresses:
+    - 127.0.0.1
+  secretName: {{ template "vault.fullname" . }}-server-tls
+  issuerRef:
+    {{- if .Values.certManager.certificate.issuerRef }}
+    name: {{ .Values.certManager.certificate.issuerRef }}
+    {{- else }}
+    name: {{ template "vault.fullname" . }}-server-tls
+    {{- end }}
+{{- end }}

--- a/charts/vault/templates/secret.yaml
+++ b/charts/vault/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.tls.secretName }}
+{{- if and (not .Values.tls.secretName) (not .Values.certManager.certificate.enabled) }}
 {{- $cn := include "vault.fullname" . -}}
 {{- $externalDNS := print $cn "." .Release.Namespace -}}
 {{- $ca := genCA "vault-ca" 365 -}}

--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -282,6 +282,8 @@ spec:
           secret:
             {{- if .Values.tls.secretName }}
             secretName: "{{ .Values.tls.secretName }}"
+            {{- else if .Values.certManager.certificate.enabled }}
+            secretName: "{{ template "vault.fullname" . }}-server-tls"
             {{- else }}
             secretName: "{{ template "vault.fullname" . }}-tls"
             {{- end }}

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -156,6 +156,10 @@ vault:
         # tls_disable: true
         tls_cert_file: /vault/tls/server.crt
         tls_key_file: /vault/tls/server.key
+        # If certManager.certificate is enabled use these parameters intead
+        # tls_client_ca_file: /vault/tls/ca.crt
+        # tls_cert_file: /vault/tls/tls.crt
+        # tls_key_file: /vault/tls/tls.key
 
     telemetry:
       statsd_address: localhost:9125
@@ -269,3 +273,14 @@ prometheusStatsdExporter:
     requests:
       cpu: 50m
       memory: 128Mi
+
+# Please see necessary changes to vault.config.listener.tcp above if enabled
+# Either issuerRef must be set to your Issuer or issuer must be enabled to generate a SelfSigned one
+certManager:
+  issuer:
+    enabled: false
+  certificate:
+    enabled: false
+    # issuerRef:
+    # additionalDomains:
+    #   - vault.mydomain.com


### PR DESCRIPTION
Signed-off-by: Sam Weston <weston.sam@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
The option use cert-manager to generate the Vault certs rather than Helm.

### Why?
Regeneration every Helm apply was an annoyance for us and cert-manager gives us more flexibility.

### Checklist
- [N/A] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [N/A] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
