### PR TITLE
webhook: give back error logging

### DIFF
--- a/pkg/sdk/vault/client.go
+++ b/pkg/sdk/vault/client.go
@@ -502,7 +502,11 @@ func NewClientFromRawClient(rawClient *vaultapi.Client, opts ...ClientOption) (*
 						continue
 					}
 
-					client.logger.Info("received new Vault token")
+					client.logger.Info("received new Vault token", map[string]interface{}{
+						"addr": o.url,
+						"role": o.role,
+						"path": o.authPath,
+					})
 
 					// Set the first token from the response
 					rawClient.SetToken(secret.Auth.ClientToken)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1340
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
After migrating to kubewebhook v2 the framework has dropped error logging, so we have added this back with a a wrapper.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
