### PR TITLE
When checking available ingress points, use the defined loadbalanceri…

### DIFF
--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1096,7 +1096,7 @@ func loadBalancerIngressPoints(service *corev1.Service) []string {
 
 	// Use defined IP
 	if service.Spec.LoadBalancerIP != "" {
-		hostAndIPs = append(hostAndIPs, service.Spec.LoadBalancerIP)
+		hostsAndIPs = append(hostsAndIPs, service.Spec.LoadBalancerIP)
 
 	// Use allocated IP or Hostname
 	} else {

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -324,7 +324,7 @@ func (r *ReconcileVault) Reconcile(request reconcile.Request) (reconcile.Result,
 	if service.Spec.Type == corev1.ServiceTypeLoadBalancer && !v.Spec.IsTLSDisabled() && v.Spec.ExistingTLSSecretName == "" {
 		key, err := client.ObjectKeyFromObject(service)
 		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to get objecy key for service: %v", err)
+			return reconcile.Result{}, fmt.Errorf("failed to get object key for service: %v", err)
 		}
 
 		err = r.client.Get(context.Background(), key, service)
@@ -1093,12 +1093,20 @@ func hostsAndIPsForVault(v *vaultv1alpha1.Vault, service *corev1.Service) []stri
 
 func loadBalancerIngressPoints(service *corev1.Service) []string {
 	var hostsAndIPs []string
-	for _, ingress := range service.Status.LoadBalancer.Ingress {
-		if ingress.IP != "" {
-			hostsAndIPs = append(hostsAndIPs, ingress.IP)
-		}
-		if ingress.Hostname != "" {
-			hostsAndIPs = append(hostsAndIPs, ingress.Hostname)
+
+	// Use defined IP
+	if service.Spec.LoadBalancerIP != "" {
+		hostAndIPs = append(hostAndIPs, service.Spec.LoadBalancerIP)
+
+	// Use allocated IP or Hostname
+	} else {
+		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			if ingress.IP != "" {
+				hostsAndIPs = append(hostsAndIPs, ingress.IP)
+			}
+			if ingress.Hostname != "" {
+				hostsAndIPs = append(hostsAndIPs, ingress.Hostname)
+			}
 		}
 	}
 	return hostsAndIPs


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?
Ability to use the defined LoadBalancerIP instead of the received one.

### Why?

When it's allocated it's retrieved via Service.Status.LoadBalancer.Ingress, when it's defined in the crd its retrieved via Service.Spec.LoadBalancerIP


### Additional context
Tested this by running 2 of 3 vault instances in one DC

### Checklist
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

### To Do