### PR TITLE
Add awskms seal configuration to example

### DIFF
--- a/operator/deploy/cr-awskms.yaml
+++ b/operator/deploy/cr-awskms.yaml
@@ -51,6 +51,12 @@ spec:
         tls_cert_file: /vault/tls/server.crt
         tls_key_file: /vault/tls/server.key
     ui: true
+    # Configure Vault to use AWS KMS seal
+    # See: https://www.vaultproject.io/docs/configuration/seal/awskms for more information.
+    # seal:
+    #   awskms:
+    #     kms_key_id: some-key-id
+    #     region: us-east-1
 
   # See: https://banzaicloud.com/docs/bank-vaults/cli-tool/#example-external-vault-configuration
   # The repository also contains a lot examples in the deploy/ and operator/deploy directories.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | None
| License         | Apache 2.0


### What's in this PR?
This PR adds a piece of configuration to a Vault CR configuration.


### Why?
I'm not sure, but I think this configuration is needed to enable the `awskms` seal, which seems to be the purpose of the said configuration.


### Additional context
I used the configuration as it was and when starting, vault did not print out the expected lines in the logs. Expected lines being:
```
==> Vault server configuration:
         AWS KMS KeyID: some-key-id                                                                                                                                                                                                                                                        
        AWS KMS Region: a-region
```


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] User guide and development docs updated (if needed)
