### PR TITLE
operator: remove direct etcd subchart support

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: vault-operator
-version: 1.13.2
-appVersion: 1.13.1
+version: 1.14.0
+appVersion: 1.14.0
 description: A Helm chart for banzaicloud/bank-vaults Vault operator
 home: https://banzaicloud.com/products/bank-vaults/
 sources:
@@ -12,8 +12,3 @@ sources:
 maintainers:
   - name: Banzai Cloud
     email: info@banzaicloud.com
-dependencies:
-- name: etcd-operator
-  version: 0.11.0
-  repository: https://charts.helm.sh/stable
-  condition: etcd-operator.enabled

--- a/charts/vault-operator/README.md
+++ b/charts/vault-operator/README.md
@@ -34,10 +34,13 @@ helm upgrade --install vault-operator banzaicloud-stable/vault-operator
 
 To install the chart backed with a cluster-wide Etcd Operator, use the following:
 
+**Please note that the etcd-operator has been deprecated for a long time (chart and code as well), and the last version of the chart is not installable on Kubernetes 1.22 and onwards. We don't offer any kind of support for etcd-operator.**
+
 ```bash
-helm upgrade --install vault-operator . \
---set=etcd-operator.enabled=true \
---set=etcd-operator.etcdOperator.commandArgs.cluster-wide=true
+helm upgrade --install vault-operator banzaicloud-stable/vault-operator
+
+helm repo add stable https://charts.helm.sh/stable
+helm upgrade --install etcd-operator stable/etcd-operator --set=etcdOperator.commandArgs.cluster-wide=true
 ```
 
 ### Helm2 -> Helm3 migration
@@ -79,8 +82,7 @@ The following table lists the configurable parameters of the vault chart and the
 | `resources.requests.memory` | Container requested memory                  | `128Mi`                                             |
 | `resources.limits.cpu`      | Container CPU limit                         | `100m`                                              |
 | `resources.limits.memory`   | Container memory limit                      | `256Mi`                                             |
-| `crdAnnotations`            | Annotations for the Vault CRD               | `{}`                                                |
-| `etcd-operator.enabled`     | Install etcd operator as well               | `false`                                             |
+| `crdAnnotations`            | Annotations for the Vault CRD               | `{}`                                                   |
 | `psp.enabled`               | Deploy PSP resources                        | `false`                                             |
 | `psp.vaultSA`               | Used service account for vault              | `vault`                                             |
 

--- a/charts/vault-operator/templates/deployment.yaml
+++ b/charts/vault-operator/templates/deployment.yaml
@@ -30,14 +30,6 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      initContainers:
-      {{- if index .Values "etcd-operator" "enabled" }}
-      - name: check-etcd-crd
-        image: lachlanevenson/k8s-kubectl
-        command: ['kubectl', 'get', 'customresourcedefinitions', 'etcdclusters.etcd.database.coreos.com']
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ include "vault-operator.vault-operator.version" . }}"

--- a/charts/vault-operator/values.yaml
+++ b/charts/vault-operator/values.yaml
@@ -65,13 +65,6 @@ readinessProbe:
   successThreshold: 1
   timeoutSeconds: 1
 
-etcd-operator:
-  enabled: false
-  etcdOperator:
-    commandArgs:
-      cluster-wide: true
-      create-crd: false
-
 psp:
   enabled: false
   vaultSA: "vault"

--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.13.3
-appVersion: 1.13.1
+version: 1.14.0
+appVersion: 1.14.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/
 sources:

--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: vault
-version: 1.13.4
-appVersion: 1.13.1
+version: 1.14.0
+appVersion: 1.14.0
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -47,25 +47,12 @@ helm upgrade --install vault-operator ./charts/vault-operator \
     --set image.tag=latest \
     --set image.bankVaultsTag=latest \
     --set image.pullPolicy=IfNotPresent \
-    --set etcd-operator.enabled=true \
-    --set etcd-operator.deployments.backupOperator=false \
-    --set etcd-operator.deployments.restoreOperator=false \
     --wait
 
 # Install common RBAC setup for CRs
 kubectl apply -f operator/deploy/rbac.yaml
 
