### PR TITLE
fix vault agent `-once` command to exit after auth

### DIFF
--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -680,7 +680,7 @@ func getContainers(vaultConfig VaultConfig, containerEnvVars []corev1.EnvVar, co
 
 	var ctCommandString []string
 	if vaultConfig.CtOnce {
-		ctCommandString = []string{"-config", "/vault/ct-config/config.hcl", "-exit-after-auth"}
+		ctCommandString = []string{"-config", "/vault/ct-config/config.hcl", "-once"}
 	} else {
 		ctCommandString = []string{"-config", "/vault/ct-config/config.hcl"}
 	}
@@ -742,7 +742,7 @@ func getAgentContainers(originalContainers []corev1.Container, vaultConfig Vault
 
 	var agentCommandString []string
 	if vaultConfig.AgentOnce {
-		agentCommandString = []string{"agent", "-config", "/vault/config/config.hcl", "-once"}
+		agentCommandString = []string{"agent", "-config", "/vault/config/config.hcl", "-exit-after-auth"}
 	} else {
 		agentCommandString = []string{"agent", "-config", "/vault/config/config.hcl"}
 	}

--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -680,7 +680,7 @@ func getContainers(vaultConfig VaultConfig, containerEnvVars []corev1.EnvVar, co
 
 	var ctCommandString []string
 	if vaultConfig.CtOnce {
-		ctCommandString = []string{"-config", "/vault/ct-config/config.hcl", "-once"}
+		ctCommandString = []string{"-config", "/vault/ct-config/config.hcl", "-exit-after-auth"}
 	} else {
 		ctCommandString = []string{"-config", "/vault/ct-config/config.hcl"}
 	}


### PR DESCRIPTION
Q | A
-- | --
Bug fix | Yes
New feature | no
API breaks | no
Deprecations | no
Related tickets | none
License | Apache 2.0


### What's in this PR?
This PR fixes the command passing the `vault agent` command to exit after the auth process. 

### Why?
`vault agent` command doesn't support the current `-once` attribute, the correct attribute is `-exit-after-auth`


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
