### PR TITLE
allow token access to vault

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -83,6 +83,7 @@ type VaultConfig struct {
 	AgentImagePullPolicy        corev1.PullPolicy
 	Skip                        bool
 	VaultEnvFromPath            string
+	TokenAuthMount              string
 }
 
 func init() {
@@ -326,6 +327,10 @@ func parseVaultConfig(obj metav1.Object) VaultConfig {
 
 	if val, ok := annotations["vault.security.banzaicloud.io/vault-env-from-path"]; ok {
 		vaultConfig.VaultEnvFromPath = val
+	}
+
+	if val, ok := annotations["vault.security.banzaicloud.io/token-auth-mount"]; ok {
+		vaultConfig.TokenAuthMount = val
 	}
 
 	vaultConfig.AgentImage = viper.GetString("vault_image")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1155
| License         | Apache 2.0


### What's in this PR?
I would like to be able to use a pre-provided token to access the vault. We are using the mutating webhook to access but there is no way to use a provided token throughout the mutating webhook.


### Additional context
Tested with a vault where kubernetes auth is disabled
- injected secrets using `vault-env` into environment variables
- injected secrets using `consul-template` into ct-secrets


### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed) [updated documentation](https://github.com/banzaicloud/bank-vaults-docs/pull/43)
