### PR TITLE
webhook: Adding KubeVersion validation when using admissionReviewVersions

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.6.1
+version: 1.6.3
 appVersion: 1.6.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -47,7 +47,9 @@ metadata:
 {{- end }}
 webhooks:
 - name: pods.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
   admissionReviewVersions: ["v1beta1"]
+  {{- end }}
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}
@@ -92,7 +94,9 @@ webhooks:
   sideEffects: {{ .Values.apiSideEffectValue }}
 {{- end }}
 - name: secrets.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
   admissionReviewVersions: ["v1beta1"]
+  {{- end }}
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}
@@ -128,7 +132,9 @@ webhooks:
 {{- end }}
 {{- if .Values.configMapMutation }}
 - name: configmaps.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
   admissionReviewVersions: ["v1beta1"]
+  {{- end }}
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}
@@ -165,7 +171,9 @@ webhooks:
 {{- end }}
 {{- if .Values.customResourceMutations }}
 - name: objects.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
   admissionReviewVersions: ["v1beta1"]
+  {{- end }}
   clientConfig:
     service:
       namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1149
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Adding a Kubernetes Version validation before using the AdmissionReviewVersions parameter, as it was only introduced in [Kubernetes 1.14](https://github.com/kubernetes/kubernetes/commit/f7dff4725f8dc694a852e7fdbdde2c8a6dd5b7d4)
### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)