### PR TITLE
webhook: Load CA for non-pods as well

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -16,10 +16,13 @@ package main
 
 import (
 	"context"
+	"crypto/x509"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
 
+	"emperror.dev/errors"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -333,6 +336,7 @@ func parseVaultConfig(obj metav1.Object) VaultConfig {
 
 type mutatingWebhook struct {
 	k8sClient kubernetes.Interface
+	namespace string
 	registry  registry.ImageRegistry
 	logger    *logrus.Entry
 }
@@ -469,10 +473,31 @@ func (mw *mutatingWebhook) newVaultClient(vaultConfig VaultConfig) (*vault.Clien
 	clientConfig.Address = vaultConfig.Addr
 
 	tlsConfig := vaultapi.TLSConfig{Insecure: vaultConfig.SkipVerify}
-
 	err := clientConfig.ConfigureTLS(&tlsConfig)
 	if err != nil {
 		return nil, err
+	}
+
+	if vaultConfig.TLSSecret != "" {
+		tlsSecret, err := mw.k8sClient.CoreV1().Secrets(mw.namespace).Get(
+			context.Background(),
+			vaultConfig.TLSSecret,
+			metav1.GetOptions{},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read Vault TLS Secret")
+		}
+
+		clientTLSConfig := clientConfig.HttpClient.Transport.(*http.Transport).TLSClientConfig
+
+		pool := x509.NewCertPool()
+
+		ok := pool.AppendCertsFromPEM(tlsSecret.Data["ca.crt"])
+		if !ok {
+			return nil, errors.Errorf("error loading Vault CA PEM from TLS Secret", tlsSecret.Name)
+		}
+
+		clientTLSConfig.RootCAs = pool
 	}
 
 	return vault.NewClientFromConfig(
@@ -540,8 +565,14 @@ func main() {
 		logger.Fatalf("error creating k8s client: %s", err)
 	}
 
+	namespace, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		logger.Fatalf("error reading k8s namespace: %s", err)
+	}
+
 	mutatingWebhook := mutatingWebhook{
 		k8sClient: k8sClient,
+		namespace: string(namespace),
 		registry:  registry.NewRegistry(),
 		logger:    logger,
 	}

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -494,7 +494,7 @@ func (mw *mutatingWebhook) newVaultClient(vaultConfig VaultConfig) (*vault.Clien
 
 		ok := pool.AppendCertsFromPEM(tlsSecret.Data["ca.crt"])
 		if !ok {
-			return nil, errors.Errorf("error loading Vault CA PEM from TLS Secret", tlsSecret.Name)
+			return nil, errors.Errorf("error loading Vault CA PEM from TLS Secret: %s", tlsSecret.Name)
 		}
 
 		clientTLSConfig.RootCAs = pool

--- a/deploy/test-secret.yaml
+++ b/deploy/test-secret.yaml
@@ -5,7 +5,8 @@ metadata:
   annotations:
     vault.security.banzaicloud.io/vault-addr: "https://vault.default.svc.cluster.local:8200"
     vault.security.banzaicloud.io/vault-role: "default"
-    vault.security.banzaicloud.io/vault-skip-verify: "true"
+    vault.security.banzaicloud.io/vault-tls-secret: vault-tls
+    # vault.security.banzaicloud.io/vault-skip-verify: "true"
     vault.security.banzaicloud.io/vault-path: "kubernetes"
 type: kubernetes.io/dockerconfigjson
 data:

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -123,7 +123,6 @@ kurun apply -f hack/oidc-pod.yaml
 waitfor "kubectl get pod/oidc -o json | jq -e '.status.phase == \"Succeeded\"'"
 
 # Run the webhook test, the hello-secrets deployment should be successfully mutated
-kubectl create namespace vswh
 helm upgrade --install vault-secrets-webhook ./charts/vault-secrets-webhook \
     --set image.tag=latest \
     --set image.pullPolicy=IfNotPresent \

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -109,20 +109,18 @@ sleep 20
 kurun run cmd/examples/main.go
 
 # Only kind is configured to be able to run this test
-if [ "${GITHUB_ACTIONS}" == "true" ]
-then
-    kubectl delete -f operator/deploy/cr-priority.yaml
-    kubectl delete -f operator/deploy/priorityclass.yaml
-    kubectl delete secret vault-unseal-keys
-    kubectl delete pvc --all
+kubectl delete -f operator/deploy/cr-priority.yaml
+kubectl delete -f operator/deploy/priorityclass.yaml
+kubectl delete secret vault-unseal-keys
+kubectl delete pvc --all
 
-    # Sixth test: Run the OIDC authenticated client test
-    kubectl apply -f operator/deploy/cr-oidc.yaml
-    kubectl wait --for=condition=healthy --timeout=120s vault/vault
+# Sixth test: Run the OIDC authenticated client test
+kubectl create namespace vswh # create the namespace beforehand, because we need the CA cert here as well
+kubectl apply -f operator/deploy/cr-oidc.yaml
+kubectl wait --for=condition=healthy --timeout=120s vault/vault
 
-    kurun apply -f hack/oidc-pod.yaml
-    waitfor "kubectl get pod/oidc -o json | jq -e '.status.phase == \"Succeeded\"'"
-fi
+kurun apply -f hack/oidc-pod.yaml
+waitfor "kubectl get pod/oidc -o json | jq -e '.status.phase == \"Succeeded\"'"
 
 # Run the webhook test, the hello-secrets deployment should be successfully mutated
 kubectl create namespace vswh


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Allow applying the `vault.security.banzaicloud.io/vault-tls-secret` annotation on non-Pod resources as well.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To have proper TLS CA validation between the webhook and Vault for all-resources.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
