### PR TITLE
Add inline secrets for vault-env/vault-secrets-webhook

### DIFF
--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -210,6 +210,9 @@ func (mw *mutatingWebhook) mutateContainers(containers []corev1.Container, podSp
 			if hasVaultPrefix(env.Value) {
 				envVars = append(envVars, env)
 			}
+			if hasInlineVaultDelimiters(env.Value) {
+				envVars = append(envVars, env)
+			}
 			if env.ValueFrom != nil {
 				valueFrom, err := mw.lookForValueFrom(env, ns)
 				if err != nil {

--- a/cmd/vault-secrets-webhook/pod_test.go
+++ b/cmd/vault-secrets-webhook/pod_test.go
@@ -343,6 +343,54 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 			mutated: true,
 			wantErr: false,
 		},
+		{name: "Will mutate container with command, no args, with inline mutation",
+			fields: fields{
+				k8sClient: fake.NewSimpleClientset(),
+				registry: &MockRegistry{
+					Image: imagev1.ImageConfig{},
+				},
+			},
+			args: args{
+				containers: []corev1.Container{
+					{
+						Name:    "MyContainer",
+						Image:   "myimage",
+						Command: []string{"/bin/bash"},
+						Args:    nil,
+						Env: []corev1.EnvVar{
+							{
+								Name:  "myvar",
+								Value: "scheme://${vault:secret/data/account#password}:${vault:secret/data/account#password}@127.0.0.1:8080",
+							},
+						},
+					},
+				},
+				vaultConfig: vaultConfig,
+			},
+			wantedContainers: []corev1.Container{
+				{
+					Name:         "MyContainer",
+					Image:        "myimage",
+					Command:      []string{"/vault/vault-env"},
+					Args:         []string{"/bin/bash"},
+					VolumeMounts: []corev1.VolumeMount{{Name: "vault-env", MountPath: "/vault/"}},
+					Env: []corev1.EnvVar{
+						{Name: "myvar", Value: "scheme://${vault:secret/data/account#password}:${vault:secret/data/account#password}@127.0.0.1:8080"},
+						{Name: "VAULT_ADDR", Value: "addr"},
+						{Name: "VAULT_SKIP_VERIFY", Value: "false"},
+						{Name: "VAULT_AUTH_METHOD", Value: "jwt"},
+						{Name: "VAULT_PATH", Value: "path"},
+						{Name: "VAULT_ROLE", Value: "role"},
+						{Name: "VAULT_IGNORE_MISSING_SECRETS", Value: "ignoreMissingSecrets"},
+						{Name: "VAULT_ENV_PASSTHROUGH", Value: "vaultEnvPassThrough"},
+						{Name: "VAULT_JSON_LOG", Value: "enableJSONLog"},
+						{Name: "VAULT_CLIENT_TIMEOUT", Value: "10s"},
+					},
+				},
+			},
+			mutated: true,
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/vault-secrets-webhook/pod_test.go
+++ b/cmd/vault-secrets-webhook/pod_test.go
@@ -360,7 +360,7 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 						Env: []corev1.EnvVar{
 							{
 								Name:  "myvar",
-								Value: "scheme://${vault:secret/data/account#password}:${vault:secret/data/account#password}@127.0.0.1:8080",
+								Value: "scheme://${vault:secret/data/account#username}:${vault:secret/data/account#password}@127.0.0.1:8080",
 							},
 						},
 					},
@@ -375,7 +375,7 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 					Args:         []string{"/bin/bash"},
 					VolumeMounts: []corev1.VolumeMount{{Name: "vault-env", MountPath: "/vault/"}},
 					Env: []corev1.EnvVar{
-						{Name: "myvar", Value: "scheme://${vault:secret/data/account#password}:${vault:secret/data/account#password}@127.0.0.1:8080"},
+						{Name: "myvar", Value: "scheme://${vault:secret/data/account#username}:${vault:secret/data/account#password}@127.0.0.1:8080"},
 						{Name: "VAULT_ADDR", Value: "addr"},
 						{Name: "VAULT_SKIP_VERIFY", Value: "false"},
 						{Name: "VAULT_AUTH_METHOD", Value: "jwt"},

--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -16,6 +16,7 @@ package injector
 
 import (
 	"encoding/json"
+	"regexp"
 	"strings"
 
 	"emperror.dev/errors"
@@ -52,6 +53,10 @@ func NewSecretInjector(config Config, client *vault.Client, renewer SecretRenewe
 	return SecretInjector{config: config, client: client, renewer: renewer, logger: logger}
 }
 
+var (
+	InlineMutationRegex = regexp.MustCompile(`\${([>]{0,2}vault:.*?)}`)
+)
+
 func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inject SecretInjectorFunc) error {
 	transitCache := map[string][]byte{}
 	secretCache := map[string]map[string]interface{}{}
@@ -59,6 +64,20 @@ func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inj
 	templater := configuration.NewTemplater(configuration.DefaultLeftDelimiter, configuration.DefaultRightDelimiter)
 
 	for name, value := range references {
+		if hasInlineVaultDelimiters(value) {
+			for _, vaultSecretReference := range findInlineVaultDelimiters(value) {
+				mapData, err := getDataFromVault(map[string]string{name: vaultSecretReference[1]}, i)
+				if err != nil {
+					return err
+				}
+				for _, v := range mapData {
+					value = strings.Replace(value, vaultSecretReference[0], v, -1)
+				}
+			}
+			inject(name, value)
+			continue
+		}
+
 		var update bool
 		if strings.HasPrefix(value, ">>vault:") {
 			value = strings.TrimPrefix(value, ">>")
@@ -271,4 +290,22 @@ func (i SecretInjector) readVaultPath(path, versionOrData string, update bool) (
 	}
 
 	return secretData, nil
+}
+
+func hasInlineVaultDelimiters(value string) bool {
+	return len(findInlineVaultDelimiters(value)) > 0
+}
+
+func findInlineVaultDelimiters(value string) [][]string {
+	return InlineMutationRegex.FindAllStringSubmatch(value, -1)
+}
+
+func getDataFromVault(data map[string]string, secretInjector SecretInjector) (map[string]string, error) {
+	vaultData := make(map[string]string, len(data))
+
+	inject := func(key, value string) {
+		vaultData[key] = value
+	}
+
+	return vaultData, secretInjector.InjectSecretsFromVault(data, inject)
 }

--- a/internal/injector/injector_test.go
+++ b/internal/injector/injector_test.go
@@ -97,6 +97,7 @@ func TestSecretInjector(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			"ACCOUNT_PASSWORD": "secret",
 			"TRANSIT_SECRET":   "secret",
+			"INLINE_SECRET":    "scheme://secret:secret@127.0.0.1:8080",
 		}, results)
 	})
 

--- a/internal/injector/injector_test.go
+++ b/internal/injector/injector_test.go
@@ -52,7 +52,7 @@ func TestSecretInjector(t *testing.T) {
 
 	ciphertext := secret.Data["ciphertext"].(string)
 
-	_, err = client.RawClient().Logical().Write("secret/data/account", vault.NewData(0, map[string]interface{}{"password": "secret"}))
+	_, err = client.RawClient().Logical().Write("secret/data/account", vault.NewData(0, map[string]interface{}{"username": "superusername", "password": "secret"}))
 	assert.NoError(t, err)
 
 	err = client.RawClient().Sys().Mount("pki", &vaultapi.MountInput{Type: "pki"})
@@ -77,7 +77,7 @@ func TestSecretInjector(t *testing.T) {
 			"TRANSIT_SECRET":   `>>vault:transit/decrypt/mykey#${.plaintext | b64dec}#{"ciphertext":"` + ciphertext + `"}`,
 			"ROOT_CERT":        ">>vault:pki/root/generate/internal#certificate",
 			"ROOT_CERT_CACHED": ">>vault:pki/root/generate/internal#certificate",
-			"INLINE_SECRET":    "scheme://${vault:secret/data/account#password}:${vault:secret/data/account#password}@127.0.0.1:8080",
+			"INLINE_SECRET":    "scheme://${vault:secret/data/account#username}:${vault:secret/data/account#password}@127.0.0.1:8080",
 		}
 
 		results := map[string]string{}
@@ -97,7 +97,7 @@ func TestSecretInjector(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			"ACCOUNT_PASSWORD": "secret",
 			"TRANSIT_SECRET":   "secret",
-			"INLINE_SECRET":    "scheme://secret:secret@127.0.0.1:8080",
+			"INLINE_SECRET":    "scheme://superusername:secret@127.0.0.1:8080",
 		}, results)
 	})
 

--- a/internal/injector/injector_test.go
+++ b/internal/injector/injector_test.go
@@ -77,6 +77,7 @@ func TestSecretInjector(t *testing.T) {
 			"TRANSIT_SECRET":   `>>vault:transit/decrypt/mykey#${.plaintext | b64dec}#{"ciphertext":"` + ciphertext + `"}`,
 			"ROOT_CERT":        ">>vault:pki/root/generate/internal#certificate",
 			"ROOT_CERT_CACHED": ">>vault:pki/root/generate/internal#certificate",
+			"INLINE_SECRET":    "scheme://${vault:secret/data/account#password}:${vault:secret/data/account#password}@127.0.0.1:8080",
 		}
 
 		results := map[string]string{}


### PR DESCRIPTION
Signed-off-by: Lord-Y <Lord-Y@users.noreply.github.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
This PR permit inline secrets mutation from vault-env/vault-secrets-webhook

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)