### PR TITLE
vault-env/vault-secrets-webhook: Add VAULT_ENV_DELAY and vault-env-delay annotation

### DIFF
--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -79,6 +79,7 @@ var sanitizeEnvmap = map[string]envType{
 	"VAULT_REVOKE_TOKEN":           {login: false},
 	"VAULT_ENV_DAEMON":             {login: false},
 	"VAULT_ENV_FROM_PATH":          {login: false},
+	"VAULT_ENV_DELAY":              {login: false},
 }
 
 // Appends variable an entry (name=value) into the environ list.
@@ -148,6 +149,7 @@ func main() {
 	}
 
 	daemonMode := cast.ToBool(os.Getenv("VAULT_ENV_DAEMON"))
+	delayExec := cast.ToDuration(os.Getenv("VAULT_ENV_DELAY"))
 
 	sigs := make(chan os.Signal, 1)
 
@@ -262,6 +264,11 @@ func main() {
 		}
 
 		client.Close()
+	}
+
+	if delayExec > 0 {
+		logger.Infof("sleeping for %s...", delayExec)
+		time.Sleep(delayExec)
 	}
 
 	logger.Infoln("spawning process:", entrypointCmd)

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -56,6 +56,7 @@ type VaultConfig struct {
 	ClientTimeout               time.Duration
 	UseAgent                    bool
 	VaultEnvDaemon              bool
+	VaultEnvDelay               time.Duration
 	TransitKeyID                string
 	TransitPath                 string
 	CtConfigMap                 string
@@ -196,6 +197,12 @@ func parseVaultConfig(obj metav1.Object) VaultConfig {
 		vaultConfig.VaultEnvDaemon, _ = strconv.ParseBool(val)
 	} else {
 		vaultConfig.VaultEnvDaemon, _ = strconv.ParseBool(viper.GetString("vault_env_daemon"))
+	}
+
+	if val, ok := annotations["vault.security.banzaicloud.io/vault-env-delay"]; ok {
+		vaultConfig.VaultEnvDelay, _ = time.ParseDuration(val)
+	} else {
+		vaultConfig.VaultEnvDelay, _ = time.ParseDuration(viper.GetString("vault_env_delay"))
 	}
 
 	if val, ok := annotations["vault.security.banzaicloud.io/vault-ct-configmap"]; ok {

--- a/cmd/vault-secrets-webhook/pod.go
+++ b/cmd/vault-secrets-webhook/pod.go
@@ -369,6 +369,13 @@ func (mw *mutatingWebhook) mutateContainers(ctx context.Context, containers []co
 			})
 		}
 
+		if vaultConfig.VaultEnvDelay > 0 {
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  "VAULT_ENV_DELAY",
+				Value: vaultConfig.VaultEnvDelay.String(),
+			})
+		}
+
 		if vaultConfig.VaultEnvFromPath != "" {
 			container.Env = append(container.Env, corev1.EnvVar{
 				Name:  "VAULT_ENV_FROM_PATH",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1330
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR implements the proposed fix for race conditions with dynamic secrets (issue #1330). It adds:
- `VAULT_ENV_DELAY` environment var to `vault-env`
- `vault.security.banzaicloud.io/vault-env-delay` annotation to `vault-secrets-webhook`

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
To fix #1330.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
