### PR TITLE
operator: fix raft ha_storage combined with seal stanza

### DIFF
--- a/internal/vault/operator_client.go
+++ b/internal/vault/operator_client.go
@@ -94,10 +94,10 @@ type Vault interface {
 	Active() (bool, error)
 	Unseal() error
 	Leader() (bool, error)
+	LeaderAddress() (string, error)
 	Configure(config *viper.Viper) error
 }
 
-//
 type KVService interface {
 	Set(key string, value []byte) error
 	Get(key string) ([]byte, error)
@@ -164,6 +164,15 @@ func (v *vault) Leader() (bool, error) {
 	}
 
 	return resp.IsSelf, nil
+}
+
+func (v *vault) LeaderAddress() (string, error) {
+	resp, err := v.cl.Sys().Leader()
+	if err != nil {
+		return "", errors.Wrap(err, "error checking leader address")
+	}
+
+	return resp.LeaderAddress, nil
 }
 
 // Unseal will attempt to unseal vault by retrieving keys from the kms service


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1366 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
In case of Vault built-in auto-unseal and raft ha_storage we should build up the raft cluster correctly.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The operator haven't done this before this fix.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Operator and bank-vaults image update is needed as well when testing this.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
