### PR TITLE
[charts/vault-operator]Add PSP for vault-operator and vault that is deployed by the oerator

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-operator
-version: 1.4.2
+version: 1.4.3
 appVersion: 1.4.2
 description: A Helm chart for banzaicloud/bank-vaults Vault operator
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-operator/README.md
+++ b/charts/vault-operator/README.md
@@ -55,6 +55,8 @@ The following table lists the configurable parameters of the vault chart and the
 | `resources.limits.memory`   | Container memory limit                      | `256Mi`                                             |
 | `crdAnnotations`            | Annotations for the Vault CRD               | `{}`                                                |
 | `etcd-operator.enabled`     | Install etcd operator as well               | `false`                                             |
+| `psp.enabled`               | Deploy PSP resources                        | `false`                                             |
+| `psp.vaultSA`               | Used service account for vault              | `vault`                                             |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/charts/vault-operator/templates/psp.yaml
+++ b/charts/vault-operator/templates/psp.yaml
@@ -37,7 +37,7 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ .Values.psp.vaultSA | default "vault" }}
+  name: {{ .Values.psp.vaultSA }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'

--- a/charts/vault-operator/templates/psp.yaml
+++ b/charts/vault-operator/templates/psp.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.psp.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "vault-operator.fullname" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Values.psp.vaultSA | default "vault" }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - IPC_LOCK
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+    - 'projected'
+  hostNetwork: false
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/vault-operator/templates/role.yaml
+++ b/charts/vault-operator/templates/role.yaml
@@ -96,12 +96,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: psp:{{ .Values.psp.vaultSA | default "vault" }}
+  name: psp:{{ .Values.psp.vaultSA }}
 rules:
 - apiGroups:
   - policy
   resourceNames:
-  - {{ .Values.psp.vaultSA | default "vault" }}
+  - {{ .Values.psp.vaultSA }}
   resources:
   - podsecuritypolicies
   verbs:

--- a/charts/vault-operator/templates/role.yaml
+++ b/charts/vault-operator/templates/role.yaml
@@ -77,3 +77,33 @@ rules:
   - get
   - create
   - watch
+{{- if .Values.psp.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp:{{ include "vault-operator.fullname" . }}
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - {{ include "vault-operator.fullname" . }}
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp:{{ .Values.psp.vaultSA | default "vault" }}
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - {{ .Values.psp.vaultSA | default "vault" }}
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+{{- end }}

--- a/charts/vault-operator/templates/rolebinding.yaml
+++ b/charts/vault-operator/templates/rolebinding.yaml
@@ -12,3 +12,33 @@ roleRef:
   kind: ClusterRole
   name: {{ include "vault-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- if .Values.psp.enabled }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: psp:{{ include "vault-operator.fullname" . }}
+  labels:
+    helm.sh/chart: {{ include "vault-operator.chart" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "vault-operator.fullname" . }}
+roleRef:
+  kind: Role
+  name: psp:{{ include "vault-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: psp:{{ .Values.psp.vaultSA | default "vault" }}
+  labels:
+    helm.sh/chart: {{ include "vault-operator.chart" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.psp.vaultSA | default "vault" }}
+roleRef:
+  kind: Role
+  name: psp:{{ .Values.psp.vaultSA | default "vault" }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/vault-operator/templates/rolebinding.yaml
+++ b/charts/vault-operator/templates/rolebinding.yaml
@@ -31,14 +31,14 @@ roleRef:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: psp:{{ .Values.psp.vaultSA | default "vault" }}
+  name: psp:{{ .Values.psp.vaultSA }}
   labels:
     helm.sh/chart: {{ include "vault-operator.chart" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.psp.vaultSA | default "vault" }}
+  name: {{ .Values.psp.vaultSA }}
 roleRef:
   kind: Role
-  name: psp:{{ .Values.psp.vaultSA | default "vault" }}
+  name: psp:{{ .Values.psp.vaultSA }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/vault-operator/values.yaml
+++ b/charts/vault-operator/values.yaml
@@ -71,3 +71,7 @@ etcd-operator:
     commandArgs:
       cluster-wide: true
       create-crd: false
+
+psp:
+  enable: false
+  vaultSA: ""

--- a/charts/vault-operator/values.yaml
+++ b/charts/vault-operator/values.yaml
@@ -74,4 +74,4 @@ etcd-operator:
 
 psp:
   enable: false
-  vaultSA: ""
+  vaultSA: "vault"


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1109 
| License         | Apache 2.0


### What's in this PR?
Add PSP for `vault-operator` and `vault` that is deployed by the operator.

### Why?
If `PodSecurityPolicy` is enabled it will be useful to set a flag to deploy the necessary PSP resources via helm.
