### PR TITLE
vault-secrets-webhook: Add missing objectSelector configuration options

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.11.6
+version: 1.11.7
 appVersion: 1.11.3
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -161,6 +161,10 @@ webhooks:
     {{- if .Values.objectSelector.matchExpressions }}
 {{ toYaml .Values.objectSelector.matchExpressions | indent 4 }}
     {{- end }}
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
     - key: security.banzaicloud.io/mutate
       operator: NotIn
       values:
@@ -221,6 +225,10 @@ webhooks:
     {{- if .Values.objectSelector.matchExpressions }}
 {{ toYaml .Values.objectSelector.matchExpressions | indent 4 }}
     {{- end }}
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
     - key: security.banzaicloud.io/mutate
       operator: NotIn
       values:

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -94,6 +94,10 @@ webhooks:
       - {{ .Release.Namespace }}
 {{- if semverCompare ">=1.15-0" .Capabilities.KubeVersion.GitVersion }}
   objectSelector:
+  {{- if .Values.objectSelector.matchLabels }}
+    matchLabels:
+{{ toYaml .Values.objectSelector.matchLabels | indent 6 }}
+  {{- end }}
     matchExpressions:
     {{- if .Values.objectSelector.matchExpressions }}
 {{ toYaml .Values.objectSelector.matchExpressions | indent 4 }}
@@ -147,6 +151,21 @@ webhooks:
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
+{{- if semverCompare ">=1.15-0" .Capabilities.KubeVersion.GitVersion }}
+  objectSelector:
+  {{- if .Values.objectSelector.matchLabels }}
+    matchLabels:
+{{ toYaml .Values.objectSelector.matchLabels | indent 6 }}
+  {{- end }}
+    matchExpressions:
+    {{- if .Values.objectSelector.matchExpressions }}
+{{ toYaml .Values.objectSelector.matchExpressions | indent 4 }}
+    {{- end }}
+    - key: security.banzaicloud.io/mutate
+      operator: NotIn
+      values:
+      - skip
+{{- end }}
 {{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
   sideEffects: {{ .Values.apiSideEffectValue }}
 {{- end }}
@@ -192,6 +211,21 @@ webhooks:
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
+{{- if semverCompare ">=1.15-0" .Capabilities.KubeVersion.GitVersion }}
+  objectSelector:
+  {{- if .Values.objectSelector.matchLabels }}
+    matchLabels:
+{{ toYaml .Values.objectSelector.matchLabels | indent 6 }}
+  {{- end }}
+    matchExpressions:
+    {{- if .Values.objectSelector.matchExpressions }}
+{{ toYaml .Values.objectSelector.matchExpressions | indent 4 }}
+    {{- end }}
+    - key: security.banzaicloud.io/mutate
+      operator: NotIn
+      values:
+      - skip
+{{- end }}
 {{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
   sideEffects: {{ .Values.apiSideEffectValue }}
 {{- end }}
@@ -240,6 +274,10 @@ webhooks:
       - {{ .Release.Namespace }}
 {{- if semverCompare ">=1.15-0" .Capabilities.KubeVersion.GitVersion }}
   objectSelector:
+  {{- if .Values.objectSelector.matchLabels }}
+    matchLabels:
+{{ toYaml .Values.objectSelector.matchLabels | indent 6 }}
+  {{- end }}
     matchExpressions:
     {{- if .Values.objectSelector.matchExpressions }}
 {{ toYaml .Values.objectSelector.matchExpressions | indent 4 }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -155,6 +155,8 @@ objectSelector: {}
   #   operator: NotIn
   #   values:
   #   - skip
+  # matchLabels:
+  #   vault-injection: enabled
 
 podDisruptionBudget:
   enabled: true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | kind of
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds missing `objectSelector` configuration options to the MutatingWebhookConfiguration resource. On one hand the `objectSelector` was completely missing for some hooks, on the other it did not support the `matchLabels` selector option (to provide the same options as `namespaceSelector`).

In addition, this PR adds a default `objectSelector` rule to not trigger on internal Helm v3 state resources (can be in Secrets or ConfigMaps).

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
My attempts to use the `objectSelector` configuration to prevent the `vault-secrets-webhook` to trigger on internal Helm v3 state resources have failed. By default Helm v3 state is stored in Secrets with a label `owner=helm`, so one would expect this to work:
```yaml
objectSelector:
  matchExpressions:
    - key: owner
      operator: NotIn
      values:
        - helm
```

Unfortunately, it did not work, because hook for the Secret resources was missing the `objectSelector` configuration (it only had
`namespaceSelector`).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] Related Helm chart(s) updated (if needed)
