### PR TITLE
webhook: use admissionregistration.k8s.io/v1 in registration wherever possible

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.4.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -32,7 +32,11 @@ data:
   ca.crt:  {{ $caCrt }}
 {{- end }}
 ---
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "vault-secrets-webhook.fullname" . }}
@@ -43,6 +47,7 @@ metadata:
 {{- end }}
 webhooks:
 - name: pods.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  admissionReviewVersions: ["v1beta1"]
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}
@@ -83,7 +88,11 @@ webhooks:
       values:
       - skip
 {{- end }}
+{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
+  sideEffects: {{ .Values.apiSideEffectValue }}
+{{- end }}
 - name: secrets.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  admissionReviewVersions: ["v1beta1"]
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}
@@ -114,8 +123,12 @@ webhooks:
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
+{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
+  sideEffects: {{ .Values.apiSideEffectValue }}
+{{- end }}
 {{- if .Values.configMapMutation }}
 - name: configmaps.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  admissionReviewVersions: ["v1beta1"]
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}
@@ -146,9 +159,13 @@ webhooks:
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
+{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
+  sideEffects: {{ .Values.apiSideEffectValue }}
+{{- end }}
 {{- end }}
 {{- if .Values.customResourceMutations }}
 - name: objects.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  admissionReviewVersions: ["v1beta1"]
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}
@@ -190,7 +207,7 @@ webhooks:
       values:
       - skip
 {{- end }}
-{{- end }}
 {{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
   sideEffects: {{ .Values.apiSideEffectValue }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | partially #1071 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Use `apiVersion: admissionregistration.k8s.io/v1` for webhooks after in case of Kubernetes > 1.16.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
`apiVersion: admissionregistration.k8s.io/v1beta1` got deprecated in 1.16 and might cause issues in some distros.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] Related Helm chart(s) updated (if needed)

