### PR TITLE
Fix API versions for k8s < 1.21 for the vault chart

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: vault
 version: 1.14.2
-appVersion: 1.14.2
+appVersion: 1.14.1
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: vault
-version: 1.14.1
-appVersion: 1.14.1
+version: 1.14.2
+appVersion: 1.14.2
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/charts/vault/templates/_helpers.tpl
+++ b/charts/vault/templates/_helpers.tpl
@@ -48,3 +48,45 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the target Kubernetes version.
+https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_capabilities.tpl
+*/}}
+{{- define "vault.capabilities.kubeVersion" -}}
+{{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for policy.
+*/}}
+{{- define "vault.capabilities.policy.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "vault.capabilities.kubeVersion" .) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "vault.capabilities.ingress.apiVersion" -}}
+{{- if .Values.ingress -}}
+{{- if .Values.ingress.apiVersion -}}
+{{- .Values.ingress.apiVersion -}}
+{{- else if semverCompare "<1.14-0" (include "vault.capabilities.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (include "vault.capabilities.kubeVersion" .) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end }}
+{{- else if semverCompare "<1.14-0" (include "vault.capabilities.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (include "vault.capabilities.kubeVersion" .) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/vault/templates/ingress.yaml
+++ b/charts/vault/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "vault.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
-apiVersion: networking.k8s.io/v1
+apiVersion: {{ include "vault.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "vault.fullname" . }}

--- a/charts/vault/templates/pdb.yaml
+++ b/charts/vault/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1
+apiVersion: {{ include "vault.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "vault.fullname" . }}

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -309,3 +309,6 @@ podDisruptionBudget:
 
 ## Assign a PriorityClassName to pods if set
 priorityClassName: ""
+
+# Override cluster version
+kubeVersion: ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1420
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This fixes chart deployment in clusters with version < 1.21 due to breaking change introduced at #1404 but not covered in #1413

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The `vault` chart has some places that was missing from the fix.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
