### PR TITLE
vault-env: Support JWT-based auth methods outside of K8s clusters

### DIFF
--- a/pkg/sdk/vault/client.go
+++ b/pkg/sdk/vault/client.go
@@ -35,7 +35,6 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iam/v1"
 	credentialspb "google.golang.org/genproto/googleapis/iam/credentials/v1"
-	"k8s.io/client-go/rest"
 )
 
 const (
@@ -323,17 +322,9 @@ func NewClientFromRawClient(rawClient *vaultapi.Client, opts ...ClientOption) (*
 		if err == nil {
 			rawClient.SetToken(string(token))
 		} else {
-			// If VAULT_TOKEN, VAULT_TOKEN_PATH or ~/.vault-token wasn't provided let's
-			// suppose we are in Kubernetes and try to get one with the Kubernetes ServiceAccount JWT.
-			//
-			// This logic works for for Vault GCP authentication as well, see:
-			// https://www.vaultproject.io/api/auth/gcp#login
-
-			// Check that we are in Kubernetes
-			_, err := rest.InClusterConfig()
-			if err != nil {
-				return nil, err
-			}
+			// If VAULT_TOKEN, VAULT_TOKEN_PATH or ~/.vault-token wasn't provided,
+			// attempt to get one with supported JWT-based authentication methods
+			// (such as Kubernetes ServiceAccount JWT).
 
 			jwtFile := defaultJWTFile
 			if file := os.Getenv("KUBERNETES_SERVICE_ACCOUNT_TOKEN"); file != "" {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | maybe
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR enables `vault-env` to use JWT-based authentication methods while running outside a Kubernetes cluster (and even from outside cloud providers). It just removes an unnecessary check for running in an Kubernetes environment, that made it impossible to use `vault-env` elsewhere. 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Attempts to use a self-signed GCP SA JWT token (not signed by the metadata server as with `gcp-iam`) with `VAULT_AUTH_METHOD=jwt` resulted in:
```
FATA[0000] failed to create vault clientunable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined  app=vault-env
```

With this PR you can do:
```bash
$ export VAULT_AUTH_METHOD=jwt VAULT_JWT_FILE=/tmp/gcp-jwt.token VAULT_PATH=gcp VAULT_ROLE=mygcprole
$ gcp_create_jwt_token "${GOOGLE_APPLICATION_CREDENTIALS}" "vault/${VAULT_ROLE}" $((15*60)) > "${VAULT_JWT_FILE}"
$ vault-env ./yourcommand
INFO[0001] received new Vault token                      app=vault-env
INFO[0001] initial Vault token arrived                   app=vault-env
INFO[0001] spawning process: [./yourcommand]  app=vault-env
```

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
To use the above, download the GCP SA private key JSON file (set path in `GOOGLE_APPLICATION_CREDENTIALS`) and use the following Bash function (roughly based on https://gist.github.com/jtbonhomme/d41efed3946a400bf5f93d7ccad4283c):
```bash
base64var() {
    printf "$1" | base64stream
}
base64stream() {
    base64 | tr '/+' '_-' | tr -d '=\n'
}
gcp_create_jwt_token() {
    # Creates a GCP locally-signed JWT token using GCP SA private key.
    key_json_file="$1"
    scope="$2"
    valid_for_sec="${3:-3600}"

    private_key_id=$(jq -r .private_key_id $key_json_file)
    private_key=$(jq -r .private_key $key_json_file)
    sa_email=$(jq -r .client_email $key_json_file)

    header=$(jq -c . <<-EOF
    {
        "alg": "RS256",
        "typ": "JWT",
        "kid": "$private_key_id"
    }
EOF
    )
    claim=$(jq -c . <<-EOF
    {
        "sub": "$sa_email",
        "aud": "$scope",
        "exp": $(($(date +%s) + $valid_for_sec)),
        "iat": $(date +%s)
    }
EOF
    )
    request_body="$(base64var "$header").$(base64var "$claim")"
    signature=$(openssl dgst -sha256 -sign <(echo "$private_key") <(printf "$request_body") | base64stream)

    printf "$request_body.$signature"
}
```
Because the JWT token creation is independent of the GCP metadata server, this also works outside GCP.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
