### PR TITLE
Add support for externally defined Certificate by cert-manager

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.6.1
+version: 1.6.2
 appVersion: 1.6.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -124,6 +124,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | podDisruptionBudget.minAvailable | represents the number of Pods that must be available (integer or percentage) | `1`                                 |
 | certificate.generate             | should a new CA and TLS certificate be generated for the webhook             | `true`                              |
 | certificate.useCertManager       | should request cert-manager for getting a new CA and TLS certificate         | `false`                             |
+| certificate.servingCertificate   | should use an already externally defined Certificate by cert-manager         | `null`                              |
 | certificate.ca.crt               | Base64 encoded CA certificate                                                | ``                                  |
 | certificate.server.tls.crt       | Base64 encoded TLS certificate signed by the CA                              | ``                                  |
 | certificate.server.tls.key       | Base64 encoded  private key of TLS certificate signed by the CA              | ``                                  |

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -12,7 +12,10 @@
 {{- $tlsKey = b64enc $server.Key }}
 {{- $caCrt =  b64enc $ca.Cert }}
 {{- else if .Values.certificate.useCertManager }}
-{{/* do nothing with certs here. Cert-manager will handle it all */}}
+{{/* Create a new Certificate with cert-manager. */}}
+{{/* all clientConfig.caBundle will be overridden by cert-manager */}}
+{{- else if .Values.certificate.servingCertificate }}
+{{/* Use an already externally defined Certificate by cert-manager. */}}
 {{/* all clientConfig.caBundle will be overridden by cert-manager */}}
 {{- else }}
 {{- $tlsCrt = required "Required when certificate.generate is false" .Values.certificate.server.tls.crt }}
@@ -20,7 +23,7 @@
 {{- $caCrt = required "Required when certificate.generate is false" .Values.certificate.ca.crt }}
 {{- end }}
 
-{{- if (eq .Values.certificate.useCertManager false) }}
+{{- if $tlsCrt }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -44,6 +47,9 @@ metadata:
 {{- if .Values.certificate.useCertManager }}
   annotations:
     cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "vault-secrets-webhook.servingCertificate" . }}"
+{{- else if .Values.certificate.servingCertificate }}
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ .Values.certificate.servingCertificate }}"
 {{- end }}
 webhooks:
 - name: pods.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -8,6 +8,7 @@ debug: false
 
 certificate:
   useCertManager: false
+  servingCertificate: null
   generate: true
   server:
     tls:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds an option to `vault-secrets-webhook` chart to provide an already externally defined Certificate produced by cert-manager, without generating any new certificates or even CAs.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The existing chart currently has 2 options to generate a whole new CA and a new TLS certificate, and an option to manually specify Base64-encoded keys for a Secret. In my opinion some users already have an existing CA infrastructure managed by cert-manager, and issue all Certificates for all internal services and webhooks through it. Consequently, the `vault-secrets-webhook` chart only needs an option to specify which Certificate to use (without generating a new one).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
