### PR TITLE
[BUGFIX] Fixes invalid yaml when `.Values.rbac.enabled` is set to `true`

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.6.0
+version: 1.6.1
 appVersion: 1.6.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/templates/webhook-rbac.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-rbac.yaml
@@ -57,6 +57,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
   name: {{ template "vault-secrets-webhook.fullname" . }}
 {{- if .Values.rbac.authDelegatorRole.enabled }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
Fixes invalid yaml when `.Values.rbac.authDelegatorRole.enabled` is set to `true`. A yaml separator is missing then.
Original commit was: https://github.com/banzaicloud/bank-vaults/pull/1101
Seems like nobody tested it so far.

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Helm Chart needs to be updated
