### PR TITLE
operator: fix single cluster raft with LoadBalancer serviceType

### DIFF
--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1676,7 +1676,11 @@ func withClusterAddr(v *vaultv1alpha1.Vault, service *corev1.Service, envs []cor
 		value = ingressPoints[len(ingressPoints)-1]
 	}
 
-	if value != "" {
+	// Only applies to multi-cluster setups:
+	// This currently allows only one instance per cluster,
+	// since the cluster_addr is bound to the LB address.
+	// Possible workaround: 1 LB/Vault member instance.
+	if value != "" && v.Spec.RaftLeaderAddress != "" {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "VAULT_CLUSTER_ADDR",
 			Value: "https://" + value + ":8201",


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | partially #1085 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Only apply custom VAULT_CLUSTER_ADDR in case of multi-cluster setups when using LoadBalancer.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Otherwise the default `cluster_addr: "https://${.Env.POD_NAME}:8201"` from the Vault config should work fine.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
