### PR TITLE
Use agent ConfigMap when agent is in the InitContainers

### DIFF
--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -185,7 +185,7 @@ func (mw *mutatingWebhook) mutatePod(pod *corev1.Pod, vaultConfig VaultConfig, n
 			shareProcessNamespace := true
 			pod.Spec.ShareProcessNamespace = &shareProcessNamespace
 		}
-		pod.Spec.Containers = append(getAgentContainers(pod.Spec.Containers, vaultConfig, containerEnvVars, containerVolMounts), pod.Spec.Containers...)
+		pod.Spec.initContainers = append(getAgentContainers(pod.Spec.Containers, vaultConfig, containerEnvVars, containerVolMounts), pod.Spec.Containers...)
 
 		mw.logger.Debug("Successfully appended pod containers to spec")
 	}

--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -164,7 +164,7 @@ func (mw *mutatingWebhook) mutatePod(pod *corev1.Pod, vaultConfig VaultConfig, n
 		mw.logger.Debug("Successfully appended pod containers to spec")
 	}
 
-	if vaultConfig.AgentConfigMap != "" && vaultConfig.UseAgent == false {
+	if vaultConfig.AgentConfigMap != "" && !vaultConfig.UseAgent {
 		mw.logger.Debug("Vault Agent config found")
 
 		mw.addAgentSecretsVolToContainers(vaultConfig, pod.Spec.Containers)

--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -680,7 +680,7 @@ func getContainers(vaultConfig VaultConfig, containerEnvVars []corev1.EnvVar, co
 
 	var ctCommandString []string
 	if vaultConfig.CtOnce {
-		ctCommandString = []string{"-config", "/vault/ct-config/config.hcl", "-exit-after-auth"}
+		ctCommandString = []string{"-config", "/vault/ct-config/config.hcl", "-once"}
 	} else {
 		ctCommandString = []string{"-config", "/vault/ct-config/config.hcl"}
 	}
@@ -742,7 +742,7 @@ func getAgentContainers(originalContainers []corev1.Container, vaultConfig Vault
 
 	var agentCommandString []string
 	if vaultConfig.AgentOnce {
-		agentCommandString = []string{"agent", "-config", "/vault/config/config.hcl", "-once"}
+		agentCommandString = []string{"agent", "-config", "/vault/config/config.hcl", "-exit-after-auth"}
 	} else {
 		agentCommandString = []string{"agent", "-config", "/vault/config/config.hcl"}
 	}

--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -680,7 +680,7 @@ func getContainers(vaultConfig VaultConfig, containerEnvVars []corev1.EnvVar, co
 
 	var ctCommandString []string
 	if vaultConfig.CtOnce {
-		ctCommandString = []string{"-config", "/vault/ct-config/config.hcl", "-once"}
+		ctCommandString = []string{"-config", "/vault/ct-config/config.hcl", "-exit-after-auth"}
 	} else {
 		ctCommandString = []string{"-config", "/vault/ct-config/config.hcl"}
 	}

--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -29,7 +29,6 @@ import (
 
 const vaultAgentConfig = `
 pid_file = "/tmp/pidfile"
-exit_after_auth = true
 
 auto_auth {
 	method "kubernetes" {
@@ -602,19 +601,12 @@ func getInitContainers(originalContainers []corev1.Container, podSecurityContext
 			AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
 		}
 
-		var agentCommandString []string
-		if vaultConfig.AgentOnce {
-			agentCommandString = []string{"vault", "agent", "-config", "/vault/agent/config.hcl", "-exit-after-auth"}
-		} else {
-			agentCommandString = []string{"vault", "agent", "-config", "/vault/agent/config.hcl"}
-		}
-
 		containers = append(containers, corev1.Container{
 			Name:            "vault-agent",
 			Image:           vaultConfig.AgentImage,
 			ImagePullPolicy: vaultConfig.AgentImagePullPolicy,
 			SecurityContext: securityContext,
-			Command:         agentCommandString,
+			Command:         []string{"vault", "agent", "-config=/vault/agent/config.hcl", "-exit-after-auth"},
 			Env:             containerEnvVars,
 			VolumeMounts:    containerVolMounts,
 			Resources: corev1.ResourceRequirements{

--- a/cmd/vault-secrets-webhook/pod_test.go
+++ b/cmd/vault-secrets-webhook/pod_test.go
@@ -481,7 +481,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 						{
 							Name:            "vault-agent",
 							Image:           "vault:latest",
-							Command:         []string{"vault", "agent", "-config=/vault/agent/config.hcl"},
+							Command:         []string{"vault", "agent", "-config=/vault/agent/config.hcl", "-exit-after-auth"},
 							ImagePullPolicy: "IfNotPresent",
 							Env: []corev1.EnvVar{
 								{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix        | no
| New feature    | yes
| API breaks     | no
| Deprecations   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
This PR allows to use a ConfigMap with the agent when the agent is in the initContainers

### Why?
I want to make sure the agent runs before all other containers and exits since I want to use the token the agent sinks directly in my application. 


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
