### PR TITLE
allow the vault-webhook to be contacted over loadbalancer or ingress

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.8.1
+version: 1.8.2
 appVersion: 1.8.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -7,7 +7,7 @@
 {{- $cn := printf "%s.%s.svc" $svcName .Release.Namespace }}
 {{- $altName1 := printf "%s.cluster.local" $cn }}
 {{- $altName2 := printf "%s" $cn }}
-{{- $server := genSignedCert $cn nil (list $altName1 $altName2) 365 $ca }}
+{{- $server := genSignedCert $cn nil (concat (list $altName1 $altName2) .Values.certificate.extraAltNames) 365 $ca }}
 {{- $tlsCrt = b64enc $server.Cert }}
 {{- $tlsKey = b64enc $server.Key }}
 {{- $caCrt =  b64enc $ca.Cert }}
@@ -60,10 +60,14 @@ webhooks:
   {{- end }}
   {{- end }}
   clientConfig:
+    {{- if .Values.webhookClientConfig.useUrl }}
+    url: {{ .Values.webhookClientConfig.url }}
+    {{- else }}
     service:
       namespace: {{ .Release.Namespace }}
       name: {{ template "vault-secrets-webhook.fullname" . }}
       path: /pods
+    {{- end }}
     caBundle: {{ $caCrt }}
   rules:
   - operations:
@@ -110,10 +114,14 @@ webhooks:
   {{- end }}
   {{- end }}
   clientConfig:
+    {{- if .Values.webhookClientConfig.useUrl }}
+    url: {{ .Values.webhookClientConfig.url }}
+    {{- else }}
     service:
       namespace: {{ .Release.Namespace }}
       name: {{ template "vault-secrets-webhook.fullname" . }}
       path: /secrets
+    {{- end }}
     caBundle: {{ $caCrt }}
   rules:
   - operations:
@@ -151,10 +159,14 @@ webhooks:
   {{- end }}
   {{- end }}
   clientConfig:
+    {{- if .Values.webhookClientConfig.useUrl }}
+    url: {{ .Values.webhookClientConfig.url }}
+    {{- else }}
     service:
       namespace: {{ .Release.Namespace }}
       name: {{ template "vault-secrets-webhook.fullname" . }}
       path: /configmaps
+    {{- end }}
     caBundle: {{ $caCrt }}
   rules:
     - operations:
@@ -193,10 +205,14 @@ webhooks:
   {{- end }}
   {{- end }}
   clientConfig:
+    {{- if .Values.webhookClientConfig.useUrl }}
+    url: {{ .Values.webhookClientConfig.url }}
+    {{- else }}
     service:
       namespace: {{ .Release.Namespace }}
       name: {{ template "vault-secrets-webhook.fullname" . }}
       path: /objects
+    {{- end }}
     caBundle: {{ $caCrt }}
   rules:
   - operations:

--- a/charts/vault-secrets-webhook/templates/warnings.tpl
+++ b/charts/vault-secrets-webhook/templates/warnings.tpl
@@ -5,3 +5,9 @@
     {{ fail "It is not allowed to both set certificate.generate=true and certificate.useCertManager=true."}}
 {{- end }}
 {{- end }}
+
+{{- if .Values.webhookClientConfig.useUrl -}}
+{{- if or (not .Values.webhookClientConfig.url )  }}
+  {{ fail "When webhookClientConfig.useUrl=true webhookClientConfig.url should be set and not empty "}}
+{{- end }}
+{{- end }}

--- a/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
@@ -75,5 +75,8 @@ spec:
   - {{ include "vault-secrets-webhook.fullname" . }}
   - {{ include "vault-secrets-webhook.fullname" . }}.{{ .Release.Namespace }}
   - {{ include "vault-secrets-webhook.fullname" . }}.{{ .Release.Namespace }}.svc
+  {{- range .Values.certificate.extraAltNames }}
+  - {{ . }}
+  {{- end }}
 
 {{- end }}

--- a/charts/vault-secrets-webhook/templates/webhook-ingress.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "vault-secrets-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+  {{- end }}  
+spec:
+  tls:
+  - hosts:
+      - {{ .Values.ingress.host }}
+    secretName: {{ include "vault-secrets-webhook.servingCertificate" . }}
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - path: /
+        backend:
+          service:
+            name: {{ template "vault-secrets-webhook.fullname" . }}
+            port:
+              number: {{ .Values.service.externalPort }}
+{{- end }}

--- a/charts/vault-secrets-webhook/templates/webhook-service.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-service.yaml
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: mutating-webhook
+  {{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}  
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -16,6 +16,9 @@ certificate:
       key:
   ca:
     crt:
+  extraAltNames: []
+  # use extra names if you want use the webhook via an ingress or a loadbalancer
+
 image:
   repository: ghcr.io/banzaicloud/vault-secrets-webhook
   # tag: ""
@@ -27,6 +30,22 @@ service:
   type: ClusterIP
   externalPort: 443
   internalPort: 8443
+  annotations: {}
+  # Annotate service
+  # This can be used for example if type is AWS LoadBalancer and you want to add security groups
+
+ingress:
+  enabled: false
+  annotations: {}
+  # dns of ingress for vault-webhook
+  # host: example.com
+
+webhookClientConfig:
+  # By default the mutating webhook uses the service of the webhook directly to contact webhook
+  # Use url if webhook should be contacted over loadbalancer or ingress instead of service object
+  useUrl: false
+  # set the url how the webhook should be contacted (including protocol https://)
+  # url: https://example.com
 
 serviceAccount:
   labels: {}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no|
| Deprecations?   | nos
| License         | Apache 2.0


### What's in this PR?
MutatingWebhook can also connect to an url. Currently this can only be an (k8s) service. This PR add the ability to create 
a k8s Loadbalancer or k8s Ingress and use the url method


### Why?
Using the Service method can cause the webhook to be temporary unreachable. Check the following issues
https://github.com/kubernetes/kubernetes/issues/80313
https://github.com/kubernetes/client-go/issues/374#issuecomment-632457187
In short, the client-go library caches the ip of the pod so if the pod gets  an different ip the cache needs to invalidate
which takes time. Using a url instead of the service is a workaround until this is fixed in k8s. 


### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
