### PR TITLE
[webhook] Fix for inline mutations in custom resources

### DIFF
--- a/cmd/vault-secrets-webhook/object.go
+++ b/cmd/vault-secrets-webhook/object.go
@@ -106,6 +106,7 @@ func traverseObject(o interface{}, vaultClient *vault.Client, vaultConfig VaultC
 					}
 					dataFromVault = strings.Replace(dataFromVault, vaultSecretReference[0], mapData["data"], -1)
 				}
+				e.Set(dataFromVault)
 			}
 		case map[string]interface{}, []interface{}:
 			err := traverseObject(e.Get(), vaultClient, vaultConfig, logger)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fix for inline mutations in custom resources


### Why?
Inline mutations in custom resources did not work for me (values were not replaced), i looked into the source code and it seems like the data gets successfully retrieved from vault, but the object (custom resource) is not updated afterwards. I tested the fixed version in my cluster and it now works as expected.

To test it, create a custom resource definition, add it to the "customResourceMutations" list in the helm chart values and create a custom resource with an annotation, like:
```
metadata:
  annotations:
    foo: "secret is ${vault:secrets/data/foo#bar}"
```

It does not work for me with the current version, when i apply the fix from this PR it works.

### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
