### PR TITLE
[webhook] Draft of namespaced service accounts

### DIFF
--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -16,12 +16,14 @@ package webhook
 
 import (
 	"strconv"
+	"context"
 	"time"
 
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // VaultConfig represents vault options
@@ -72,9 +74,10 @@ type VaultConfig struct {
 	EnvCPULimit                 resource.Quantity
 	EnvMemoryLimit              resource.Quantity
 	VaultNamespace              string
+	ServiceAccountJWT              string
 }
 
-func parseVaultConfig(obj metav1.Object) VaultConfig {
+func parseVaultConfig(ctx context.Context, obj metav1.Object, k8s_client kubernetes.Interface) VaultConfig {
 	var vaultConfig VaultConfig
 	annotations := obj.GetAnnotations()
 
@@ -115,6 +118,26 @@ func parseVaultConfig(obj metav1.Object) VaultConfig {
 		vaultConfig.Path = val
 	} else {
 		vaultConfig.Path = viper.GetString("vault_path")
+	}
+
+	// TODO: Check for flag to verify we want to use namespace-local SAs instead of the vault webhook namespaces SA
+	if val, ok := annotations["vault.security.banzaicloud.io/vault-serviceaccount"]; ok {
+		vaultConfig.AuthMethod = "namespaced"
+		sa, err := k8s_client.CoreV1().ServiceAccounts(obj.GetNamespace()).Get(ctx,val, metav1.GetOptions{})
+		if err != nil {
+			logger.Error("Error retrieving specified service account")
+			return vaultConfig
+		}
+		secret, err := k8s_client.CoreV1().Secrets(obj.GetNamespace()).Get(ctx, sa.Name, metav1.GetOptions{})
+
+		if err != nil {
+			logger.Error("Error retrieving secret for specified service account")
+			return vaultConfig
+		}
+		vaultConfig.ServiceAccountJWT = string(secret.Data["token"])
+
+	} else {
+		vaultConfig.ServiceAccount = viper.GetString("vault_serviceaccount")
 	}
 
 	if val, ok := annotations["vault.security.banzaicloud.io/vault-skip-verify"]; ok {

--- a/pkg/webhook/secret.go
+++ b/pkg/webhook/secret.go
@@ -72,7 +72,7 @@ func (mw *MutatingWebhook) MutateSecret(secret *corev1.Secret, vaultConfig Vault
 		return nil
 	}
 
-	vaultClient, err := mw.newVaultClient(vaultConfig)
+	vaultClient, err := mw.newVaultClient(vaultConfig, mw.k8sClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to create vault client")
 	}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -213,7 +213,8 @@ func (mw *MutatingWebhook) newVaultClient(vaultConfig VaultConfig) (*vault.Clien
 		vault.ClientAuthPath(vaultConfig.Path),
 		vault.ClientAuthMethod(vaultConfig.AuthMethod),
 		vault.ClientLogger(logrusadapter.NewFromEntry(mw.logger)),
-	)
+		vault.ExistingJWT(vaultConfig.ServiceAccountJWT),
+	), nil
 }
 
 func (mw *MutatingWebhook) ServeMetrics(addr string, handler http.Handler) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #929
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Add a new authentication method that uses a token from the same namespace as the resource.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Non-pod resources are mutated with access privileges of the mutating webhook container. This doesn't allow for least privilege principles.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
This is just a first draft to gather some feedback on the general direction.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] Validate general idea
- [ ] Add tests