### PR TITLE
webhook: fix inline-mutation for envFrom constructs

### DIFF
--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -52,7 +52,7 @@ func NewSecretInjector(config Config, client *vault.Client, renewer SecretRenewe
 	return SecretInjector{config: config, client: client, renewer: renewer, logger: logger}
 }
 
-var InlineMutationRegex = regexp.MustCompile(`\${([>]{0,2}vault:.*?)}`)
+var inlineMutationRegex = regexp.MustCompile(`\${([>]{0,2}vault:.*?)}`)
 
 func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inject SecretInjectorFunc) error {
 	transitCache := map[string][]byte{}
@@ -61,8 +61,8 @@ func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inj
 	templater := configuration.NewTemplater(configuration.DefaultLeftDelimiter, configuration.DefaultRightDelimiter)
 
 	for name, value := range references {
-		if hasInlineVaultDelimiters(value) {
-			for _, vaultSecretReference := range findInlineVaultDelimiters(value) {
+		if HasInlineVaultDelimiters(value) {
+			for _, vaultSecretReference := range FindInlineVaultDelimiters(value) {
 				mapData, err := getDataFromVault(map[string]string{name: vaultSecretReference[1]}, i)
 				if err != nil {
 					return err
@@ -296,12 +296,12 @@ func (i SecretInjector) readVaultPath(path, versionOrData string, update bool) (
 	return secretData, nil
 }
 
-func hasInlineVaultDelimiters(value string) bool {
-	return len(findInlineVaultDelimiters(value)) > 0
+func HasInlineVaultDelimiters(value string) bool {
+	return len(FindInlineVaultDelimiters(value)) > 0
 }
 
-func findInlineVaultDelimiters(value string) [][]string {
-	return InlineMutationRegex.FindAllStringSubmatch(value, -1)
+func FindInlineVaultDelimiters(value string) [][]string {
+	return inlineMutationRegex.FindAllStringSubmatch(value, -1)
 }
 
 func getDataFromVault(data map[string]string, secretInjector SecretInjector) (map[string]string, error) {

--- a/pkg/webhook/common.go
+++ b/pkg/webhook/common.go
@@ -15,7 +15,6 @@
 package webhook
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -23,8 +22,6 @@ import (
 	"github.com/banzaicloud/bank-vaults/internal/injector"
 	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
 )
-
-var InlineMutationRegex = regexp.MustCompile(`\${([>]{0,2}vault:.*?)}`)
 
 func getDataFromVault(data map[string]string, vaultClient *vault.Client, vaultConfig VaultConfig, logger logrus.FieldLogger) (map[string]string, error) {
 	vaultData := make(map[string]string, len(data))
@@ -44,12 +41,4 @@ func getDataFromVault(data map[string]string, vaultClient *vault.Client, vaultCo
 
 func hasVaultPrefix(value string) bool {
 	return strings.HasPrefix(value, "vault:") || strings.HasPrefix(value, ">>vault:")
-}
-
-func hasInlineVaultDelimiters(value string) bool {
-	return len(findInlineVaultDelimiters(value)) > 0
-}
-
-func findInlineVaultDelimiters(value string) [][]string {
-	return InlineMutationRegex.FindAllStringSubmatch(value, -1)
 }

--- a/pkg/webhook/configmap.go
+++ b/pkg/webhook/configmap.go
@@ -15,18 +15,17 @@
 package webhook
 
 import (
-	"encoding/base64"
-	"strings"
-
 	"emperror.dev/errors"
+	"encoding/base64"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/banzaicloud/bank-vaults/internal/injector"
 	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
 )
 
 func configMapNeedsMutation(configMap *corev1.ConfigMap) bool {
 	for _, value := range configMap.Data {
-		if hasVaultPrefix(value) || hasInlineVaultDelimiters(value) {
+		if hasVaultPrefix(value) || injector.HasInlineVaultDelimiters(value) {
 			return true
 		}
 	}
@@ -52,24 +51,9 @@ func (mw *MutatingWebhook) MutateConfigMap(configMap *corev1.ConfigMap, vaultCon
 
 	defer vaultClient.Close()
 
-	for key, value := range configMap.Data {
-		if hasInlineVaultDelimiters(value) {
-			data := map[string]string{
-				key: value,
-			}
-			err := mw.mutateInlineConfigMapData(configMap, data, vaultClient, vaultConfig)
-			if err != nil {
-				return err
-			}
-		} else if hasVaultPrefix(value) {
-			data := map[string]string{
-				key: value,
-			}
-			err := mw.mutateConfigMapData(configMap, data, vaultClient, vaultConfig)
-			if err != nil {
-				return err
-			}
-		}
+	configMap.Data, err = getDataFromVault(configMap.Data, vaultClient, vaultConfig, mw.logger)
+	if err != nil {
+		return err
 	}
 
 	for key, value := range configMap.BinaryData {
@@ -80,35 +64,6 @@ func (mw *MutatingWebhook) MutateConfigMap(configMap *corev1.ConfigMap, vaultCon
 			err := mw.mutateConfigMapBinaryData(configMap, binaryData, vaultClient, vaultConfig)
 			if err != nil {
 				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func (mw *MutatingWebhook) mutateConfigMapData(configMap *corev1.ConfigMap, data map[string]string, vaultClient *vault.Client, vaultConfig VaultConfig) error {
-	mapData, err := getDataFromVault(data, vaultClient, vaultConfig, mw.logger)
-	if err != nil {
-		return err
-	}
-
-	for key, value := range mapData {
-		configMap.Data[key] = value
-	}
-
-	return nil
-}
-
-func (mw *MutatingWebhook) mutateInlineConfigMapData(configMap *corev1.ConfigMap, data map[string]string, vaultClient *vault.Client, vaultConfig VaultConfig) error {
-	for key, value := range data {
-		for _, vaultSecretReference := range findInlineVaultDelimiters(value) {
-			mapData, err := getDataFromVault(map[string]string{key: vaultSecretReference[1]}, vaultClient, vaultConfig, mw.logger)
-			if err != nil {
-				return err
-			}
-			for key, value := range mapData {
-				configMap.Data[key] = strings.Replace(configMap.Data[key], vaultSecretReference[0], value, -1)
 			}
 		}
 	}

--- a/pkg/webhook/configmap.go
+++ b/pkg/webhook/configmap.go
@@ -15,8 +15,9 @@
 package webhook
 
 import (
-	"emperror.dev/errors"
 	"encoding/base64"
+
+	"emperror.dev/errors"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/banzaicloud/bank-vaults/internal/injector"

--- a/pkg/webhook/object.go
+++ b/pkg/webhook/object.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/banzaicloud/bank-vaults/internal/injector"
 	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
 )
 
@@ -97,9 +98,9 @@ func traverseObject(o interface{}, vaultClient *vault.Client, vaultConfig VaultC
 				}
 
 				e.Set(dataFromVault["data"])
-			} else if hasInlineVaultDelimiters(s) {
+			} else if injector.HasInlineVaultDelimiters(s) {
 				dataFromVault := s
-				for _, vaultSecretReference := range findInlineVaultDelimiters(s) {
+				for _, vaultSecretReference := range injector.FindInlineVaultDelimiters(s) {
 					mapData, err := getDataFromVault(map[string]string{"data": vaultSecretReference[1]}, vaultClient, vaultConfig, logger)
 					if err != nil {
 						return err

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeVer "k8s.io/apimachinery/pkg/version"
+
+	"github.com/banzaicloud/bank-vaults/internal/injector"
 )
 
 const vaultAgentConfig = `
@@ -217,10 +219,7 @@ func (mw *MutatingWebhook) mutateContainers(ctx context.Context, containers []co
 		}
 
 		for _, env := range container.Env {
-			if hasVaultPrefix(env.Value) {
-				envVars = append(envVars, env)
-			}
-			if hasInlineVaultDelimiters(env.Value) {
+			if hasVaultPrefix(env.Value) || injector.HasInlineVaultDelimiters(env.Value) {
 				envVars = append(envVars, env)
 			}
 			if env.ValueFrom != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1379 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fixing envFrom with inline mutation.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
This wasn't working at all if only inline form data was requested. (Was working if there were simple `vault:...` fields as well).

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
