### PR TITLE
operator: add VaultContainerSpec override

### DIFF
--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -206,6 +206,14 @@ spec:
   #     hostnames:
   #     - "vault.local"
 
+  # It is possible to override the Vault container directly:
+  # vaultContainerSpec:
+  #   lifecycle:
+  #     postStart:
+  #       exec:
+  #         command:
+  #              - setcap cap_ipc_lock=+ep /vault/plugins/orchestrate
+  
   # Marks presence of Istio, which influences things like port namings
   istioEnabled: false
 

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -188,6 +188,11 @@ type VaultSpec struct {
 	// default:
 	VaultPodSpec v1.PodSpec `json:"vaultPodSpec"`
 
+	// VaultContainerSpec is a Kubernetes Container specification snippet that will be merged into the operator generated
+	// Vault Container specification.
+	// default:
+	VaultContainerSpec v1.Container `json:"vaultContainerSpec"`
+
 	// VaultConfigurerAnnotations define a set of Kubernetes annotations that will be added to the Vault Configurer Pod.
 	// default:
 	VaultConfigurerAnnotations map[string]string `json:"vaultConfigurerAnnotations"`

--- a/operator/pkg/apis/vault/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/vault/v1alpha1/zz_generated.deepcopy.go
@@ -411,6 +411,7 @@ func (in *VaultSpec) DeepCopyInto(out *VaultSpec) {
 		}
 	}
 	in.VaultPodSpec.DeepCopyInto(&out.VaultPodSpec)
+	in.VaultContainerSpec.DeepCopyInto(&out.VaultContainerSpec)
 	if in.VaultConfigurerAnnotations != nil {
 		in, out := &in.VaultConfigurerAnnotations, &out.VaultConfigurerAnnotations
 		*out = make(map[string]string, len(*in))

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1403,6 +1403,12 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 		return nil, err
 	}
 
+	// merge provided VaultContainerSpec into the Vault Container defined above
+	// the values in VaultContainerSpec will never overwrite fields defined in the PodSpec above
+	if err := mergo.Merge(&podSpec.Containers[0], v.Spec.VaultContainerSpec, mergo.WithOverride); err != nil {
+		return nil, err
+	}
+
 	podManagementPolicy := appsv1.ParallelPodManagement
 	if v.Spec.IsRaftStorage() || v.Spec.IsRaftHAStorage() {
 		podManagementPolicy = appsv1.OrderedReadyPodManagement


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1200 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Allows overriding the container specification of the Vault container deployed by the operator, see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#container-v1-core for all fields.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To be able to add lifecycle hooks for example.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
