### PR TITLE
docs(readme): change broken newsletter link to blog url

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ If you are using Bank-Vaults in a production environment and [require commercial
 
 ### Engineering Blog
 
-To be up-to-date with Bank-Vaults and the other open source and commercial [products of Banzai Cloud, subscribe to our blog](https://pages.banzaicloud.com/sign-up-for-the-banzai-cloud-newsletter/).
+To be up-to-date with Bank-Vaults and the other open source and commercial [products of Banzai Cloud, read our blog](https://banzaicloud.com/blog/).
 
 ## Credits
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no|
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
Fix the broken blog URL in `README.md`


### Why?
In the `README.md` I found a broken link, furthermore didn't find any newsletter link in the official BanzaiCloud site so I change the text and the URL behind pointing to the blog. 
