### PR TITLE
fix(webhook): wrong namespace used for serviceaccount

### DIFF
--- a/pkg/sdk/vault/client.go
+++ b/pkg/sdk/vault/client.go
@@ -464,7 +464,13 @@ func NewClientFromRawClient(rawClient *vaultapi.Client, opts ...ClientOption) (*
 
 			case NamespacedSecretAuthMethod:
 				loginDataFunc = func() (map[string]interface{}, error) {
-					// Projected SA JWTs do expire, so we need to move the reading logic into the loop
+					if len(o.existingSecret) > 0 {
+						return map[string]interface{}{
+							"jwt":  o.existingSecret,
+							"role": o.role,
+						}, nil
+					}
+
 					jwt, err := ioutil.ReadFile(jwtFile)
 					if err != nil {
 						return nil, err


### PR DESCRIPTION
mutated object namespace must be used to inherit  vault policies

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
With the new feature serviceAccount, it is possible to choose which serviceAccount is used by the webhook to connect to Vault. The problem for me is that this serviceAccount is searched/used in the vault-webhook namespace instead of the mutated object namespace.

### Why?
 In our case, vault policies are namespaced and with this fix, vault-webhook namespace doesn't need to have access on all secrets...
