### PR TITLE
vault-mutating-webhook: allow specifying pod securityContext and full container securityContext

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.5.0
+version: 1.5.1
 appVersion: 1.5.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -128,6 +128,8 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | certificate.server.tls.crt       | Base64 encoded TLS certificate signed by the CA                              | ``                                  |
 | certificate.server.tls.key       | Base64 encoded  private key of TLS certificate signed by the CA              | ``                                  |
 | apiSideEffectValue               | Webhook sideEffect value                                                     | `NoneOnDryRun`                      |
+| securityContext                  | Container security context for webhook deployment                            | `{ runAsUser: 65534, allowPrivaledgeEscalation: false }` |
+| podSecurityContext               | Pod security context for webhook deployment                                  | `{}`                                |
 
 ### Certificate options
 

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -98,3 +98,7 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
   {{- end }}
+  {{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+  {{- end }}

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -83,11 +83,7 @@ spec:
 {{- if .Values.volumeMounts }}
 {{ toYaml .Values.volumeMounts | indent 12 }}
 {{- end }}
-          securityContext:
-            {{- if .Values.securityContext.runAsUser }}
-            runAsUser: {{ .Values.securityContext.runAsUser }}
-            {{- end }}
-            allowPrivilegeEscalation: false
+          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- if .Values.nodeSelector }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -57,6 +57,7 @@ metrics:
 
 securityContext:
   runAsUser: 65534
+  allowPrivilegeEscalation: false
 
 volumes: []
 # - name: vault-tls

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -59,6 +59,8 @@ securityContext:
   runAsUser: 65534
   allowPrivilegeEscalation: false
 
+podSecurityContext: {}
+
 volumes: []
 # - name: vault-tls
 #   secret:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

It is not possible to specify full gamut of `pod.spec.container[].securityContext` or `pod.spec.securityContext` without modifying the chart itself. In our case, we needed to set `pod.spec.securityContext.fsGroup` to the same group as the user in order to be compatible with AWS [OIDC EKS IAM](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html). This PR includes a minor fix to allow specifying all `securityContext` options on the webhook deployment. There should be no effective change unless custom options are set.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Users who may have set custom options and not realized they were unset may be affected. We tested the implementation on our in-house setup and verified options can be set appropriately.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] (not needed) User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
