### PR TITLE
vault-secrets-webhook: Allow users to specify resources for init-containers

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.12.0
-appVersion: 1.12.0
+version: 1.12.1
+appVersion: 1.12.1
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/
 sources:

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -117,6 +117,10 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | rbac.psp.enabled                 | use pod security policy                                                      | `false`                             |
 | rbac.authDelegatorRole.enabled    | bind `system:auth-delegator` to the ServiceAccount                          | `false`                             |
 | env.VAULT_IMAGE                  | vault image                                                                  | `vault:1.6.2`                       |
+| env.VAULT_ENV_CPU_REQUEST        | cpu requests for init-containers vault-env and copy-vault-env                | `50m`                               |
+| env.VAULT_ENV_MEMORY_REQUEST     | memory requests for init-containers vault-env and copy-vault-env             | `64Mi`                              |
+| env.VAULT_ENV_CPU_LIMIT          | cpu limits for init-containers vault-env and copy-vault-env                  | `250m`                              |
+| env.VAULT_ENV_MEMORY_LIMIT       | memory limits for init-containers vault-env and copy-vault-env               | `64Mi`                              |
 | volumes                          | extra volume definitions                                                     | `[]`                                |
 | volumeMounts                     | extra volume mounts                                                          | `[]`                                |
 | configMapMutation                | enable injecting values from Vault to ConfigMaps                             | `false`                             |

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -62,6 +62,11 @@ env:
   # # define the webhook's role in Vault used for authentication,
   # # if not defined individually in resources by annotations.
   # VAULT_ROLE: vault-secrets-webhook
+  # Resource requests and limits for init containers
+  # VAULT_ENV_CPU_REQUEST:
+  # VAULT_ENV_MEMORY_REQUEST:
+  # VAULT_ENV_CPU_LIMIT:
+  # VAULT_ENV_MEMORY_LIMIT
 
 metrics:
   enabled: false

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -88,6 +88,10 @@ type VaultConfig struct {
 	Skip                        bool
 	VaultEnvFromPath            string
 	TokenAuthMount              string
+	EnvCPURequest               resource.Quantity
+	EnvMemoryRequest            resource.Quantity
+	EnvCPULimit                 resource.Quantity
+	EnvMemoryLimit              resource.Quantity
 }
 
 func init() {
@@ -122,6 +126,10 @@ func init() {
 	viper.SetDefault("enable_json_log", "false")
 	viper.SetDefault("log_level", "info")
 	viper.SetDefault("vault_agent_share_process_namespace", "")
+	viper.SetDefault("VAULT_ENV_CPU_REQUEST", "")
+	viper.SetDefault("VAULT_ENV_MEMORY_REQUEST", "")
+	viper.SetDefault("VAULT_ENV_CPU_LIMIT", "")
+	viper.SetDefault("VAULT_ENV_MEMORY_LIMIT", "")
 	viper.AutomaticEnv()
 }
 
@@ -364,6 +372,30 @@ func parseVaultConfig(obj metav1.Object) VaultConfig {
 		vaultConfig.CtInjectInInitcontainers, _ = strconv.ParseBool(val)
 	} else {
 		vaultConfig.CtInjectInInitcontainers = false
+	}
+
+	if val, err := resource.ParseQuantity(viper.GetString("VAULT_ENV_CPU_REQUEST")); err == nil {
+		vaultConfig.EnvCPURequest = val
+	} else {
+		vaultConfig.EnvCPURequest = resource.MustParse("50m")
+	}
+
+	if val, err := resource.ParseQuantity(viper.GetString("VAULT_ENV_MEMORY_REQUEST")); err == nil {
+		vaultConfig.EnvMemoryRequest = val
+	} else {
+		vaultConfig.EnvMemoryRequest = resource.MustParse("64Mi")
+	}
+
+	if val, err := resource.ParseQuantity(viper.GetString("VAULT_ENV_CPU_LIMIT")); err == nil {
+		vaultConfig.EnvCPULimit = val
+	} else {
+		vaultConfig.EnvCPULimit = resource.MustParse("250m")
+	}
+
+	if val, err := resource.ParseQuantity(viper.GetString("VAULT_ENV_MEMORY_LIMIT")); err == nil {
+		vaultConfig.EnvMemoryLimit = val
+	} else {
+		vaultConfig.EnvMemoryLimit = resource.MustParse("64Mi")
 	}
 
 	return vaultConfig

--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -620,12 +620,12 @@ func getInitContainers(originalContainers []corev1.Container, podSecurityContext
 			VolumeMounts:    containerVolMounts,
 			Resources: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("250m"),
-					corev1.ResourceMemory: resource.MustParse("64Mi"),
+					corev1.ResourceCPU:    vaultConfig.EnvCPULimit,
+					corev1.ResourceMemory: vaultConfig.EnvMemoryLimit,
 				},
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("50m"),
-					corev1.ResourceMemory: resource.MustParse("64Mi"),
+					corev1.ResourceCPU:    vaultConfig.EnvCPURequest,
+					corev1.ResourceMemory: vaultConfig.EnvMemoryRequest,
 				},
 			},
 		})
