### PR TITLE
Support separate tags in webhook helm chart for vault-secrets-webhook…

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.11.5
+version: 1.11.6
 appVersion: 1.11.3
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -101,7 +101,8 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | image.repository                 | image repo that contains the admission server                                | `ghcr.io/banzaicloud/vault-secrets-webhook` |
 | image.tag                        | image tag                                                                    | `.Chart.AppVersion`                 |
 | image.imagePullSecrets           | image pull secrets for private repositories                                  | `[]`                                |
-| vaultEnv.repository             | image repo that contains the vault-env container                              | `ghcr.io/banzaicloud/vault-env`     |
+| vaultEnv.repository              | image repo that contains the vault-env container                             | `ghcr.io/banzaicloud/vault-env`     |
+| vaultEnv.tag                     | image tag for the vault-env container                                        | `.Chart.AppVersion`                 |
 | namespaceSelector                | namespace selector to use, will limit webhook scope                          | `{}`                                |
 | objectSelector                | object selector to use, will limit webhook scope (K8s version 1.15+)            | `{}`                                |
 | nodeSelector                     | node selector to use                                                         | `{}`                                |

--- a/charts/vault-secrets-webhook/templates/_helpers.tpl
+++ b/charts/vault-secrets-webhook/templates/_helpers.tpl
@@ -53,6 +53,9 @@ Overrideable version for container image tags.
 {{- define "vault-secrets-webhook.bank-vaults.version" -}}
 {{- .Values.image.tag | default (printf "%s" .Chart.AppVersion) -}}
 {{- end -}}
+{{- define "vault-secrets-webhook.vault-env.version" -}}
+{{- .Values.vaultEnv.tag | default (printf "%s" .Chart.AppVersion) -}}
+{{- end -}}
 
 {{/*
 Create the name of the service account to use

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -67,7 +67,7 @@ spec:
               value: "debug"
             {{- end }}
             - name: VAULT_ENV_IMAGE
-              value: "{{ .Values.vaultEnv.repository }}:{{ include "vault-secrets-webhook.bank-vaults.version" . }}"
+              value: "{{ .Values.vaultEnv.repository }}:{{ include "vault-secrets-webhook.vault-env.version" . }}"
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -49,6 +49,7 @@ webhookClientConfig:
 
 vaultEnv:
   repository: ghcr.io/banzaicloud/vault-env
+  # tag: ""
 
 env:
   VAULT_IMAGE: vault:1.6.2


### PR DESCRIPTION
… repo and vault-env repo

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
This will allow to have separate versions of the the vault-secrets-webhook and vault-env containers

### Why?
When you build your own versions of the images you can't necessarily guarantee the same tag for different containers

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)

