### PR TITLE
webhook: allow adding auth-delegator role in the chart

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.4.4
+version: 1.4.5
 appVersion: 1.4.2
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -114,6 +114,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | tolerations                      | tolerations to add                                                           | `[]`                                |
 | rbac.enabled                     | use rbac                                                                     | `true`                              |
 | rbac.psp.enabled                 | use pod security policy                                                      | `false`                             |
+| rbac.authDelegatorRole.enabled    | bind `system:auth-delegator` to the ServiceAccount                          | `false`                             |
 | env.VAULT_IMAGE                  | vault image                                                                  | `vault:1.5.0`                      |
 | volumes                          | extra volume definitions                                                     | `[]`                                |
 | volumeMounts                     | extra volume mounts                                                          | `[]`                                |

--- a/charts/vault-secrets-webhook/templates/webhook-rbac.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-rbac.yaml
@@ -56,4 +56,18 @@ subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
   name: {{ template "vault-secrets-webhook.fullname" . }}
+{{- if .Values.rbac.authDelegatorRole.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "vault-secrets-webhook.fullname" . }}-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "vault-secrets-webhook.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -87,6 +87,8 @@ rbac:
   enabled: true
   psp:
     enabled: false
+  authDelegatorRole:
+    enabled: false
 
 # A list of Kubernetes resource types to mutate as well:
 # Example: ["ingresses", "servicemonitors"]


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1099
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add `system:auth-delegator` to the webhook ServiceAccount optionally.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To be able to authenticate via the webhook SA in an external Vault cluster.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
