### PR TITLE
[HELM] Webhook timeoutSeconds value

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.7.0
+version: 1.7.1
 appVersion: 1.7.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -131,6 +131,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | apiSideEffectValue               | Webhook sideEffect value                                                     | `NoneOnDryRun`                      |
 | securityContext                  | Container security context for webhook deployment                            | `{ runAsUser: 65534, allowPrivaledgeEscalation: false }` |
 | podSecurityContext               | Pod security context for webhook deployment                                  | `{}`                                |
+| timeoutSeconds                   | Webhook timeoutSeconds value                                                 | ``                                  |
 
 ### Certificate options
 

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -55,6 +55,9 @@ webhooks:
 - name: pods.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
   {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
   admissionReviewVersions: ["v1beta1"]
+  {{- if .Values.timeoutSeconds }}
+  timeoutSeconds: {{ .Values.timeoutSeconds }}
+  {{- end }}
   {{- end }}
   clientConfig:
     service:
@@ -102,6 +105,9 @@ webhooks:
 - name: secrets.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
   {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
   admissionReviewVersions: ["v1beta1"]
+  {{- if .Values.timeoutSeconds }}
+  timeoutSeconds: {{ .Values.timeoutSeconds }}
+  {{- end }}
   {{- end }}
   clientConfig:
     service:
@@ -140,6 +146,9 @@ webhooks:
 - name: configmaps.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
   {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
   admissionReviewVersions: ["v1beta1"]
+  {{- if .Values.timeoutSeconds }}
+  timeoutSeconds: {{ .Values.timeoutSeconds }}
+  {{- end }}
   {{- end }}
   clientConfig:
     service:
@@ -179,6 +188,9 @@ webhooks:
 - name: objects.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
   {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
   admissionReviewVersions: ["v1beta1"]
+  {{- if .Values.timeoutSeconds }}
+  timeoutSeconds: {{ .Values.timeoutSeconds }}
+  {{- end }}
   {{- end }}
   clientConfig:
     service:

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -131,3 +131,5 @@ objectSelector: {}
 podDisruptionBudget:
   enabled: true
   minAvailable: 1
+
+timeoutSeconds: false


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
Add timeoutSeconds in chart.

### Why?

> Default timeout for a webhook call is 10 seconds for webhooks registered created using admissionregistration.k8s.io/v1, and 30 seconds for webhooks created using admissionregistration.k8s.io/v1beta1. Starting in kubernetes 1.14 you can set the timeout.

With 10 seconds we have timeouts

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
