### PR TITLE
client: automated GCP GCE authentication

### DIFF
--- a/cmd/vault-secrets-webhook/registry/registry.go
+++ b/cmd/vault-secrets-webhook/registry/registry.go
@@ -35,13 +35,13 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/iam/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 const ecrCredentialsKey = "AWS_ECR_CREDENTIALS"
-const gcrAuthScope = "https://www.googleapis.com/auth/cloud-platform"
 
 var logger *log.Logger
 var ecrHostPattern *regexp.Regexp
@@ -463,7 +463,7 @@ func getECRRegistryIDAndRegion(registryAddr string) (string, string) {
 func getGCRCredentials(k *ContainerInfo) error {
 	logger.Infof("trying to request Google Cloud credentials for GCR registry %s", k.RegistryAddress)
 
-	tokenSrc, err := google.DefaultTokenSource(context.TODO(), gcrAuthScope)
+	tokenSrc, err := google.DefaultTokenSource(context.TODO(), iam.CloudPlatformScope)
 	if err != nil {
 		log.Errorf("error fetching Google Cloud credentials: %s", err)
 		return err

--- a/deploy/test-deployment-gcp.yaml
+++ b/deploy/test-deployment-gcp.yaml
@@ -12,12 +12,13 @@ spec:
       labels:
         app.kubernetes.io/name: vault-env-gcp-auth
       annotations:
-        # These annotations enable Vault GCP Auth, see:
-        # https://www.vaultproject.io/api/auth/gcp#login
+        # These annotations enable Vault GCP GCE auth, see:
+        # https://www.vaultproject.io/docs/auth/gcp#gce-login
         vault.security.banzaicloud.io/vault-addr: "https://vault:8200"
         vault.security.banzaicloud.io/vault-tls-secret: vault-tls
         vault.security.banzaicloud.io/vault-role: "my-role"
         vault.security.banzaicloud.io/vault-path: "gcp"
+        vault.security.banzaicloud.io/vault-auth-method: "gcp-gce"
     spec:
       containers:
         - name: alpine
@@ -28,30 +29,33 @@ spec:
               "-c",
               "echo $MYSQL_PASSWORD && echo going to sleep... && sleep 10000",
             ]
-          env:
-            - name: VAULT_JWT_FILE
-              value: /etc/gcp/credentials.json
-            - name: MYSQL_PASSWORD
-              value: vault:secret/data/mysql#MYSQL_PASSWORD
           resources:
             limits:
               memory: "64Mi"
               cpu: "100m"
-          volumeMounts:
-            - name: gcp-secret
-              mountPath: "/etc/gcp/"
-              readOnly: true
-      volumes:
-        - name: gcp-secret
-          secret:
-            secretName: gcp-secret
+          env:
+            - name: MYSQL_PASSWORD
+              value: vault:secret/data/mysql#MYSQL_PASSWORD
+#             # If you wish to supply your own GOOGLE_APPLICATION_CREDENTIALS file to the Pod,
+#             # and bypass automatic authentication, uncomment the following lines:
+#
+#             - name: GOOGLE_APPLICATION_CREDENTIALS
+#               value: /etc/gcp/credentials.json
+#           volumeMounts:
+#             - name: gcp-secret
+#               mountPath: "/etc/gcp/"
+#               readOnly: true
+#       volumes:
+#         - name: gcp-secret
+#           secret:
+#             secretName: gcp-secret
 
----
+# ---
 
-apiVersion: v1
-kind: Secret
-metadata:
-  name: gcp-secret
-type: Opaque
-data:
-  credentials.json: "YOUR_SERVICE_ACCOUNT_JWT_IN_BASE64"
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: gcp-secret
+# type: Opaque
+# data:
+#   credentials.json: "YOUR_SERVICE_ACCOUNT_JWT_IN_BASE64"


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #1093 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Automated GCP GCE auth (https://www.vaultproject.io/docs/auth/gcp#gce-login) without providing `GOOGLE_APPLICATION_CREDENTIALS`. For the webhook, client, and vault-env.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
