### PR TITLE
fix(webhook-registry): use default value if no ImagePullSecrets was specified in podspec

### DIFF
--- a/pkg/webhook/registry.go
+++ b/pkg/webhook/registry.go
@@ -105,7 +105,7 @@ func (r *Registry) GetImageConfig(
 	// The pod imagePullSecrets did not contained any credentials.
 	// Try to find matching registry credentials in the default imagePullSecret if one was provided.
 	// Otherwise cloud credential providers will be tried.
-	if containerInfo.Namespace == "" && len(containerInfo.ImagePullSecrets) == 0 {
+	if len(containerInfo.ImagePullSecrets) == 0 {
 		containerInfo.Namespace = viper.GetString("default_image_pull_secret_namespace")
 		containerInfo.ImagePullSecrets = []string{viper.GetString("default_image_pull_secret")}
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | May fix  #1384 and #1398
| License         | Apache 2.0


### What's in this PR?
As @fdpeiter suggested, `containerInfo.Namespace` seems to never be empty.  So I changed the condition to only care about the presence of a credential in the pod spec. This will allow to use the default configuration for the auth k8s chain. 
I tried to implement tests but I ran into the use of the remote package which retrieves the image blob.

With this modification, we will always keep the priority of the presence of the configuration in the pod being deployed. 
And this will allow the default configuration to be used in case of absence in this one. 
Since the default value of the two parameters is empty. I don't see any possible impact if the default values are not configured

In order to avoid creating the secret for every possible namespace, I think you should override the namespace with the one present in the configuration. But it makes me worry from a security point of view. I'm not sure it's a good thing to make a private registry accessible to a whole cluster

**_I don't have an Azure cluster available or a private registry to test._** 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)