### PR TITLE
fix: move VAULT_ENV_FROM_PATH to mutateContainers

### DIFF
--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -107,13 +107,6 @@ func (mw *mutatingWebhook) mutatePod(pod *corev1.Pod, vaultConfig VaultConfig, n
 		})
 	}
 
-	if vaultConfig.VaultEnvFromPath != "" {
-		containerEnvVars = append(containerEnvVars, corev1.EnvVar{
-			Name:  "VAULT_ENV_FROM_PATH",
-			Value: vaultConfig.VaultEnvFromPath,
-		})
-	}
-
 	if initContainersMutated || containersMutated || vaultConfig.CtConfigMap != "" || vaultConfig.AgentConfigMap != "" {
 		var agentConfigMapName string
 
@@ -358,6 +351,13 @@ func (mw *mutatingWebhook) mutateContainers(containers []corev1.Container, podSp
 			container.Env = append(container.Env, corev1.EnvVar{
 				Name:  "VAULT_ENV_DAEMON",
 				Value: "true",
+			})
+		}
+
+		if vaultConfig.VaultEnvFromPath != "" {
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  "VAULT_ENV_FROM_PATH",
+				Value: vaultConfig.VaultEnvFromPath,
 			})
 		}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
When adding the env-from-path annotation, I was incorrectly mutating the pod instead of the container.  This fix is to actually mutate the container.  The work around for this is to explicitly add `VAULT_ENV_FROM_PATH` environment variable to the container.

### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

