### PR TITLE
add check for EnvFromPath to be empty for continuation

### DIFF
--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -224,7 +224,7 @@ func (mw *mutatingWebhook) mutateContainers(containers []corev1.Container, podSp
 			}
 		}
 
-		if len(envVars) == 0 {
+		if len(envVars) == 0 && vaultConfig.VaultEnvFromPath == "" {
 			continue
 		}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
The pod mutation checks to see if there are any env variables
that have vault keys in them, if there are no env variables it
continues on and doesn't mutate the pod.  This fix also checks if
the EnvFromPath annotation is empty, if it's empty and there are no 
env variables that reference vault keys it continues without mutating the pod.

### Why?
If you have a pod that only has the envFromPath annotation and no env variables that reference vault keys, the pod does not get mutated.

### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
