### PR TITLE
certmanager: use v1 resource versions

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.11.7
+version: 1.11.8
 appVersion: 1.11.3
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
@@ -2,7 +2,7 @@
 ---
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "vault-secrets-webhook.selfSignedIssuer" . }}
@@ -18,7 +18,7 @@ spec:
 ---
 
 # Generate a CA Certificate used to sign certificates for the webhook
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "vault-secrets-webhook.rootCACertificate" . }}
@@ -39,7 +39,7 @@ spec:
 ---
 
 # Create an Issuer that uses the above generated CA certificate to issue certs
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "vault-secrets-webhook.rootCAIssuer" . }}
@@ -56,7 +56,7 @@ spec:
 ---
 
 # Finally, generate a serving certificate for the webhook to use
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "vault-secrets-webhook.servingCertificate" . }}

--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault
-version: 1.11.6
+version: 1.11.7
 appVersion: 1.11.3
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/

--- a/charts/vault/templates/certificate-issuer.yaml
+++ b/charts/vault/templates/certificate-issuer.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.certManager.issuer.enabled -}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ template "vault.fullname" . }}-server-tls

--- a/charts/vault/templates/certificate.yaml
+++ b/charts/vault/templates/certificate.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.certManager.certificate.enabled -}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ template "vault.fullname" . }}-server-tls

--- a/operator/deploy/issuer.yaml
+++ b/operator/deploy/issuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: vault-issuer


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | fixes https://github.com/banzaicloud/bank-vaults/issues/1283
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Upgrading to certmanager v1 resources in charts and examples.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Cert manager v1 has ben released last September, so now it's time to support the stable API version of it.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

