### PR TITLE
update vault-env main

### DIFF
--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -310,7 +310,7 @@ func main() {
 		if err != nil {
 			exitCode := -1
 			// try to get the original exit code if possible
-			var exitError exec.ExitError
+			var exitError *exec.ExitError
 			if errors.As(err, &exitError) {
 				exitCode = exitError.ExitCode()
 			}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
fix panic
```
panic: errors: *target must be interface or implement error
```

### Why?
`errors.As` will panic if target not a pointer to instance of `error`
`exec.ExitError` is not an instance of `error`, but `*exec.ExitError` is
following code is to reproduce the panic
```go
package main

import (
	"errors"
	"fmt"
	"os/exec"
)

func main() {
	cmd := exec.Command("bash", "-c", "exit 42")

	cmd.Start()

	err := cmd.Wait()

	var exitError exec.ExitError

	if errors.As(err, &exitError) {
		fmt.Println("an ExitError", exitError.ExitCode())
	} else {
		fmt.Println("not an ExitError", err)
	}
}
```