### PR TITLE
vault-env: fix vault:login clientOptions

### DIFF
--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -158,9 +158,7 @@ func main() {
 	// or requests one for itself (Kubernetes Auth, or GCP, etc...),
 	// so if we got a VAULT_TOKEN for the special value with "vault:login"
 	originalVaultTokenEnvVar := os.Getenv("VAULT_TOKEN")
-	if originalVaultTokenEnvVar == vaultLogin {
-		os.Unsetenv("VAULT_TOKEN")
-	} else if tokenFile := os.Getenv("VAULT_TOKEN_FILE"); tokenFile != "" {
+	if tokenFile := os.Getenv("VAULT_TOKEN_FILE"); tokenFile != "" {
 		// load token from vault-agent .vault-token or injected webhook
 		if b, err := ioutil.ReadFile(tokenFile); err == nil {
 			originalVaultTokenEnvVar = string(b)
@@ -169,6 +167,9 @@ func main() {
 		}
 		clientOptions = append(clientOptions, vault.ClientToken(originalVaultTokenEnvVar))
 	} else {
+		if originalVaultTokenEnvVar == vaultLogin {
+			os.Unsetenv("VAULT_TOKEN")
+		}
 		// use role/path based authentication
 		clientOptions = append(clientOptions,
 			vault.ClientRole(os.Getenv("VAULT_ROLE")),


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #1177, #1156 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fixing a regression introduced by #1156, the `vault:login` special value won't allow the client to be properly configured with clientOptions.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
