### PR TITLE
Fix API versions for k8s < 1.21

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.14.0
+version: 1.14.1
 appVersion: 1.14.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/templates/_helpers.tpl
+++ b/charts/vault-secrets-webhook/templates/_helpers.tpl
@@ -67,3 +67,45 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the target Kubernetes version.
+https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_capabilities.tpl
+*/}}
+{{- define "vault-secrets-webhook.capabilities.kubeVersion" -}}
+{{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for policy.
+*/}}
+{{- define "vault-secrets-webhook.capabilities.policy.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "vault-secrets-webhook.capabilities.ingress.apiVersion" -}}
+{{- if .Values.ingress -}}
+{{- if .Values.ingress.apiVersion -}}
+{{- .Values.ingress.apiVersion -}}
+{{- else if semverCompare "<1.14-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end }}
+{{- else if semverCompare "<1.14-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -35,7 +35,7 @@ data:
   ca.crt:  {{ $caCrt }}
 {{- end }}
 ---
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.16-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
 apiVersion: admissionregistration.k8s.io/v1
 {{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -53,7 +53,7 @@ metadata:
 {{- end }}
 webhooks:
 - name: pods.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
-  {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.14-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   admissionReviewVersions: ["v1beta1"]
   {{- if .Values.timeoutSeconds }}
   timeoutSeconds: {{ .Values.timeoutSeconds }}
@@ -92,7 +92,7 @@ webhooks:
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
-{{- if semverCompare ">=1.15-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.15-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   objectSelector:
   {{- if .Values.objectSelector.matchLabels }}
     matchLabels:
@@ -107,11 +107,11 @@ webhooks:
       values:
       - skip
 {{- end }}
-{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.12-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   sideEffects: {{ .Values.apiSideEffectValue }}
 {{- end }}
 - name: secrets.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
-  {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.14-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   admissionReviewVersions: ["v1beta1"]
   {{- if .Values.timeoutSeconds }}
   timeoutSeconds: {{ .Values.timeoutSeconds }}
@@ -151,7 +151,7 @@ webhooks:
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
-{{- if semverCompare ">=1.15-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.15-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   objectSelector:
   {{- if .Values.objectSelector.matchLabels }}
     matchLabels:
@@ -170,12 +170,12 @@ webhooks:
       values:
       - skip
 {{- end }}
-{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.12-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   sideEffects: {{ .Values.apiSideEffectValue }}
 {{- end }}
 {{- if .Values.configMapMutation }}
 - name: configmaps.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
-  {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.14-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   admissionReviewVersions: ["v1beta1"]
   {{- if .Values.timeoutSeconds }}
   timeoutSeconds: {{ .Values.timeoutSeconds }}
@@ -215,7 +215,7 @@ webhooks:
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
-{{- if semverCompare ">=1.15-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.15-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   objectSelector:
   {{- if .Values.objectSelector.matchLabels }}
     matchLabels:
@@ -234,13 +234,13 @@ webhooks:
       values:
       - skip
 {{- end }}
-{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.12-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   sideEffects: {{ .Values.apiSideEffectValue }}
 {{- end }}
 {{- end }}
 {{- if .Values.customResourceMutations }}
 - name: objects.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
-  {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.14-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   admissionReviewVersions: ["v1beta1"]
   {{- if .Values.timeoutSeconds }}
   timeoutSeconds: {{ .Values.timeoutSeconds }}
@@ -280,7 +280,7 @@ webhooks:
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
-{{- if semverCompare ">=1.15-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.15-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   objectSelector:
   {{- if .Values.objectSelector.matchLabels }}
     matchLabels:
@@ -295,7 +295,7 @@ webhooks:
       values:
       - skip
 {{- end }}
-{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.12-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   sideEffects: {{ .Values.apiSideEffectValue }}
 {{- end }}
 {{- end }}

--- a/charts/vault-secrets-webhook/templates/webhook-ingress.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled }}
 ---
-apiVersion: networking.k8s.io/v1
+apiVersion: {{ include "vault-secrets-webhook.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "vault-secrets-webhook.fullname" . }}

--- a/charts/vault-secrets-webhook/templates/webhook-pdb.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1
+apiVersion: {{ include "vault-secrets-webhook.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "vault-secrets-webhook.fullname" . }}

--- a/charts/vault-secrets-webhook/templates/webhook-psp.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.psp.enabled }}
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.16-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
 apiVersion: policy/v1beta1
 {{- else  }}
 apiVersion: extensions/v1beta1
@@ -35,7 +35,7 @@ spec:
   - emptyDir
   - configMap
 ---
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.16-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
 apiVersion: policy/v1beta1
 {{- else  }}
 apiVersion: extensions/v1beta1

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -173,3 +173,6 @@ podDisruptionBudget:
 timeoutSeconds: false
 
 hostNetwork: false
+
+# Override cluster version
+kubeVersion: ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This fixes chart deployment in clusters with version < 1.21 due to breaking change introduced at https://github.com/banzaicloud/bank-vaults/pull/1404.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Happy to do the same changes in the Vault chart if all looks good.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] Related Helm chart(s) updated (if needed)

