### PR TITLE
Multidc use specific loadbalancerip

### DIFF
--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -13,6 +13,7 @@ function finish {
     echo "The last command was: $(history 1 | awk '{print $2}')"
     kubectl get pods
     kubectl describe pods
+    kubectl describe services
     kubectl logs deployment/vault-operator
     kubectl logs --all-containers statefulset/vault
     kubectl logs -n vswh deployment/vault-secrets-webhook

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -269,9 +269,14 @@ type VaultSpec struct {
 	// default:
 	EtcdAffinity *v1.Affinity `json:"etcdAffinity,omitempty"`
 
-	// ServiceType is a Kuberrnetes Service type of the Vault Service.
+	// ServiceType is a Kubernetes Service type of the Vault Service.
 	// default: ClusterIP
 	ServiceType string `json:"serviceType"`
+
+	// LoadBalancerIP is an optional setting for allocating a specific address for the entry service object
+	// of type LoadBalancer
+	// default: ""
+	LoadBalancerIP string `json:"loadBalancerIP,omitempty"`
 
 	// serviceRegistrationEnabled enables the injection of the service_registration Vault stanza.
 	// This requires elaborated RBAC privileges for updating Pod labels for the Vault Pod.

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -284,6 +284,14 @@ type VaultSpec struct {
 	// default: ""
 	RaftLeaderAddress string `json:"raftLeaderAddress"`
 
+	// MultiDCRaftFollowerExternalAddress defines an explicit address on which a follower is reachable.
+	// This only applies in multidc configurations. The default operation is to fetch the raft cluster address from
+	// the service's ingress allocated address. This option provides the ability to provide a specific external address
+	// for the raft cluster to communicate with, in case of values returned by kubernetes internally, are not re-usable
+	// between external cluster members.
+	// default: ""
+	MultiDCRaftFollowerExternalAddress string `json:"multiDCRaftFollowerExternalAddress"`
+
 	// ServicePorts is an extra map of ports that should be exposed by the Vault Service.
 	// default:
 	ServicePorts map[string]int32 `json:"servicePorts"`

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -289,14 +289,6 @@ type VaultSpec struct {
 	// default: ""
 	RaftLeaderAddress string `json:"raftLeaderAddress"`
 
-	// MultiDCRaftFollowerExternalAddress defines an explicit address on which a follower is reachable.
-	// This only applies in multidc configurations. The default operation is to fetch the raft cluster address from
-	// the service's ingress allocated address. This option provides the ability to provide a specific external address
-	// for the raft cluster to communicate with, in case of values returned by kubernetes internally, are not re-usable
-	// between external cluster members.
-	// default: ""
-	MultiDCRaftFollowerExternalAddress string `json:"multiDCRaftFollowerExternalAddress"`
-
 	// ServicePorts is an extra map of ports that should be exposed by the Vault Service.
 	// default:
 	ServicePorts map[string]int32 `json:"servicePorts"`

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1640,10 +1640,20 @@ func withCredentialsEnv(v *vaultv1alpha1.Vault, envs []corev1.EnvVar) []corev1.E
 func withClusterAddr(v *vaultv1alpha1.Vault, service *corev1.Service, envs []corev1.EnvVar) []corev1.EnvVar {
 	value := ""
 
-	ingressPoints := loadBalancerIngressPoints(service)
+	// Use specific external address to form raft cluster
+    if v.Spec.MultiDCRaftFollowerExternalAddress != "" {
 
-	if len(ingressPoints) > 0 {
-		value = ingressPoints[len(ingressPoints)-1]
+        value = v.Spec.MultiDCRaftFollowerExternalAddress
+
+   // Use address provided by the service's ingress IP or Hostname
+    } else {
+
+	    ingressPoints := loadBalancerIngressPoints(service)
+
+	    if len(ingressPoints) > 0 {
+	     	value = ingressPoints[len(ingressPoints)-1]
+     	}
+
 	}
 
 	// Only applies to multi-cluster setups:

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -717,6 +717,8 @@ func serviceForVault(v *vaultv1alpha1.Vault) *corev1.Service {
 			Type:     serviceType(v),
 			Selector: selectorLs,
 			Ports:    servicePorts,
+			// Optional setting for requesting specific load balancer ip addresses.
+			LoadBalancerIP: v.Spec.LoadBalancerIP,
 			// In case of multi-cluster deployments we need to publish the port
 			// before being considered ready, otherwise the LoadBalancer won't
 			// be able to direct traffic from the leader to the joining instance.

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1641,12 +1641,11 @@ func withCredentialsEnv(v *vaultv1alpha1.Vault, envs []corev1.EnvVar) []corev1.E
 // withClusterAddr overrides cluster_addr with the env var in multi-cluster deployments
 func withClusterAddr(v *vaultv1alpha1.Vault, service *corev1.Service, envs []corev1.EnvVar) []corev1.EnvVar {
 	value := ""
-
-    ingressPoints := loadBalancerIngressPoints(service)
+	ingressPoints := loadBalancerIngressPoints(service)
 
 	if len(ingressPoints) > 0 {
-	    value = ingressPoints[len(ingressPoints)-1]
-    }
+		value = ingressPoints[len(ingressPoints)-1]
+	}
 
 	// Only applies to multi-cluster setups:
 	// This currently allows only one instance per cluster,

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1642,21 +1642,11 @@ func withCredentialsEnv(v *vaultv1alpha1.Vault, envs []corev1.EnvVar) []corev1.E
 func withClusterAddr(v *vaultv1alpha1.Vault, service *corev1.Service, envs []corev1.EnvVar) []corev1.EnvVar {
 	value := ""
 
-	// Use specific external address to form raft cluster
-    if v.Spec.MultiDCRaftFollowerExternalAddress != "" {
+    ingressPoints := loadBalancerIngressPoints(service)
 
-        value = v.Spec.MultiDCRaftFollowerExternalAddress
-
-   // Use address provided by the service's ingress IP or Hostname
-    } else {
-
-	    ingressPoints := loadBalancerIngressPoints(service)
-
-	    if len(ingressPoints) > 0 {
-	     	value = ingressPoints[len(ingressPoints)-1]
-     	}
-
-	}
+	if len(ingressPoints) > 0 {
+	    value = ingressPoints[len(ingressPoints)-1]
+    }
 
 	// Only applies to multi-cluster setups:
 	// This currently allows only one instance per cluster,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Adding type LoadBalancerIP for the vault crd


### Why?
Selecting a specific loadbalancerIP is sometimes necessary. In case of multiple metallb pools and firewall configuration requirements.

### Additional context
Did test the setup. The setting of the loadbalancerIP of worked. I did experience TLS issues following normal documentation. I did got this fixed by adding:

```
  tlsAdditionalHosts:
    - vault-secondary
    - vault-secondary.default
    - vault-secondary.default.svc.cluster.local
    - vault-tertiary
    - vault-tertiary.default
    - vault-tertiary.default.svc.cluster.local
    - 172.21.123.10  # (lb dc2)
    - 172.21.124.10  # (lb dc1)
```

the code automatically added the executing external loadbalancerLB IP of the respective master instance to the SANs accordingly.

the secondary and tertiary node were provided with:

```
    - name: VAULT_RAFT_CACERT
      value: /vault/raft-tls/ca.crt

  existingTlsSecretName: vault-primary-tls

  volumes:
    - name: vault-primary-tls
      secret:
        secretName: vault-primary-tls
    - name: vault-tls
      secret:
        secretName: vault-primary-tls
```

additionally, to get rid of internal TLS issues this setting was added to all instance cr definitions (cr-primary,secondary,tertiary) 
```
    - name: VAULT_CACERT
      value: /vault/tls/ca.crt
```

### Checklist
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)


### To Do