### PR TITLE
Support NonVoter option on Raft Join Request (RaftJoin) in operator. 

### DIFF
--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/hashicorp/vault/api"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -111,10 +110,7 @@ from one of the followings:
 				}
 			} else {
 				logrus.Info("joining raft cluster...")
-				if err := v.RaftJoin(
-					&api.RaftJoinRequest{
-						LeaderAPIAddr: unsealConfig.raftLeaderAddress,
-					}); err != nil {
+				if err := v.RaftJoin(unsealConfig.raftLeaderAddress); err != nil {
 					logrus.Fatalf("error joining leader vault: %s", err.Error())
 				}
 			}
@@ -180,7 +176,7 @@ func raftJoin(v internalVault.Vault) bool {
 	// If this instance can't tell the leaderAddress, it is not part of the cluster,
 	// so we should ask it join.
 	if leaderAddress == "" {
-		if err = v.RaftJoin(&api.RaftJoinRequest{}); err != nil {
+		if err = v.RaftJoin(""); err != nil {
 			logrus.Errorf("error joining leader vault: %s", err.Error())
 			return false
 		}

--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/hashicorp/vault/api"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -110,7 +111,10 @@ from one of the followings:
 				}
 			} else {
 				logrus.Info("joining raft cluster...")
-				if err := v.RaftJoin(unsealConfig.raftLeaderAddress); err != nil {
+				if err := v.RaftJoin(
+					&api.RaftJoinRequest{
+						LeaderAPIAddr: unsealConfig.raftLeaderAddress,
+					}); err != nil {
 					logrus.Fatalf("error joining leader vault: %s", err.Error())
 				}
 			}
@@ -176,7 +180,7 @@ func raftJoin(v internalVault.Vault) bool {
 	// If this instance can't tell the leaderAddress, it is not part of the cluster,
 	// so we should ask it join.
 	if leaderAddress == "" {
-		if err = v.RaftJoin(""); err != nil {
+		if err = v.RaftJoin(&api.RaftJoinRequest{}); err != nil {
 			logrus.Errorf("error joining leader vault: %s", err.Error())
 			return false
 		}

--- a/internal/vault/operator_client.go
+++ b/internal/vault/operator_client.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -423,6 +424,12 @@ func (v *vault) RaftJoin(rjo *api.RaftJoinRequest) error {
 
 		rjo.LeaderCACert = string(leaderCACert)
 	}
+
+	raftReadOnlyReplica, err := strconv.ParseBool(os.Getenv("VAULT_NON_VOTER"))
+	if err != nil {
+		return errors.Wrap(err, "Error conversation VAULT_NON_VOTER to boolean value")
+	}
+	rjo.NonVoter = raftReadOnlyReplica
 
 	response, err := v.cl.Sys().RaftJoin(rjo)
 	if err != nil {

--- a/internal/vault/operator_client.go
+++ b/internal/vault/operator_client.go
@@ -90,7 +90,7 @@ var _ Vault = &vault{}
 type Vault interface {
 	Init() error
 	RaftInitialized() (bool, error)
-	RaftJoin(rjo *api.RaftJoinRequest) error
+	RaftJoin(rjr *api.RaftJoinRequest) error
 	Sealed() (bool, error)
 	Active() (bool, error)
 	Unseal() error
@@ -392,9 +392,9 @@ func (v *vault) RaftInitialized() (bool, error) {
 }
 
 // RaftJoin joins Vault raft cluster if is not initialized already
-func (v *vault) RaftJoin(rjo *api.RaftJoinRequest) error {
+func (v *vault) RaftJoin(rjr *api.RaftJoinRequest) error {
 	// raft storage mode
-	if rjo.LeaderAPIAddr != "" {
+	if rjr.LeaderAPIAddr != "" {
 		initialized, err := v.cl.Sys().InitStatus()
 		if err != nil {
 			return errors.Wrap(err, "error testing if vault is initialized")
@@ -422,16 +422,16 @@ func (v *vault) RaftJoin(rjo *api.RaftJoinRequest) error {
 			return errors.Wrap(err, "error reading vault raft CA certificate")
 		}
 
-		rjo.LeaderCACert = string(leaderCACert)
+		rjr.LeaderCACert = string(leaderCACert)
 	}
 
 	raftReadOnlyReplica, err := strconv.ParseBool(os.Getenv("VAULT_NON_VOTER"))
 	if err != nil {
 		return errors.Wrap(err, "Error conversation VAULT_NON_VOTER to boolean value")
 	}
-	rjo.NonVoter = raftReadOnlyReplica
+	rjr.NonVoter = raftReadOnlyReplica
 
-	response, err := v.cl.Sys().RaftJoin(rjo)
+	response, err := v.cl.Sys().RaftJoin(rjr)
 	if err != nil {
 		return errors.Wrap(err, "error joining raft cluster")
 	}

--- a/operator/deploy/multi-dc/aws/cr-tertiary.yaml
+++ b/operator/deploy/multi-dc/aws/cr-tertiary.yaml
@@ -101,6 +101,9 @@ spec:
           secretKeyRef:
             name: aws
             key: AWS_SECRET_ACCESS_KEY
+    # Example of running a VAULT as a non-voter: https://www.vaultproject.io/api/system/storage/raft#non_voter
+    - name: VAULT_NON_VOTER
+      value: "true"
 
   volumes:
     - name: vault-primary-tls


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1486 
| License         | Apache 2.0


### What's in this PR?
This is a basic example of introducing the [non_voter](https://www.vaultproject.io/api/system/storage/raft#non_voter) flag to enable read only replicas of the Vault for the multi cluster deployment.

The changes encompass a basic addition of an environment variable and also room to expand `RaftJoin` to be init with `api.RaftJoinRequest` from the CRD itself (This has not been done as I'd want to discuss with someone first). 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
fixes #1486 - However, I think this is more of a bandaid then a full-featured fix. As the big changes could introduce deprecations. 

### Additional context
Right now, none. This is a very basic change to add a simple argument to the raft join API request.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] Update the RaftJoin initialization of an `api.RaftJoinRequest` struct from the CR itself. 
- [ ] Proper Documented approach to include this (I don't know where to update this). 
