### PR TITLE
add permissions to make ingress work on openshift

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-operator
-version: 1.11.2
+version: 1.11.3
 appVersion: 1.11.2
 description: A Helm chart for banzaicloud/bank-vaults Vault operator
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-operator/templates/role.yaml
+++ b/charts/vault-operator/templates/role.yaml
@@ -58,6 +58,19 @@ rules:
   - customresourcedefinitions
   verbs:
   - get
+{{- if .Capabilities.APIVersions.Has "route.openshift.io/v1/Route" }}
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  - routes/custom-host
+  verbs:
+  - list
+  - get
+  - create
+  - update
+  - watch
+{{- end }}
 - apiGroups:
   - extensions
   resources:


### PR DESCRIPTION
Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1260
| License         | Apache 2.0


### What's in this PR?
OpenShift uses a special route concept, and w/o these permissions it will fail as described in #1260. I might have added a bit many verbs, but it mirrors the ingress, which makes sense.

### Why?
Make ingress work ootb on openshift.

### Additional context
Uses api detection to avoid problems on non-openshift platforms - should not be intrusive.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)

