### PR TITLE
Custom fluentd conf path

### DIFF
--- a/operator/deploy/cr-audit.yaml
+++ b/operator/deploy/cr-audit.yaml
@@ -24,6 +24,7 @@ spec:
 
   fluentdEnabled: true
   fluentdImage: banzaicloud/fluentd-s3:latest
+  fleuntdConfLocation: "/fluentd/etc"
   fluentdConfig: |
     <source>
       @type tail

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -148,6 +148,10 @@ type VaultSpec struct {
 	// default: fluent/fluentd:stable
 	FluentDImage string `json:"fluentdImage"`
 
+	// FleuntDConfLocation is the location of the fluent.conf file
+	// default: "/fluentd/etc"
+	FleuntDConfLocation string `json:"fleuntdConfLocation"`
+
 	// FluentDConfig specifices the FluentD configuration to use for Vault log exportation
 	// default:
 	FluentDConfig string `json:"fluentdConfig"`
@@ -658,6 +662,14 @@ func (spec *VaultSpec) GetFluentDImage() string {
 		return "fluent/fluentd:edge"
 	}
 	return spec.FluentDImage
+}
+
+// GetFluentDConfMountPath returns the mount path for the fluent.conf
+func (spec *VaultSpec) GetFleuntDConfLocation() string {
+	if spec.FleuntDConfLocation == "" {
+		return "/fluentd/etc"
+	}
+	return spec.FleuntDConfLocation
 }
 
 // IsFluentDEnabled returns true if fluentd sidecar is to be deployed

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1792,7 +1792,7 @@ func withAuditLogContainer(v *vaultv1alpha1.Vault, containers []corev1.Container
 				},
 				{
 					Name:      "fluentd-config",
-					MountPath: "/fluentd/etc",
+					MountPath: v.Spec.GetFleuntDConfLocation(),
 				},
 			}),
 		})


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1135 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Enable setting custom path for fluent.conf

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
We are using a custom fluentd image that expects `fluent.conf` to be under `/etc/fluent/` and we need a way to customise it.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ Y ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ Y ] User guide and development docs updated (if needed)
- [ Y ] Related Helm chart(s) updated (if needed)