-# First test: HA setup with etcd
-kubectl apply -f operator/deploy/cr-etcd-ha.yaml
-waitfor kubectl get etcdclusters.etcd.database.coreos.com/etcd-cluster
-kubectl wait --for=condition=available --timeout=120s etcdclusters.etcd.database.coreos.com/etcd-cluster
-kubectl wait --for=condition=healthy --timeout=180s vault/vault
-kubectl delete -f operator/deploy/cr-etcd-ha.yaml
-kubectl delete secret vault-unseal-keys
-kubectl delete pvc --all
-kubectl delete deployment vault-operator-etcd-operator-etcd-operator # the etcd operator is also unused from this point
-
-# Second test: test the external secrets watcher work and match as expected
+# 1. test: test the external secrets watcher work and match as expected
 kubectl apply -f deploy/test-external-secrets-watch-deployment.yaml
 kubectl wait --for=condition=healthy --timeout=120s vault/vault
 test x`kubectl get pod vault-0 -o jsonpath='{.metadata.annotations.vault\.banzaicloud\.io/watched-secrets-sum}'` = "x"
@@ -80,21 +67,21 @@ kubectl delete -f deploy/test-external-secrets-watch-deployment.yaml
 kubectl delete -f deploy/test-external-secrets-watch-secrets.yaml
 kubectl delete secret vault-unseal-keys
 
-# Third test: Raft HA setup
+# 2. test: Raft HA setup
 kubectl apply -f operator/deploy/cr-raft.yaml
 kubectl wait --for=condition=healthy --timeout=150s vault/vault
 kubectl delete -f operator/deploy/cr-raft.yaml
 kubectl delete secret vault-unseal-keys
 kubectl delete pvc --all
 
-# Fourth test: HSM setup with SoftHSM
+# 3. test: HSM setup with SoftHSM
 kubectl apply -f operator/deploy/cr-hsm-softhsm.yaml
 kubectl wait --for=condition=healthy --timeout=120s vault/vault
 kubectl delete -f operator/deploy/cr-hsm-softhsm.yaml
 kubectl delete secret vault-unseal-keys
 kubectl delete pvc --all
 
-# Fifth test: single node cluster with defined PriorityClass via vaultPodSpec and vaultConfigurerPodSpec
+# 4. test: single node cluster with defined PriorityClass via vaultPodSpec and vaultConfigurerPodSpec
 kubectl apply -f operator/deploy/priorityclass.yaml
 kubectl apply -f operator/deploy/cr-priority.yaml
 kubectl wait --for=condition=healthy --timeout=120s vault/vault
@@ -115,7 +102,7 @@ kubectl delete -f operator/deploy/priorityclass.yaml
 kubectl delete secret vault-unseal-keys
 kubectl delete pvc --all
 
-# Sixth test: Run the OIDC authenticated client test
+# 5. test: Run the OIDC authenticated client test
 kubectl create namespace vswh # create the namespace beforehand, because we need the CA cert here as well
 kubectl create clusterrolebinding oidc-reviewer --clusterrole=system:service-account-issuer-discovery --group=system:unauthenticated
 kubectl apply -f operator/deploy/cr-oidc.yaml

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -54,7 +54,7 @@ kubectl apply -f operator/deploy/rbac.yaml
 
 # 1. test: test the external secrets watcher work and match as expected
 kubectl apply -f deploy/test-external-secrets-watch-deployment.yaml
-kubectl wait --for=condition=healthy --timeout=120s vault/vault
+kubectl wait --for=condition=healthy --timeout=180s vault/vault
 test x`kubectl get pod vault-0 -o jsonpath='{.metadata.annotations.vault\.banzaicloud\.io/watched-secrets-sum}'` = "x"
 kubectl delete -f deploy/test-external-secrets-watch-deployment.yaml
 kubectl delete secret vault-unseal-keys


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| Related tickets | fixes #1410 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
We are removing support for the automatic (and deprecated) etcd-operator install via the vault-operator chart.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
etcd-operator is unmaintained and the chart doesn't support `Kubernetes 1.22 <=`.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
If you still wish to use etcd-operator the code is still in the code base but you have to install it manually, see the README of the vault-operator for instructions.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

