### PR TITLE
charts/vault: openshift support

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault
-version: 1.13.0
+version: 1.13.1
 appVersion: 1.13.0
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/

--- a/charts/vault/templates/role.yaml
+++ b/charts/vault/templates/role.yaml
@@ -13,7 +13,7 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   resourceNames: ["bank-vaults"]
-  verbs: ["*"]
+  verbs: ["create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"]
 - apiGroups: [""]
   resources: ["secrets"]
   resourceNames: [""]

--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -262,8 +262,10 @@ spec:
                   app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- end }}
       serviceAccountName: {{ template "vault.serviceAccountName" . }}
+      {{- if not .Values.global.openshift }}
       securityContext:
         fsGroup: 65534
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -1,6 +1,10 @@
 # Default values for vault.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+global:
+  # If deploying to OpenShift
+  openshift: false
+
 replicaCount: 1
 strategy:
   type: RollingUpdate


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1353 
| License         | Apache 2.0


### What's in this PR?

- Adds a global `openshift` flag to be set when deploying to OpenShift. This removes the hard-coded fsGroup from the stateful set
- Explicitly sets the required verbs in the secret-access Role - the default OpenShift config rejects the wildcard currently used.
