### PR TITLE
webhook: add hostnetwork in chart (following of #1154)

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.7.1
+version: 1.7.2
 appVersion: 1.7.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -132,6 +132,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | securityContext                  | Container security context for webhook deployment                            | `{ runAsUser: 65534, allowPrivaledgeEscalation: false }` |
 | podSecurityContext               | Pod security context for webhook deployment                                  | `{}`                                |
 | timeoutSeconds                   | Webhook timeoutSeconds value                                                 | ``                                  |
+| hostNetwork                      | allow pod to use the node network namespace                                  | `false`                             |
 
 ### Certificate options
 

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -33,6 +33,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.hostNetwork}}
+      hostNetwork: {{ .Values.hostNetwork}}
+      {{- end }}
       serviceAccountName: {{ template "vault-secrets-webhook.fullname" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -133,3 +133,5 @@ podDisruptionBudget:
   minAvailable: 1
 
 timeoutSeconds: false
+
+hostNetwork: false


### PR DESCRIPTION
Q | A
-- | --
Bug fix? | no
New feature? | yes
API breaks? | no
Deprecations? | no
Related tickets | #1154 
License | Apache 2.0

What's in this PR?
add hostnetwork in chart.

Why?
This can help me to create a helm release with flux by integrated with inside values file
