### PR TITLE
Use const for connection error in logparser

### DIFF
--- a/pkg/sdk/log/parser.go
+++ b/pkg/sdk/log/parser.go
@@ -23,6 +23,8 @@ import (
 	syslogformat "gopkg.in/mcuadros/go-syslog.v2/format"
 )
 
+const ConnectionError = "connection_error"
+
 var (
 	logParserRegexp    = regexp.MustCompile("(level=[a-z]+) (msg=\\\".*\\\")( app=.*)")
 	pathNotFoundRegexp = regexp.MustCompile("(path not found:) ([a-z]+/[a-z]+/.*)(\\\")")
@@ -55,7 +57,7 @@ func ParseLogMessage(content []string) map[string]string {
 	} else if path := keyNotFoundRegexp.FindStringSubmatch(content[2]); path != nil {
 		parsedError[fmt.Sprintf("%s#%s", path[3], strings.Trim(path[1], "'"))] = content[2]
 	} else {
-		parsedError["connection_error"] = fmt.Sprintf("%v %v", content[2], content[3])
+		parsedError[ConnectionError] = fmt.Sprintf("%v %v", content[2], content[3])
 	}
 
 	return parsedError

--- a/pkg/sdk/log/parser_test.go
+++ b/pkg/sdk/log/parser_test.go
@@ -194,7 +194,7 @@ func TestParseLogMessage(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"connection_error": "msg=\"failed to request new Vault token\"  app=vault-env err=\"Put \\\"https://vault.securecn-vault:8200/v1/auth/kubernetes/login\\\": x509: certificate signed by unknown authority (possibly because of \\\"crypto/rsa: verification error\\\" while trying to verify candidate authority certificate \\\"Root CA\\\")\"",
+				ConnectionError: "msg=\"failed to request new Vault token\"  app=vault-env err=\"Put \\\"https://vault.securecn-vault:8200/v1/auth/kubernetes/login\\\": x509: certificate signed by unknown authority (possibly because of \\\"crypto/rsa: verification error\\\" while trying to verify candidate authority certificate \\\"Root CA\\\")\"",
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Use ConnectionError const in sdk/log