### PR TITLE
Allow the vault-env repository to be overridden.

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.4.2
+version: 1.4.3
 appVersion: 1.4.1
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -100,6 +100,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | image.repository                 | image repo that contains the admission server                                | `banzaicloud/vault-secrets-webhook` |
 | image.tag                        | image tag                                                                    | `1.4.1`                             |
 | image.imagePullSecrets           | image pull secrets for private repositories                                  | `[]`                                |
+| vault_env.repository             | image repo that contains the vault-env container                             | `banzaicloud/vault-env`             |
 | namespaceSelector                | namespace selector to use, will limit webhook scope                          | `{}`                                |
 | objectSelector                | object selector to use, will limit webhook scope (K8s version 1.15+)            | `{}`                                |
 | nodeSelector                     | node selector to use                                                         | `{}`                                |

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -100,7 +100,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | image.repository                 | image repo that contains the admission server                                | `banzaicloud/vault-secrets-webhook` |
 | image.tag                        | image tag                                                                    | `1.4.1`                             |
 | image.imagePullSecrets           | image pull secrets for private repositories                                  | `[]`                                |
-| vault_env.repository             | image repo that contains the vault-env container                             | `banzaicloud/vault-env`             |
+| vaultEnv.repository             | image repo that contains the vault-env container                             | `banzaicloud/vault-env`             |
 | namespaceSelector                | namespace selector to use, will limit webhook scope                          | `{}`                                |
 | objectSelector                | object selector to use, will limit webhook scope (K8s version 1.15+)            | `{}`                                |
 | nodeSelector                     | node selector to use                                                         | `{}`                                |

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -64,7 +64,7 @@ spec:
               value: "debug"
             {{- end }}
             - name: VAULT_ENV_IMAGE
-              value: "{{ .Values.vault_env.repository }}:{{ include "vault-secrets-webhook.bank-vaults.version" . }}"
+              value: "{{ .Values.vaultEnv.repository }}:{{ include "vault-secrets-webhook.bank-vaults.version" . }}"
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -64,7 +64,7 @@ spec:
               value: "debug"
             {{- end }}
             - name: VAULT_ENV_IMAGE
-              value: "banzaicloud/vault-env:{{ include "vault-secrets-webhook.bank-vaults.version" . }}"
+              value: "{{ .Values.vault_env.repository }}:{{ include "vault-secrets-webhook.bank-vaults.version" . }}"
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -34,9 +34,11 @@ serviceAccount:
   # Enables GKE workload identity
   #  iam.gke.io/gcp-service-account: gsa@project.iam.gserviceaccount.com
 
+vault_env:
+  repository: banzaicloud/vault-env
+
 env:
   VAULT_IMAGE: vault:1.5.0
-  # VAULT_ENV_IMAGE: banzaicloud/vault-env:1.4.0
   # VAULT_CAPATH: /vault/tls
   # used when the pod that should get secret injected does not specify
   # an imagePullSecret

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -34,7 +34,7 @@ serviceAccount:
   # Enables GKE workload identity
   #  iam.gke.io/gcp-service-account: gsa@project.iam.gserviceaccount.com
 
-vault_env:
+vaultEnv:
   repository: banzaicloud/vault-env
 
 env:


### PR DESCRIPTION
Fixes issue #1075 to allow for the vault-env repository to be overridden via the values file.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | yes
| Deprecations?   | yes
| Related tickets | Fixes #1075 
| License         | Apache 2.0


### What's in this PR?
Allows the repository for the vault-env container, injected into deployments etc, to be overridden.  Primarily necessary in environments where dockerhub is not available due to firewalls or access rules.


### Why?
My employer has secure environments where we need to use this chart, and make use of an Artifactory installation to serve our images.  We can't directly pull from docker.io, and upload images directly to our instance once they have been reviewed and approved.


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
