### PR TITLE
[charts/vault-operator] Support separate tags in operator & bank-vaults images

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-operator
-version: 1.11.5
+version: 1.11.6
 appVersion: 1.11.3
 description: A Helm chart for banzaicloud/bank-vaults Vault operator
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-operator/README.md
+++ b/charts/vault-operator/README.md
@@ -71,7 +71,8 @@ The following table lists the configurable parameters of the vault chart and the
 | `image.pullPolicy`          | Container pull policy                       | `IfNotPresent`                                      |
 | `image.repository`          | Container image to use                      | `banzaicloud/vault-operator`                        |
 | `image.bankVaultsRepository`| Container image to use for Bank-Vaults      | `banzaicloud/bank-vaults`                           |
-| `image.tag`                 | Container image tag to deploy               | `.Chart.AppVersion`                                 |
+| `image.tag`                 | Container image tag to deploy operator in   | `.Chart.AppVersion`                                 |
+| `image.bankVaultsTag`       | Container image tag to deploy bank-vaults in| `.Chart.AppVersion`                                 |
 | `image.imagePullSecrets`    | Image pull secrets for private repositories | `[]`                                                |
 | `replicaCount`              | k8s replicas                                | `1`                                                 |
 | `resources.requests.cpu`    | Container requested CPU                     | `100m`                                              |

--- a/charts/vault-operator/templates/_helpers.tpl
+++ b/charts/vault-operator/templates/_helpers.tpl
@@ -34,8 +34,11 @@ Create chart name and version as used by the chart label.
 {{/*
 Overrideable version for container image tags.
 */}}
-{{- define "vault-operator.bank-vaults.version" -}}
+{{- define "vault-operator.vault-operator.version" -}}
 {{- .Values.image.tag | default (printf "%s" .Chart.AppVersion) -}}
+{{- end -}}
+{{- define "vault-operator.bank-vaults.version" -}}
+{{- .Values.image.bankVaultsTag | default (printf "%s" .Chart.AppVersion) -}}
 {{- end -}}
 
 {{/*

--- a/charts/vault-operator/templates/deployment.yaml
+++ b/charts/vault-operator/templates/deployment.yaml
@@ -40,7 +40,8 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ include "vault-operator.vault-operator.version" . }}"          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.image.repository }}:{{ include "vault-operator.vault-operator.version" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - vault-operator
             - -sync_period

--- a/charts/vault-operator/templates/deployment.yaml
+++ b/charts/vault-operator/templates/deployment.yaml
@@ -40,8 +40,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ include "vault-operator.bank-vaults.version" . }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.image.repository }}:{{ include "vault-operator.vault-operator.version" . }}"          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - vault-operator
             - -sync_period

--- a/charts/vault-operator/templates/deployment.yaml
+++ b/charts/vault-operator/templates/deployment.yaml
@@ -92,3 +92,4 @@ spec:
       serviceAccountName: {{ include "vault-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 {{- include "vault-operator.imagePullSecrets" . | indent 6 }}
+

--- a/charts/vault-operator/templates/deployment.yaml
+++ b/charts/vault-operator/templates/deployment.yaml
@@ -92,4 +92,3 @@ spec:
       serviceAccountName: {{ include "vault-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 {{- include "vault-operator.imagePullSecrets" . | indent 6 }}
-


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This will allow to have separate versions of the the bank-vault & operator containers

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
When you build your own versions of the images you can't necessarily guarantee the same tag for different containers

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
