### PR TITLE
configurer: exit early if possible before touching the API

### DIFF
--- a/internal/vault/operator_client.go
+++ b/internal/vault/operator_client.go
@@ -543,6 +543,10 @@ func (v *vault) configureAuthMethods(config *viper.Viper) error {
 		return errors.Wrap(err, "error unmarshalling vault auth methods config")
 	}
 
+	if len(authMethods) == 0 {
+		return nil
+	}
+
 	existingAuths, err := v.cl.Sys().ListAuth()
 	if err != nil {
 		return errors.Wrap(err, "error listing auth backends vault")
@@ -994,6 +998,10 @@ func (v *vault) configurePlugins(config *viper.Viper) error {
 	err := config.UnmarshalKey("plugins", &plugins)
 	if err != nil {
 		return errors.Wrap(err, "error unmarshalling vault plugins config")
+	}
+
+	if len(plugins) == 0 {
+		return nil
 	}
 
 	listPlugins, err := v.cl.Sys().ListPlugins(&api.ListPluginsInput{})


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
In some stricter deployments, it is not allowed to list plugins, auth backends so exit if we are not required to touch them.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
