### PR TITLE
add attribute in the Vault CRD for specific logging config filename.

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-operator
-version: 1.14.4
+version: 1.14.5
 appVersion: 1.14.3
 description: A Helm chart for banzaicloud/bank-vaults Vault operator
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-operator/crds/crd.yaml
+++ b/charts/vault-operator/crds/crd.yaml
@@ -746,6 +746,8 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               fleuntdConfLocation:
                 type: string
+              fluentdConfFile:
+                type: string
               fluentdConfig:
                 type: string
               fluentdEnabled:

--- a/operator/deploy/cr-audit.yaml
+++ b/operator/deploy/cr-audit.yaml
@@ -25,6 +25,7 @@ spec:
   fluentdEnabled: true
   fluentdImage: banzaicloud/fluentd-s3:latest
   fleuntdConfLocation: "/fluentd/etc"
+  #fluentdConfFile: "fluent.conf" # default value
   fluentdConfig: |
     <source>
       @type tail

--- a/operator/deploy/crd.yaml
+++ b/operator/deploy/crd.yaml
@@ -746,6 +746,8 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               fleuntdConfLocation:
                 type: string
+              fluentdConfFile:
+                type: string
               fluentdConfig:
                 type: string
               fluentdEnabled:

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -111,6 +111,10 @@ type VaultSpec struct {
 	// default: "/fluentd/etc"
 	FleuntDConfLocation string `json:"fleuntdConfLocation,omitempty"`
 
+	// FluentDConfFile specifices the FluentD configuration file name to use for Vault log exportation
+	// default:
+	FluentDConfFile string `json:"fluentdConfFile,omitempty"`
+
 	// FluentDConfig specifices the FluentD configuration to use for Vault log exportation
 	// default:
 	FluentDConfig string `json:"fluentdConfig,omitempty"`

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1683,13 +1683,17 @@ func configMapForStatsD(v *vaultv1alpha1.Vault) *corev1.ConfigMap {
 
 func configMapForFluentD(v *vaultv1alpha1.Vault) *corev1.ConfigMap {
 	ls := v.LabelsForVault()
+	fluentdConfFile := v.Spec.FluentDConfFile
+	if fluentdConfFile != "" {
+		fluentdConfFile = "fluent.conf"
+	}
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      v.Name + "-fluentd-config",
 			Namespace: v.Namespace,
 			Labels:    ls,
 		},
-		Data: map[string]string{"fluent.conf": v.Spec.FluentDConfig},
+		Data: map[string]string{fluentdConfFile: v.Spec.FluentDConfig},
 	}
 	return cm
 }


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | [#1475](https://github.com/banzaicloud/bank-vaults/issues/1475)
| License         | Apache 2.0


### What's in this PR?
This PR introduce a new Vault CRD attribute that allows to define the filename of the logging config which runs in the `auditlog-exporter` sidecar when `fluentdEnabled` is `true`.


### Why?
this allow to easily to swap the default sidecar image from `fluentd` to `fluent-bit` which has now extended output capabilities tight to some cloud providers.

### Additional context
Other alternative to make this work have been investigated in related project to avoid this change: [aws-for-fluent-bit](https://github.com/aws/aws-for-fluent-bit/issues/270).
But they seems not willing to add an alternative env. variable to distinguish the config path entrypoint. And this is why this PR is relevant, as I would havoid to create and maintain a custom image that could also fix this.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

