### PR TITLE
Properly check if database connections are already configured.

### DIFF
--- a/internal/vault/operator_client.go
+++ b/internal/vault/operator_client.go
@@ -1188,7 +1188,7 @@ func (v *vault) configureSecretEngines(config *viper.Viper) error {
 
 				var shouldUpdate = true
 				if (createOnly || rotate) && mountExists {
-					var sec interface{}
+					secretExists := false
 					if configOption == "root/generate" { // the pki generate call is a different beast
 						req := v.cl.NewRequest("GET", fmt.Sprintf("/v1/%s/ca", path))
 						resp, err := v.cl.RawRequestWithContext(context.Background(), req)
@@ -1199,16 +1199,19 @@ func (v *vault) configureSecretEngines(config *viper.Viper) error {
 							return errors.Wrapf(err, "failed to check pki CA")
 						}
 						if resp.StatusCode == http.StatusOK {
-							sec = true
+							secretExists = true
 						}
 					} else {
-						sec, err = v.cl.Logical().Read(configPath)
+						secret, err := v.cl.Logical().Read(configPath)
 						if err != nil {
 							return errors.Wrapf(err, "error reading configPath %s", configPath)
 						}
+						if secret != nil && secret.Data != nil {
+							secretExists = true
+						}
 					}
 
-					if sec != nil {
+					if secretExists {
 						reason := "rotate"
 						if createOnly {
 							reason = "create_only"


### PR DESCRIPTION
Fixes #1316

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1316 
| License         | Apache 2.0


### What's in this PR?
Ensure that we properly check if a database connection has actually been configured.

### Why?
Without this fix bank vaults will only try to apply a database connection once. If there is a problem it will never recover.


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
