### PR TITLE
operator: add labels to deployments and statefulsets as well

### DIFF
--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1067,6 +1067,7 @@ func deploymentForConfigurer(v *vaultv1alpha1.Vault, configmaps corev1.ConfigMap
 			Name:        v.Name + "-configurer",
 			Namespace:   v.Namespace,
 			Annotations: withVaultConfigurerAnnotations(v, map[string]string{}),
+			Labels:      withVaultConfigurerLabels(v, ls),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
@@ -1429,6 +1430,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 			Name:        v.Name,
 			Namespace:   v.Namespace,
 			Annotations: withVaultAnnotations(v, getCommonAnnotations(v, map[string]string{})),
+			Labels:      withVaultLabels(v, ls),
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &replicas,


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1077 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add labels to Vault Statefulset and to the configurer deployment as well.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
It is expected to be there.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
