### PR TITLE
feat: annotations to control agent and env images

### DIFF
--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -82,6 +82,8 @@ type VaultConfig struct {
 	AgentMemory                 resource.Quantity
 	AgentImage                  string
 	AgentImagePullPolicy        corev1.PullPolicy
+	EnvImage                    string
+	EnvImagePullPolicy          corev1.PullPolicy
 	Skip                        bool
 	VaultEnvFromPath            string
 	TokenAuthMount              string
@@ -358,9 +360,9 @@ func parseVaultConfig(obj metav1.Object) VaultConfig {
 		vaultConfig.AgentImage = viper.GetString("vault_image")
 	}
 	if val, ok := annotations["vault.security.banzaicloud.io/vault-image-pull-policy"]; ok {
-		vaultConfig.EnvImagePullPolicy = val
+		vaultConfig.AgentImagePullPolicy = val
 	} else {
-		vaultConfig.EnvImagePullPolicy = viper.GetString("vault_image_pull_policy")
+		vaultConfig.AgentImagePullPolicy = viper.GetString("vault_image_pull_policy")
 	}
 
 	return vaultConfig

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -341,8 +341,27 @@ func parseVaultConfig(obj metav1.Object) VaultConfig {
 		vaultConfig.TokenAuthMount = val
 	}
 
-	vaultConfig.AgentImage = viper.GetString("vault_image")
-	vaultConfig.AgentImagePullPolicy = corev1.PullPolicy(viper.GetString("vault_image_pull_policy"))
+	if val, ok := annotations["vault.security.banzaicloud.io/vault-env-image"]; ok {
+		vaultConfig.EnvImage = val
+	} else {
+		vaultConfig.EnvImage = viper.GetString("vault_env_image")
+	}
+	if val, ok := annotations["vault.security.banzaicloud.io/vault-env-image-pull-policy"]; ok {
+		vaultConfig.EnvImagePullPolicy = val
+	} else {
+		vaultConfig.EnvImagePullPolicy = viper.GetString("vault_env_image_pull_policy")
+	}
+
+	if val, ok := annotations["vault.security.banzaicloud.io/vault-image"]; ok {
+		vaultConfig.AgentImage = val
+	} else {
+		vaultConfig.AgentImage = viper.GetString("vault_image")
+	}
+	if val, ok := annotations["vault.security.banzaicloud.io/vault-image-pull-policy"]; ok {
+		vaultConfig.EnvImagePullPolicy = val
+	} else {
+		vaultConfig.EnvImagePullPolicy = viper.GetString("vault_image_pull_policy")
+	}
 
 	return vaultConfig
 }

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -91,9 +91,7 @@ type VaultConfig struct {
 
 func init() {
 	viper.SetDefault("vault_image", "vault:latest")
-	viper.SetDefault("vault_image_pull_policy", string(corev1.PullIfNotPresent))
 	viper.SetDefault("vault_env_image", "banzaicloud/vault-env:latest")
-	viper.SetDefault("vault_env_image_pull_policy", string(corev1.PullIfNotPresent))
 	viper.SetDefault("vault_ct_image", "hashicorp/consul-template:0.24.1-alpine")
 	viper.SetDefault("vault_addr", "https://vault:8200")
 	viper.SetDefault("vault_skip_verify", "false")
@@ -349,9 +347,16 @@ func parseVaultConfig(obj metav1.Object) VaultConfig {
 		vaultConfig.EnvImage = viper.GetString("vault_env_image")
 	}
 	if val, ok := annotations["vault.security.banzaicloud.io/vault-env-image-pull-policy"]; ok {
-		vaultConfig.EnvImagePullPolicy = val
+		switch val {
+		case "Never", "never":
+			vaultConfig.EnvImagePullPolicy = corev1.PullNever
+		case "Always", "always":
+			vaultConfig.EnvImagePullPolicy = corev1.PullAlways
+		case "IfNotPresent", "ifnotpresent":
+			vaultConfig.EnvImagePullPolicy = corev1.PullIfNotPresent
+		}
 	} else {
-		vaultConfig.EnvImagePullPolicy = viper.GetString("vault_env_image_pull_policy")
+		vaultConfig.EnvImagePullPolicy = corev1.PullIfNotPresent
 	}
 
 	if val, ok := annotations["vault.security.banzaicloud.io/vault-image"]; ok {
@@ -360,9 +365,16 @@ func parseVaultConfig(obj metav1.Object) VaultConfig {
 		vaultConfig.AgentImage = viper.GetString("vault_image")
 	}
 	if val, ok := annotations["vault.security.banzaicloud.io/vault-image-pull-policy"]; ok {
-		vaultConfig.AgentImagePullPolicy = val
+		switch val {
+		case "Never", "never":
+			vaultConfig.AgentImagePullPolicy = corev1.PullNever
+		case "Always", "always":
+			vaultConfig.AgentImagePullPolicy = corev1.PullAlways
+		case "IfNotPresent", "ifnotpresent":
+			vaultConfig.AgentImagePullPolicy = corev1.PullIfNotPresent
+		}
 	} else {
-		vaultConfig.AgentImagePullPolicy = viper.GetString("vault_image_pull_policy")
+		vaultConfig.AgentImagePullPolicy = corev1.PullIfNotPresent
 	}
 
 	return vaultConfig

--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeVer "k8s.io/apimachinery/pkg/version"
 
-	"github.com/spf13/viper"
 )
 
 const vaultAgentConfig = `

--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -622,8 +622,8 @@ func getInitContainers(originalContainers []corev1.Container, podSecurityContext
 	if initContainersMutated || containersMutated {
 		containers = append(containers, corev1.Container{
 			Name:            "copy-vault-env",
-			Image:           viper.GetString("vault_env_image"),
-			ImagePullPolicy: corev1.PullPolicy(viper.GetString("vault_env_image_pull_policy")),
+			Image:           vaultConfig.EnvImage,
+			ImagePullPolicy: vaultConfig.EnvImagePullPolicy,
 			Command:         []string{"sh", "-c", "cp /usr/local/bin/vault-env /vault/"},
 			VolumeMounts: []corev1.VolumeMount{
 				{

--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeVer "k8s.io/apimachinery/pkg/version"
-
 )
 
 const vaultAgentConfig = `


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
This PR adds 4 new annotations so we can alter the images for vault agent and vault-env at pod level.


### Why?
This is useful when you need to test new images without breaking everything or deploy a whole new environment. This can be useful when you have multiple vaults with different versions, depending on the team. It can be useful if team A has vault v2 with a breaking change from v1 but team B has still vault v1.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- Review the doc for this PR: https://github.com/banzaicloud/bank-vaults-docs/pull/44
