### PR TITLE
make affinity configurable in helm chart.

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault
-version: 1.3.6
+version: 1.3.7
 appVersion: 1.3.3
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/

--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault
-version: 1.3.9
+version: 1.3.10
 appVersion: 1.3.3
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/

--- a/charts/vault/README.md
+++ b/charts/vault/README.md
@@ -139,6 +139,7 @@ The following tables lists the configurable parameters of the vault chart and th
 | `rbac.psp.enabled`      | Use pod security policy             | `false`                                             |
 | `nodeSelector`          | Node labels for pod assignment. https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector                                                   | `{}`                                                |
 | `tolerations`           | List of node tolerations for the pods. https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/                                                           | `[]`                                |
+| `affinity`           | Node affinity settings for the pods. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/                                                          |  If not set it defaults to`podAntiAffinity` to `preferredDuringSchedulingIgnoredDuringExecution` |
 | `labels`                | Additonal labels to be applied to the Vault StatefulSet and Pods | `{}`                   |
 | `tls.secretName`        | Custom TLS certifcate secret name    | `""`                                               |
 

--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -241,6 +241,9 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}
       affinity:
+{{- if .Values.affinity }}
+{{ toYaml .Values.affinity | indent 8 }}
+{{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
@@ -250,6 +253,7 @@ spec:
                 matchLabels:
                   app.kubernetes.io/name: {{ template "vault.fullname" . }}
                   app.kubernetes.io/instance: {{ .Release.Name | quote }}
+{{- end }}
       serviceAccountName: {{ template "vault.fullname" . }}
       securityContext:
         fsGroup: 65534

--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -56,9 +56,8 @@ spec:
               name: {{ .secretName }}
               key: {{ .secretKey }}
         {{- end }}
-        {{- range .Values.vault.envs }}
-        - name: {{ .name }}
-          value: {{ .value}}
+        {{- if .Values.vault.envs }}
+{{ toYaml .Values.vault.envs | indent 8 }}
         {{- end }}
         volumeMounts:
         - name: vault-raw-config
@@ -84,10 +83,9 @@ spec:
           {{ else }}
           value: https://127.0.0.1:{{ .Values.service.port }}
           {{ end }}
-        {{- range .Values.vault.envs }}
-        - name: {{ .name }}
-          value: {{ .value}}
-        {{- end }}
+          {{- if .Values.vault.envs }}
+{{ toYaml .Values.vault.envs | indent 8 }}
+          {{- end }}
         envFrom:
         {{- range .Values.vault.customSecrets }}
         - secretRef:
@@ -161,9 +159,8 @@ spec:
               name: {{ .secretName }}
               key: {{ .secretKey }}
         {{- end }}
-        {{- range .Values.vault.envs }}
-        - name: {{ .name }}
-          value: {{ .value}}
+        {{- if .Values.vault.envs }}
+{{ toYaml .Values.vault.envs | indent 8 }}
         {{- end }}
         envFrom:
         {{- range .Values.vault.customSecrets }}
@@ -203,9 +200,8 @@ spec:
               name: {{ .secretName }}
               key: {{ .secretKey }}
         {{- end }}
-        {{- range .Values.vault.envs }}
-        - name: {{ .name }}
-          value: {{ .value}}
+        {{- if .Values.vault.envs }}
+{{ toYaml .Values.vault.envs | indent 8 }}
         {{- end }}
         envFrom:
         {{- range .Values.vault.customSecrets }}

--- a/charts/vault/templates/tests/test-vault-status.yaml
+++ b/charts/vault/templates/tests/test-vault-status.yaml
@@ -12,10 +12,10 @@ spec:
       - name: VAULT_SKIP_VERIFY
         value: "true"
       - name: VAULT_ADDR
-      {{ if .Values.vault.config.listener.tcp.tls_disable }}
+      {{- if .Values.vault.config.listener.tcp.tls_disable }}
         value: http://{{ template "vault.fullname" . }}:8200
-      {{ else }}
+      {{- else }}
         value: https://{{ template "vault.fullname" . }}:8200
-      {{ end }}
+      {{- end }}
     command: ["sh", "-c", "vault status"]
   restartPolicy: Never

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -91,6 +91,9 @@ tolerations: []
 #   operator: Equal
 #   value: "value"
 
+## Add affinity (defaults sets podAntiAffinity to preferredDuringSchedulingIgnoredDuringExecution)
+affinity: {}
+
 # Specify a secret which holds your custom TLS certificate.
 # If not specified Helm will generate one for you.
 # See templates/secret.yaml for the exact format.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | None
| License         | Apache 2.0


### What's in this PR?
This makes pod affinity configurable.


### Why?
The chart uses preferred anti-affinity while we want to use required anti-affinity as we run on spots.

### Additional context
If no affinity is defined the chart will work as before using the affinity values defined in the template.
(I also removed white space in the helm test that I introduced in a previous PR.)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)

