### PR TITLE
[charts/vault] Add PodDisruptionBudget to vault Helm Chart

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: vault-operator
-version: 1.11.3
-appVersion: 1.11.2
+version: 1.11.4
+appVersion: 1.11.4
 description: A Helm chart for banzaicloud/bank-vaults Vault operator
 home: https://banzaicloud.com/products/bank-vaults/
 sources:

--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.11.3
-appVersion: 1.11.2
+version: 1.11.4
+appVersion: 1.11.4
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/
 sources:

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -120,8 +120,9 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | volumeMounts                     | extra volume mounts                                                          | `[]`                                |
 | configMapMutation                | enable injecting values from Vault to ConfigMaps                             | `false`                             |
 | customResourceMutations         | list of CustomResources to inject values from Vault                           | `[]`                                |
-| podDisruptionBudget.enabled      | enable PodDisruptionBudget                                                   | `false`                             |
+| podDisruptionBudget.enabled      | enable PodDisruptionBudget                                                   | `true `                             |
 | podDisruptionBudget.minAvailable | represents the number of Pods that must be available (integer or percentage) | `1`                                 |
+| podDisruptionBudget.maxUnavailable | represents the number of Pods that can be unavailable (integer or percentage) | ``                               |
 | certificate.generate             | should a new CA and TLS certificate be generated for the webhook             | `true`                              |
 | certificate.useCertManager       | should request cert-manager for getting a new CA and TLS certificate         | `false`                             |
 | certificate.servingCertificate   | should use an already externally defined Certificate by cert-manager         | `null`                              |

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -158,6 +158,7 @@ objectSelector: {}
 podDisruptionBudget:
   enabled: true
   minAvailable: 1
+  #maxUnavailable: 1
 
 timeoutSeconds: false
 

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -158,7 +158,7 @@ objectSelector: {}
 podDisruptionBudget:
   enabled: true
   minAvailable: 1
-  #maxUnavailable: 1
+  # maxUnavailable: 1
 
 timeoutSeconds: false
 

--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: vault
-version: 1.11.2
-appVersion: 1.11.2
+version: 1.11.4
+appVersion: 1.11.4
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/charts/vault/README.md
+++ b/charts/vault/README.md
@@ -141,6 +141,9 @@ The following tables lists the configurable parameters of the vault chart and th
 | `affinity`           | Node affinity settings for the pods. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/                                                          |  If not set it defaults to`podAntiAffinity` to `preferredDuringSchedulingIgnoredDuringExecution` |
 | `labels`                | Additonal labels to be applied to the Vault StatefulSet and Pods | `{}`                   |
 | `tls.secretName`        | Custom TLS certifcate secret name    | `""`                                               |
+| `podDisruptionBudget.enabled`        | enable PodDisruptionBudget                                                   | `true`                             |
+| `podDisruptionBudget.minAvailable`   | represents the number of Pods that must be available (integer or percentage) | `nil`                                |
+| `podDisruptionBudget.maxUnavailable` | represents the number of Pods that can be unavailable (integer or percentage) | `1`                                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/vault/README.md
+++ b/charts/vault/README.md
@@ -144,6 +144,7 @@ The following tables lists the configurable parameters of the vault chart and th
 | `podDisruptionBudget.enabled`        | enable PodDisruptionBudget                                                   | `true`                             |
 | `podDisruptionBudget.minAvailable`   | represents the number of Pods that must be available (integer or percentage) | `nil`                                |
 | `podDisruptionBudget.maxUnavailable` | represents the number of Pods that can be unavailable (integer or percentage) | `1`                                 |
+| `priorityClassName`     | The PriorityClass to assign to Pods  | `""`                                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/vault/templates/pdb.yaml
+++ b/charts/vault/templates/pdb.yaml
@@ -2,14 +2,13 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "vault-secrets-webhook.fullname" . }}
+  name: {{ template "vault.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    helm.sh/chart: {{ template "vault-secrets-webhook.chart" . }}
-    app.kubernetes.io/name: {{ template "vault-secrets-webhook.name" . }}
+    helm.sh/chart: {{ template "vault.chart" . }}
+    app.kubernetes.io/name: {{ template "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/component: mutating-webhook
 spec:
   {{- with .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ . }}
@@ -19,6 +18,6 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ template "vault-secrets-webhook.name" . }}
+      app.kubernetes.io/name: {{ template "vault.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -259,6 +259,9 @@ spec:
       serviceAccountName: {{ template "vault.serviceAccountName" . }}
       securityContext:
         fsGroup: 65534
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       volumes:
         - name: vault-raw-config
           secret:

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -300,3 +300,7 @@ podDisruptionBudget:
   enabled: true
   #minAvailable: 1
   maxUnavailable: 1
+
+## Assign a PriorityClassName to pods if set
+priorityClassName: ""
+

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -298,9 +298,8 @@ certManager:
 
 podDisruptionBudget:
   enabled: true
-  #minAvailable: 1
+  # minAvailable: 1
   maxUnavailable: 1
 
 ## Assign a PriorityClassName to pods if set
 priorityClassName: ""
-

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -295,3 +295,8 @@ certManager:
     # issuerRef:
     # additionalDomains:
     #   - vault.mydomain.com
+
+podDisruptionBudget:
+  enabled: true
+  #minAvailable: 1
+  maxUnavailable: 1


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
Adds a PodDisruptionBudget to the vault Helm Chart, turned on by default with maxUnavailable set to 1, to avoid issues for people running the default configuration of 1 replica.

Also adds the option to set a priorityClassName to the StatefulSet Pods.

Also adds the option (but no change to default behaviour) to set maxUnavailable on the vault-secret-webhook Helm Chart PDB.


### Why?
Avoids the possibility of downtime if multiple Vault Pods get evicted at once.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)