### PR TITLE
webhook: fix registry lookup, add test for validating it in the future

### DIFF
--- a/deploy/test-deployment.yaml
+++ b/deploy/test-deployment.yaml
@@ -41,3 +41,13 @@ spec:
           limits:
             memory: "128Mi"
             cpu: "100m"
+      # Try a container without explicit command to exercise the registry lookup feature
+      - name: redis
+        image: redis
+        env:
+          - name: AWS_SECRET_ACCESS_KEY
+            value: vault:secret/data/accounts/aws#AWS_SECRET_ACCESS_KEY
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "100m"

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/slok/kubewebhook/v2/pkg/model"
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -73,10 +74,14 @@ type VaultConfig struct {
 	EnvMemoryLimit              resource.Quantity
 	VaultNamespace              string
 	VaultServiceAccount         string
+	ObjectNamespace             string
 }
 
-func parseVaultConfig(obj metav1.Object) VaultConfig {
-	var vaultConfig VaultConfig
+func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig {
+	vaultConfig := VaultConfig{
+		ObjectNamespace: ar.Namespace,
+	}
+
 	annotations := obj.GetAnnotations()
 
 	if val := annotations["vault.security.banzaicloud.io/mutate"]; val == "skip" {

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -62,7 +62,6 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 		containers  []corev1.Container
 		podSpec     *corev1.PodSpec
 		vaultConfig VaultConfig
-		ns          string
 	}
 	tests := []struct {
 		name             string
@@ -411,7 +410,7 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 				registry:  ttp.fields.registry,
 				logger:    logrus.NewEntry(logrus.New()),
 			}
-			got, err := mw.mutateContainers(context.Background(), ttp.args.containers, ttp.args.podSpec, ttp.args.vaultConfig, ttp.args.ns)
+			got, err := mw.mutateContainers(context.Background(), ttp.args.containers, ttp.args.podSpec, ttp.args.vaultConfig)
 			if (err != nil) != ttp.wantErr {
 				t.Errorf("MutatingWebhook.mutateContainers() error = %v, wantErr %v", err, ttp.wantErr)
 				return
@@ -436,7 +435,6 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 	type args struct {
 		pod         *corev1.Pod
 		vaultConfig VaultConfig
-		ns          string
 	}
 	defaultMode := int32(420)
 	runAsUser := int64(100)
@@ -1438,7 +1436,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 				registry:  ttp.fields.registry,
 				logger:    logrus.NewEntry(logrus.New()),
 			}
-			err := mw.MutatePod(context.Background(), ttp.args.pod, ttp.args.vaultConfig, ttp.args.ns, false)
+			err := mw.MutatePod(context.Background(), ttp.args.pod, ttp.args.vaultConfig, false)
 			if (err != nil) != ttp.wantErr {
 				t.Errorf("MutatingWebhook.MutatePod() error = %v, wantErr %v", err, ttp.wantErr)
 				return

--- a/pkg/webhook/registry.go
+++ b/pkg/webhook/registry.go
@@ -102,12 +102,15 @@ func (r *Registry) GetImageConfig(
 		containerInfo.ImagePullSecrets = append(containerInfo.ImagePullSecrets, imagePullSecret.Name)
 	}
 
-	// The pod imagePullSecrets did not contained any credentials.
+	// The pod imagePullSecrets did not contain any credentials.
 	// Try to find matching registry credentials in the default imagePullSecret if one was provided.
-	// Otherwise cloud credential providers will be tried.
-	if len(containerInfo.ImagePullSecrets) == 0 {
-		containerInfo.Namespace = viper.GetString("default_image_pull_secret_namespace")
-		containerInfo.ImagePullSecrets = []string{viper.GetString("default_image_pull_secret")}
+	// Otherwise, cloud credential providers will be tried.
+	defaultImagePullSecretNamespace := viper.GetString("default_image_pull_secret_namespace")
+	defaultImagePullSecret := viper.GetString("default_image_pull_secret")
+	if len(containerInfo.ImagePullSecrets) == 0 &&
+		defaultImagePullSecretNamespace != "" && defaultImagePullSecret != "" {
+		containerInfo.Namespace = defaultImagePullSecretNamespace
+		containerInfo.ImagePullSecrets = []string{defaultImagePullSecret}
 	}
 
 	imageConfig, err := getImageConfig(ctx, client, containerInfo)
@@ -122,17 +125,19 @@ func (r *Registry) GetImageConfig(
 func getImageConfig(ctx context.Context, client kubernetes.Interface, container containerInfo) (*v1.Config, error) {
 	registrySkipVerify := viper.GetBool("registry_skip_verify")
 
+	chainOpts := k8schain.Options{
+		Namespace:          container.Namespace,
+		ServiceAccountName: container.ServiceAccountName,
+		ImagePullSecrets:   container.ImagePullSecrets,
+	}
+
 	authChain, err := k8schain.New(
 		ctx,
 		client,
-		k8schain.Options{
-			Namespace:          container.Namespace,
-			ServiceAccountName: container.ServiceAccountName,
-			ImagePullSecrets:   container.ImagePullSecrets,
-		},
+		chainOpts,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create k8schain authentication")
+		return nil, errors.Wrapf(err, "failed to create k8schain authentication, opts: %+v", chainOpts)
 	}
 
 	options := []remote.Option{

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -39,17 +39,14 @@ import (
 )
 
 type MutatingWebhook struct {
-	k8sClient         kubernetes.Interface
-	namespace         string
-	mutationNamespace string
-	registry          ImageRegistry
-	logger            *logrus.Entry
+	k8sClient kubernetes.Interface
+	namespace string
+	registry  ImageRegistry
+	logger    *logrus.Entry
 }
 
 func (mw *MutatingWebhook) VaultSecretsMutator(ctx context.Context, ar *model.AdmissionReview, obj metav1.Object) (*mutating.MutatorResult, error) {
-	vaultConfig := parseVaultConfig(obj)
-
-	mw.mutationNamespace = ar.Namespace
+	vaultConfig := parseVaultConfig(obj, ar)
 
 	if vaultConfig.Skip {
 		return &mutating.MutatorResult{}, nil
@@ -57,7 +54,7 @@ func (mw *MutatingWebhook) VaultSecretsMutator(ctx context.Context, ar *model.Ad
 
 	switch v := obj.(type) {
 	case *corev1.Pod:
-		return &mutating.MutatorResult{MutatedObject: v}, mw.MutatePod(ctx, v, vaultConfig, ar.Namespace, ar.DryRun)
+		return &mutating.MutatorResult{MutatedObject: v}, mw.MutatePod(ctx, v, vaultConfig, ar.DryRun)
 
 	case *corev1.Secret:
 		return &mutating.MutatorResult{MutatedObject: v}, mw.MutateSecret(v, vaultConfig)
@@ -211,14 +208,14 @@ func (mw *MutatingWebhook) newVaultClient(vaultConfig VaultConfig) (*vault.Clien
 	}
 
 	if vaultConfig.VaultServiceAccount != "" {
-		sa, err := mw.k8sClient.CoreV1().ServiceAccounts(mw.mutationNamespace).Get(context.Background(), vaultConfig.VaultServiceAccount, metav1.GetOptions{})
+		sa, err := mw.k8sClient.CoreV1().ServiceAccounts(vaultConfig.ObjectNamespace).Get(context.Background(), vaultConfig.VaultServiceAccount, metav1.GetOptions{})
 		if err != nil {
-			return nil, errors.Wrap(err, "Failed to retrieve specified service account on namespace "+mw.mutationNamespace)
+			return nil, errors.Wrap(err, "Failed to retrieve specified service account on namespace "+vaultConfig.ObjectNamespace)
 		}
 
-		secret, err := mw.k8sClient.CoreV1().Secrets(mw.mutationNamespace).Get(context.Background(), sa.Secrets[0].Name, metav1.GetOptions{})
+		secret, err := mw.k8sClient.CoreV1().Secrets(vaultConfig.ObjectNamespace).Get(context.Background(), sa.Secrets[0].Name, metav1.GetOptions{})
 		if err != nil {
-			return nil, errors.Wrap(err, "Failed to retrieve secret for service account "+sa.Secrets[0].Name+" in namespace "+mw.mutationNamespace)
+			return nil, errors.Wrap(err, "Failed to retrieve secret for service account "+sa.Secrets[0].Name+" in namespace "+vaultConfig.ObjectNamespace)
 		}
 
 		return vault.NewClientFromConfig(


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1416 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix for registry lookup and for a race condition as well in the mutating webhook. Added test for the registry lookup.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Mutation for pods without explicit commands were broken in 1.14.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
