### PR TITLE
webhook:  mutate container probes

### DIFF
--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -75,6 +75,7 @@ type VaultConfig struct {
 	VaultNamespace              string
 	VaultServiceAccount         string
 	ObjectNamespace             string
+	MutateProbes                bool
 }
 
 func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig {
@@ -356,6 +357,12 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 		vaultConfig.EnvMemoryLimit = val
 	} else {
 		vaultConfig.EnvMemoryLimit = resource.MustParse("64Mi")
+	}
+
+	if val, ok := annotations["vault.security.banzaicloud.io/mutate-probes"]; ok {
+		vaultConfig.MutateProbes, _ = strconv.ParseBool(val)
+	} else {
+		vaultConfig.MutateProbes = false
 	}
 
 	return vaultConfig

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -279,6 +279,22 @@ func (mw *MutatingWebhook) mutateContainers(ctx context.Context, containers []co
 		container.Command = []string{"/vault/vault-env"}
 		container.Args = args
 
+		// mutate probes if needed
+		if vaultConfig.MutateProbes {
+			// mutate LivenessProbe
+			if container.LivenessProbe != nil && container.LivenessProbe.Exec != nil {
+				lProbeCmd := container.LivenessProbe.Exec.Command
+				container.LivenessProbe.Exec.Command = []string{"/vault/vault-env"}
+				container.LivenessProbe.Exec.Command = append(container.LivenessProbe.Exec.Command, lProbeCmd...)
+			}
+			// mutate LivenessProbe
+			if container.ReadinessProbe != nil && container.ReadinessProbe.Exec != nil {
+				rProbeCmd := container.ReadinessProbe.Exec.Command
+				container.ReadinessProbe.Exec.Command = []string{"/vault/vault-env"}
+				container.ReadinessProbe.Exec.Command = append(container.ReadinessProbe.Exec.Command, rProbeCmd...)
+			}
+		}
+
 		container.VolumeMounts = append(container.VolumeMounts, []corev1.VolumeMount{
 			{
 				Name:      VaultEnvVolumeName,

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -238,7 +238,8 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 						LivenessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
 								Exec: &corev1.ExecAction{
-									Command: []string{"/bin/bash"}},
+									Command: []string{"/bin/bash"},
+								},
 							},
 						},
 						Env: []corev1.EnvVar{
@@ -263,7 +264,8 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 					LivenessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							Exec: &corev1.ExecAction{
-								Command: []string{"/vault/vault-env", "/bin/bash"}},
+								Command: []string{"/vault/vault-env", "/bin/bash"},
+							},
 						},
 					},
 					Env: []corev1.EnvVar{

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -238,7 +238,7 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 						LivenessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
 								Exec: &corev1.ExecAction{
-									Command: []string{"/true"}},
+									Command: []string{"/bin/bash"}},
 							},
 						},
 						Env: []corev1.EnvVar{
@@ -263,7 +263,7 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 					LivenessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							Exec: &corev1.ExecAction{
-								Command: []string{"/vault/vault-env", "/true"}},
+								Command: []string{"/vault/vault-env", "/bin/bash"}},
 						},
 					},
 					Env: []corev1.EnvVar{

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -221,6 +221,69 @@ func Test_mutatingWebhook_mutateContainers(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Will mutate container with probes",
+			fields: fields{
+				k8sClient: fake.NewSimpleClientset(),
+				registry: &MockRegistry{
+					Image: v1.Config{},
+				},
+			},
+			args: args{
+				containers: []corev1.Container{
+					{
+						Name:    "MyContainer",
+						Image:   "myimage",
+						Command: []string{"/bin/bash"},
+						Args:    nil,
+						LivenessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								Exec: &corev1.ExecAction{
+									Command: []string{"/true"}},
+							},
+						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  "myvar",
+								Value: "vault:secrets",
+							},
+						},
+					},
+				},
+				vaultConfig: VaultConfig{
+					MutateProbes: true,
+				},
+			},
+			wantedContainers: []corev1.Container{
+				{
+					Name:         "MyContainer",
+					Image:        "myimage",
+					Command:      []string{"/vault/vault-env"},
+					Args:         []string{"/bin/bash"},
+					VolumeMounts: []corev1.VolumeMount{{Name: "vault-env", MountPath: "/vault/"}},
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							Exec: &corev1.ExecAction{
+								Command: []string{"/vault/vault-env", "/true"}},
+						},
+					},
+					Env: []corev1.EnvVar{
+						{Name: "myvar", Value: "vault:secrets"},
+						{Name: "VAULT_ADDR", Value: ""},
+						{Name: "VAULT_SKIP_VERIFY", Value: "false"},
+						{Name: "VAULT_AUTH_METHOD", Value: ""},
+						{Name: "VAULT_PATH", Value: ""},
+						{Name: "VAULT_ROLE", Value: ""},
+						{Name: "VAULT_IGNORE_MISSING_SECRETS", Value: ""},
+						{Name: "VAULT_ENV_PASSTHROUGH", Value: ""},
+						{Name: "VAULT_JSON_LOG", Value: ""},
+						{Name: "VAULT_CLIENT_TIMEOUT", Value: "0s"},
+					},
+				},
+			},
+			mutated: true,
+			wantErr: false,
+		},
+		{
 			name: "Will mutate container with no container-command, no entrypoint",
 			fields: fields{
 				k8sClient: fake.NewSimpleClientset(),


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
In some cases values from vault are needed for container probes. In this PR I add `vault-env` into exec command of liveness and readiness probes 


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
