### PR TITLE
Set Vault Namespace on underlying rawClient if it has a non-empty value

### DIFF
--- a/pkg/sdk/vault/client.go
+++ b/pkg/sdk/vault/client.go
@@ -144,7 +144,7 @@ func (co ExistingSecret) apply(o *clientOptions) {
 type VaultNamespace string
 
 func (co VaultNamespace) apply(o *clientOptions) {
-	o.vaultNamespace = co
+	o.vaultNamespace = string(co)
 }
 
 const (
@@ -329,10 +329,7 @@ func NewClientFromRawClient(rawClient *vaultapi.Client, opts ...ClientOption) (*
 
 	// Set vault namespace if defined
 	if o.vaultNamespace != "" {
-		err := rawClient.SetNamespace(o.vaultNamespace)
-		if err != nil {
-			return nil, err
-		}
+		rawClient.SetNamespace(o.vaultNamespace)
 	}
 
 	// Default timeout

--- a/pkg/sdk/vault/client.go
+++ b/pkg/sdk/vault/client.go
@@ -61,6 +61,7 @@ type clientOptions struct {
 	logger         Logger
 	authMethod     ClientAuthMethod
 	existingSecret string
+	vaultNamespace string
 }
 
 // ClientOption configures a Vault client using the functional options paradigm popularized by Rob Pike and Dave Cheney.
@@ -137,6 +138,13 @@ type ExistingSecret string
 
 func (co ExistingSecret) apply(o *clientOptions) {
 	o.existingSecret = string(co)
+}
+
+// Vault Enterprise Namespace (not Kubernetes namespace)
+type VaultNamespace string
+
+func (co VaultNamespace) apply(o *clientOptions) {
+	o.vaultNamespace = co
 }
 
 const (
@@ -316,6 +324,14 @@ func NewClientFromRawClient(rawClient *vaultapi.Client, opts ...ClientOption) (*
 		o.tokenPath = os.Getenv("HOME") + "/.vault-token"
 		if env, ok := os.LookupEnv("VAULT_TOKEN_PATH"); ok {
 			o.tokenPath = env
+		}
+	}
+
+	// Set vault namespace if defined
+	if o.vaultNamespace != "" {
+		err := rawClient.SetNamespace(o.vaultNamespace)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -237,6 +237,7 @@ func (mw *MutatingWebhook) newVaultClient(vaultConfig VaultConfig) (*vault.Clien
 		vault.ClientAuthPath(vaultConfig.Path),
 		vault.ClientAuthMethod(vaultConfig.AuthMethod),
 		vault.ClientLogger(logrusadapter.NewFromEntry(mw.logger)),
+		vault.VaultNamespace(vaultConfig.VaultNamespace),
 	)
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #917 , completes #1361 
| License         | Apache 2.0


### What's in this PR?
This completes the work in PR #1361 .  This enables mutation of non-pod resources like secrets.  It sets the vault namespace on the underlying `rawClient` used in [pkg/sdk/vault/client.go](https://github.com/banzaicloud/bank-vaults/blob/master/pkg/sdk/vault/client.go)


### Why?
Even though PR #1361 parses out `vault-namespace` from a resource's annotation, it does not set that value on the underlying vault client.


### Additional context
As described in #917, this is not an issue for pods that set the `VAULT_NAMESPACE` environment variable. Setting this environment variable does get picked up by the client, see https://github.com/hashicorp/vault/blob/v1.8.2/api/client.go#L484


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
