### PR TITLE
webhook: ignore kube-system according to the well-known kubernetes.io/metadata.name label

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault-secrets-webhook
-version: 1.15.2
+version: 1.15.3
 appVersion: 1.14.3
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request env vars from Vault Secrets
 home: https://banzaicloud.com/products/bank-vaults/

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -159,6 +159,11 @@ namespaceSelector:
       operator: NotIn
       values:
         - kube-system
+    # https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+        - kube-system
   # matchLabels:
   #   vault-injection: enabled
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1464
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
The webhook tried to ignore kube-system via the old `name: kube-system` label, but from now on it will try the well-known `kubernetes.io/metadata.name: kube-system` label as well.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
About well-known labels https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] Related Helm chart(s) updated (if needed)

