### PR TITLE
operator&chart: drsecondary nodes should be healthy

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault
-version: 1.10.0
+version: 1.10.1
 appVersion: 1.10.0
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/

--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             {{ else }}
             scheme: HTTPS
             {{ end }}
-            path: /v1/sys/health?standbyok=true&perfstandbyok=true
+            path: /v1/sys/health?standbyok=true&perfstandbyok=true&drsecondarycode=299
             port: vault
         securityContext:
           readOnlyRootFilesystem: true

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1316,7 +1316,7 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 					HTTPGet: &corev1.HTTPGetAction{
 						Scheme: getVaultURIScheme(v),
 						Port:   intstr.FromString(v.Spec.GetAPIPortName()),
-						Path:   "/v1/sys/health?standbyok=true&perfstandbyok=true",
+						Path:   "/v1/sys/health?standbyok=true&perfstandbyok=true&drsecondarycode=299",
 					}},
 				PeriodSeconds:    5,
 				FailureThreshold: 2,


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Marking DR secondary (only enterprise Vault) nodes as healthy. See https://www.vaultproject.io/api-docs/system/health#472

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Otherwise, they are marked unhealthy by the Kubernetes probes.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