@@ -647,12 +647,12 @@ func getInitContainers(originalContainers []corev1.Container, podSecurityContext
 			SecurityContext: getSecurityContext(podSecurityContext, vaultConfig),
 			Resources: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("250m"),
-					corev1.ResourceMemory: resource.MustParse("64Mi"),
+					corev1.ResourceCPU:    vaultConfig.EnvCPULimit,
+					corev1.ResourceMemory: vaultConfig.EnvMemoryLimit,
 				},
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("50m"),
-					corev1.ResourceMemory: resource.MustParse("64Mi"),
+					corev1.ResourceCPU:    vaultConfig.EnvCPURequest,
+					corev1.ResourceMemory: vaultConfig.EnvMemoryRequest,
 				},
 			},
 		})

--- a/cmd/vault-secrets-webhook/pod_test.go
+++ b/cmd/vault-secrets-webhook/pod_test.go
@@ -489,6 +489,10 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 					CtMemory:             resource.MustParse("128Mi"),
 					AgentImage:           "vault:latest",
 					AgentImagePullPolicy: "IfNotPresent",
+					EnvCPURequest:        resource.MustParse("50m"),
+					EnvMemoryRequest:     resource.MustParse("64Mi"),
+					EnvCPULimit:          resource.MustParse("250m"),
+					EnvMemoryLimit:       resource.MustParse("64Mi"),
 				},
 			},
 			wantedPod: &corev1.Pod{
@@ -680,6 +684,10 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 					CtMemory:             resource.MustParse("128Mi"),
 					AgentImage:           "vault:latest",
 					AgentImagePullPolicy: "IfNotPresent",
+					EnvCPURequest:        resource.MustParse("50m"),
+					EnvMemoryRequest:     resource.MustParse("64Mi"),
+					EnvCPULimit:          resource.MustParse("250m"),
+					EnvMemoryLimit:       resource.MustParse("64Mi"),
 				},
 			},
 			wantedPod: &corev1.Pod{
@@ -1030,6 +1038,10 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 					CtMemory:                 resource.MustParse("128Mi"),
 					AgentImage:               "vault:latest",
 					AgentImagePullPolicy:     "IfNotPresent",
+					EnvCPURequest:            resource.MustParse("50m"),
+					EnvMemoryRequest:         resource.MustParse("64Mi"),
+					EnvCPULimit:              resource.MustParse("250m"),
+					EnvMemoryLimit:           resource.MustParse("64Mi"),
 				},
 			},
 			wantedPod: &corev1.Pod{
@@ -1246,6 +1258,10 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 					CtMemory:                 resource.MustParse("128Mi"),
 					AgentImage:               "vault:latest",
 					AgentImagePullPolicy:     "IfNotPresent",
+					EnvCPURequest:            resource.MustParse("50m"),
+					EnvMemoryRequest:         resource.MustParse("64Mi"),
+					EnvCPULimit:              resource.MustParse("250m"),
+					EnvMemoryLimit:           resource.MustParse("64Mi"),
 				},
 			},
 			wantedPod: &corev1.Pod{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1328 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Introduced environment variables ( VAULT_ENV_CPU_REQUEST, VAULT_ENV_MEMORY_REQUEST, VAULT_ENV_CPU_LIMIT, VAULT_ENV_MEMORY_LIMIT) for vault-secrets-webhook. Instead of applying hard-coded values, this provides the users an option to specify resource requests and limits for the init-containers being added during pod mutation for secrets viz _vault-env_ and _copy-vault-env_. Without this change, it is not possible to run mutated pods with "guaranteed" QoS using the default settings - they always run with "burstable".

Hint: Set VAULT_ENV_CPU_LIMIT=50m to be able to run the mutated pod with guaranteed QoS.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [n] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
