### PR TITLE
Addition of dnsPolicy for deployment in helm chart

### DIFF
--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -36,6 +36,9 @@ spec:
       {{- if .Values.hostNetwork}}
       hostNetwork: {{ .Values.hostNetwork}}
       {{- end }}
+      {{ with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
       serviceAccountName: {{ template "vault-secrets-webhook.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -162,3 +162,7 @@ podDisruptionBudget:
 timeoutSeconds: false
 
 hostNetwork: false
+
+# If you're using celium (CNI) and you are required to set hostNetwork to true
+# then pods with webhooks must set the dnsPolicy to "ClusterFirstWithHostNet"
+dnsPolicy: Default


### PR DESCRIPTION
Signed-off-by: Jim Conner <snafu.x@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
Adds adidtion of `dnsPolicy` definition to helm chart, values.yaml, and documentation to README.md


### Why?
We recently switched to using `celium` as our CNI. When using `celium` in certain modes, it's required to run pods using webhooks with `hostNetwork: true`. When this is the case, `dnsPolicy` *must* be set to `ClusterFirstWithHostNet`. Unfortunately, this requires us to now self-manage the helm chart. This change, if merged to upstream, would allow us to again start sourcing the publicly available chart.

### Checklist
- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)

