### PR TITLE
webhook: add syslog capability to vault-env

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.14.2
+version: 1.14.3
 appVersion: 1.14.1
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -122,6 +122,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | env.VAULT_ENV_MEMORY_REQUEST       | memory requests for init-containers vault-env and copy-vault-env              | `64Mi`                                                   |
 | env.VAULT_ENV_CPU_LIMIT            | cpu limits for init-containers vault-env and copy-vault-env                   | `250m`                                                   |
 | env.VAULT_ENV_MEMORY_LIMIT         | memory limits for init-containers vault-env and copy-vault-env                | `64Mi`                                                   |
+| env.VAULT_ENV_LOG_SERVER           | define remote log server for vault-env                                        | ``                                                   |
 | volumes                            | extra volume definitions                                                      | `[]`                                                     |
 | volumeMounts                       | extra volume mounts                                                           | `[]`                                                     |
 | configMapMutation                  | enable injecting values from Vault to ConfigMaps                              | `false`                                                  |

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -67,6 +67,7 @@ env:
   # VAULT_ENV_MEMORY_REQUEST:
   # VAULT_ENV_CPU_LIMIT:
   # VAULT_ENV_MEMORY_LIMIT
+  # VAULT_ENV_LOG_SERVER:
 
 metrics:
   enabled: false

--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"log/syslog"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -27,6 +28,7 @@ import (
 	"emperror.dev/errors"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/sirupsen/logrus"
+	logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 	"github.com/spf13/cast"
 	logrusadapter "logur.dev/adapter/logrus"
 
@@ -147,6 +149,14 @@ func main() {
 			log.SetFormatter(&logrus.JSONFormatter{})
 		}
 		logger = log.WithField("app", "vault-env")
+
+		envLogServer := os.Getenv("VAULT_ENV_LOG_SERVER")
+		if envLogServer != "" {
+			hook, err := logrus_syslog.NewSyslogHook("udp", envLogServer, syslog.LOG_INFO, "")
+			if err == nil {
+				log.Hooks.Add(hook)
+			}
+		}
 	}
 
 	if len(os.Args) == 1 {

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -65,6 +65,7 @@ type VaultConfig struct {
 	AgentImagePullPolicy        corev1.PullPolicy
 	EnvImage                    string
 	EnvImagePullPolicy          corev1.PullPolicy
+	EnvLogServer                string
 	Skip                        bool
 	VaultEnvFromPath            string
 	TokenAuthMount              string
@@ -306,6 +307,9 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 	} else {
 		vaultConfig.EnvImage = viper.GetString("vault_env_image")
 	}
+
+	vaultConfig.EnvLogServer = viper.GetString("VAULT_ENV_LOG_SERVER")
+
 	if val, ok := annotations["vault.security.banzaicloud.io/vault-env-image-pull-policy"]; ok {
 		vaultConfig.EnvImagePullPolicy = getPullPolicy(val)
 	} else {
@@ -416,6 +420,7 @@ func SetConfigDefaults() {
 	viper.SetDefault("VAULT_ENV_MEMORY_REQUEST", "")
 	viper.SetDefault("VAULT_ENV_CPU_LIMIT", "")
 	viper.SetDefault("VAULT_ENV_MEMORY_LIMIT", "")
+	viper.SetDefault("VAULT_ENV_LOG_SERVER", "")
 	viper.SetDefault("VAULT_NAMESPACE", "")
 	viper.AutomaticEnv()
 }

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -422,6 +422,13 @@ func (mw *MutatingWebhook) mutateContainers(ctx context.Context, containers []co
 			})
 		}
 
+		if vaultConfig.EnvLogServer != "" {
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  "VAULT_ENV_LOG_SERVER",
+				Value: vaultConfig.EnvLogServer,
+			})
+		}
+
 		containers[i] = container
 	}
 


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add syslog hook to logrus in vault-env.

### Why?
With this feature, vault-env can log to a remote log server.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

