### PR TITLE
operator: remove usage of VAULT_LOCAL_CONFIG

### DIFF
--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -691,12 +691,12 @@ func (spec *VaultSpec) IsStatsDDisabled() bool {
 }
 
 // ConfigJSON returns the Config field as a JSON string
-func (v *Vault) ConfigJSON() (string, error) {
+func (v *Vault) ConfigJSON() ([]byte, error) {
 	config := map[string]interface{}{}
 
 	err := json.Unmarshal(v.Spec.Config.Raw, &config)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if v.Spec.ServiceRegistrationEnabled && v.Spec.HasHAStorage() {
@@ -709,7 +709,7 @@ func (v *Vault) ConfigJSON() (string, error) {
 		}
 
 		if err := mergo.Merge(&config, serviceRegistration); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
@@ -730,16 +730,16 @@ func (v *Vault) ConfigJSON() (string, error) {
 		}
 
 		if err := mergo.Merge(&config, etcdStorage); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
 	configJSON, err := json.Marshal(config)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return string(configJSON), nil
+	return configJSON, nil
 }
 
 // ExternalConfigJSON returns the ExternalConfig field as a JSON string


### PR DESCRIPTION
Put the vault config into a Secret instead.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | fixes #1327 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
From now on the un-templated Vault config will be put into a Secret instead of plain-text in the VAULT_LOCAL_CONFIG environment variable.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
We wanted to save a creation of a Secret but it seems like a bad idea now.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
