### PR TITLE
vault/chart: align IPC_LOCK behaviour to operator based on disable_mlock

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault
-version: 1.7.0
+version: 1.7.1
 appVersion: 1.7.0
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/

--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -120,9 +120,11 @@ spec:
             port: vault
         securityContext:
           readOnlyRootFilesystem: true
+          {{ if not .Values.vault.config.disable_mlock }}
           capabilities:
             add:
             - IPC_LOCK
+          {{ end }}
         volumeMounts:
         - name: vault-config
           mountPath: /vault/config/

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -169,6 +169,9 @@ vault:
 
     ui: true
 
+    # Uncomment this tot remove the need for the IPC_LOCK capability
+    # disable_mlock: true
+
     # See https://www.vaultproject.io/docs/configuration/storage/ for storage backends
     storage:
       {}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1170, related #895 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Remove the IPC_LOCK capability from the StatefulSet if `mlock` is disabled in config.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

