### PR TITLE
unseal: use AWS_REGION/AWS_DEFAULT_REGION if possible

### DIFF
--- a/cmd/bank-vaults/common.go
+++ b/cmd/bank-vaults/common.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"os"
+
 	"emperror.dev/errors"
 	"github.com/spf13/viper"
 
@@ -103,6 +105,19 @@ func kvStoreForConfig(cfg *viper.Viper) (kv.Service, error) {
 		s3SSEAlgos := cfg.GetStringSlice(cfgAWS3SSEAlgo)
 		kmsRegions := cfg.GetStringSlice(cfgAWSKMSRegion)
 		kmsKeyIDs := cfg.GetStringSlice(cfgAWSKMSKeyID)
+
+		// Try to use the standard AWS region
+		// setting if not provided for KMS/S3
+		awsRegion := os.Getenv("AWS_REGION")
+		if awsRegion == "" {
+			awsRegion = os.Getenv("AWS_DEFAULT_REGION")
+		}
+		if len(s3Regions) == 0 && awsRegion != "" {
+			s3Regions = []string{awsRegion}
+		}
+		if len(kmsRegions) == 0 && awsRegion != "" {
+			kmsRegions = []string{awsRegion}
+		}
 
 		if len(s3Regions) != len(s3Buckets) {
 			return nil, errors.Errorf("specify the same number of regions and buckets for AWS S3 kv store [%d != %d]", len(s3Regions), len(s3Buckets))


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1220 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Employ the AWS_REGION/AWS_DEFAULT_REGION if possible during AWS based unsealing, if not provided for KMS/S3.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
For convinience.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Only works for single region setups.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
