### PR TITLE
Fix linting in Helm 3.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,14 +216,14 @@ workflows:
 
   helm-chart:
     jobs:
-      - helm2/lint-chart:
+      - helm/lint-chart:
           executor: helm/helm2
           charts-dir: charts
           filters:
             tags:
               ignore: /.*/
 
-      - helm3/lint-chart:
+      - helm/lint-chart:
           executor: helm/helm3
           charts-dir: charts
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,8 +216,15 @@ workflows:
 
   helm-chart:
     jobs:
-      - helm/lint-chart:
+      - helm2/lint-chart:
           executor: helm/helm2
+          charts-dir: charts
+          filters:
+            tags:
+              ignore: /.*/
+
+      - helm3/lint-chart:
+          executor: helm/helm3
           charts-dir: charts
           filters:
             tags:

--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -4,6 +4,7 @@ version: 1.3.5
 appVersion: 1.3.3
 description: A Helm chart for banzaicloud/bank-vaults Vault operator
 home: https://banzaicloud.com/products/bank-vaults/
+icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:
   - https://github.com/hashicorp/vault
   - https://github.com/banzaicloud/bank-vaults
@@ -11,4 +12,3 @@ sources:
 maintainers:
   - name: Banzai Cloud
     email: info@banzaicloud.com
-type: application

--- a/charts/vault-operator/README.md
+++ b/charts/vault-operator/README.md
@@ -4,7 +4,7 @@ This directory contains a Kubernetes Helm chart to deploy the Banzai Cloud Vault
 
 ## Prerequisites Details
 
-* Kubernetes 1.6+
+* Kubernetes 1.16+
 
 ## Chart Details
 

--- a/charts/vault-operator/templates/crd.yaml
+++ b/charts/vault-operator/templates/crd.yaml
@@ -1,5 +1,5 @@
 {{- if not (include "isHelm3" .) }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: vaults.vault.banzaicloud.com

--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -4,6 +4,7 @@ version: 1.3.10
 appVersion: 1.3.3
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/
+icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:
   - https://github.com/banzaicloud/bank-vaults
 maintainers:

--- a/charts/vault/templates/rolebinding.yaml
+++ b/charts/vault/templates/rolebinding.yaml
@@ -1,40 +1,37 @@
 {{- if .Values.rbac.enabled }}
-apiVersion: v1
-kind: List
-metadata: {}
-items:
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRoleBinding
-  metadata:
-    name: {{ .Release.Namespace }}-{{ template "vault.fullname" . }}-auth-delegator
-    labels:
-      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-      app.kubernetes.io/name: {{ template "vault.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: system:auth-delegator
-  subjects:
-  - kind: ServiceAccount
-    name: {{ template "vault.fullname" . }}
-    namespace: {{ .Release.Namespace }}
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-    name: {{ template "vault.fullname" . }}-secret-access
-    labels:
-      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-      app.kubernetes.io/name: {{ template "vault.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
-  roleRef:
-    kind: Role
-    name: {{ template "vault.fullname" . }}-secret-access
-    apiGroup: rbac.authorization.k8s.io
-  subjects:
-  - kind: ServiceAccount
-    name: {{ template "vault.fullname" . }}
-    namespace: {{ .Release.Namespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Namespace }}-{{ template "vault.fullname" . }}-auth-delegator
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ template "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: {{ template "vault.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "vault.fullname" . }}-secret-access
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ template "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  kind: Role
+  name: {{ template "vault.fullname" . }}-secret-access
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "vault.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Sam Weston <weston.sam@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
We run all our deployments through Helm's Linting and in 3.3 there are some additional rules which the charts in this repo fail. I don't think any of these changes are particularly controversial other than the change in the vault-operator chart to move away from the apiextensions.k8s.io/v1beta1 deprecated in Kubernetes 1.16, which does mean that the chart won't work on older Kubernetes versions. However I would hope most people using this chart would be on 1.16 or newer anyway.

### Why?
Pass Helm linting for best practises.

### Additional context
- vault-operator chart `type: application` removal is because this is only valid for v2 charts
- vault-operator chart `apiextensions.k8s.io/v1beta1` to `v1` change is because this API is deprecated since v1.16 of Kubernetes
- icon addition was just a warning but thought it made sense to add
- vault chart RoleBinding change away from a list is due to this https://github.com/helm/helm/issues/8615. We could potentially just add a name to the List instead.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
