### PR TITLE
feature: add option to purge unmanaged policies from vault

### DIFF
--- a/deploy/test-external-secrets-watch-deployment.yaml
+++ b/deploy/test-external-secrets-watch-deployment.yaml
@@ -87,6 +87,7 @@ spec:
   # See: https://banzaicloud.com/docs/bank-vaults/cli-tool/#example-external-vault-configuration
   # The repository also contains a lot examples in the deploy/ and operator/deploy directories.
   externalConfig:
+    removeUnmanagedConfiguration: true
     policies:
       - name: allow_secrets
         rules: path "secret/*" {

--- a/deploy/test-external-secrets-watch-deployment.yaml
+++ b/deploy/test-external-secrets-watch-deployment.yaml
@@ -87,7 +87,11 @@ spec:
   # See: https://banzaicloud.com/docs/bank-vaults/cli-tool/#example-external-vault-configuration
   # The repository also contains a lot examples in the deploy/ and operator/deploy directories.
   externalConfig:
-    removeUnmanagedConfiguration: true
+    purgeUnmanagedConfig:
+      enabled: true
+      exclude:
+        # Auth is not implemented yet, but just for demonstration.
+        auth: true
     policies:
       - name: allow_secrets
         rules: path "secret/*" {

--- a/internal/vault/operator_client.go
+++ b/internal/vault/operator_client.go
@@ -96,10 +96,17 @@ type Vault interface {
 	Configure(config *viper.Viper) error
 }
 
+type purgeUnmanagedConfig struct {
+	Enabled bool `json:"enabled,omitempty"`
+	Exclude struct {
+		Policies bool `json:"policies,omitempty"`
+	} `json:"exclude,omitempty"`
+}
+
 // WIP: This should hold all externalConfig when all sections refactord.
 type externalConfig struct {
-	RemoveUnmanagedConfiguration bool     `json:"removeUnmanagedConfiguration,omitempty"`
-	Policies                     []policy `json:"policies,omitempty"`
+	PurgeUnmanagedConfig purgeUnmanagedConfig `json:"purgeUnmanagedConfig,omitempty"`
+	Policies             []policy             `json:"policies,omitempty"`
 }
 
 var extConfig externalConfig

--- a/internal/vault/operator_client.go
+++ b/internal/vault/operator_client.go
@@ -26,8 +26,6 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/cristalhq/jwt/v3"
-	"github.com/hashicorp/hcl"
-	hclPrinter "github.com/hashicorp/hcl/hcl/printer"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 	json "github.com/json-iterator/go"
@@ -97,6 +95,14 @@ type Vault interface {
 	LeaderAddress() (string, error)
 	Configure(config *viper.Viper) error
 }
+
+// WIP: This should hold all externalConfig when all sections refactord.
+type externalConfig struct {
+	RemoveUnmanagedConfiguration bool     `json:"removeUnmanagedConfiguration,omitempty"`
+	Policies                     []policy `json:"policies,omitempty"`
+}
+
+var extConfig externalConfig
 
 type KVService interface {
 	Set(key string, value []byte) error
@@ -457,13 +463,17 @@ func (v *vault) Configure(config *viper.Viper) error {
 	defer v.cl.SetToken("")
 	defer func() { rootToken = nil }()
 
+	err = config.Unmarshal(&extConfig)
+	if err != nil {
+		return errors.Wrap(err, "error loading externalConfig")
+	}
+
 	err = v.configureAuthMethods(config)
 	if err != nil {
 		return errors.Wrap(err, "error configuring auth methods for vault")
 	}
 
-	err = v.configurePolicies(config)
-	if err != nil {
+	if err = v.configurePolicies(); err != nil {
 		return errors.Wrap(err, "error configuring policies for vault")
 	}
 
@@ -838,40 +848,6 @@ func (v *vault) configureAuthMethods(config *viper.Viper) error {
 			if err != nil {
 				return errors.Wrap(err, "error configuring azure auth roles for vault")
 			}
-		}
-	}
-
-	return nil
-}
-
-func (v *vault) configurePolicies(config *viper.Viper) error {
-	policies := []map[string]string{}
-
-	err := config.UnmarshalKey("policies", &policies)
-	if err != nil {
-		return errors.Wrap(err, "error unmarshalling vault policy config")
-	}
-
-	for _, policy := range policies {
-		policyName := policy["name"]
-
-		// Try to format rules (HCL only)
-		policyRules, err := hclPrinter.Format([]byte(policy["rules"]))
-		if err != nil {
-			// Check if rules parse (HCL or JSON)
-			_, parseErr := hcl.Parse(policy["rules"])
-			if parseErr != nil {
-				return errors.Wrapf(err, "error parsing %s policy rules", policyName)
-			}
-
-			// Policies are parsable but couldn't be HCL formatted (most likely JSON)
-			policyRules = []byte(policy["rules"])
-			logrus.Debugf("error HCL-formatting %s policy rules (ignore if rules are JSON-formatted): %s", policyName, err.Error())
-		}
-
-		err = v.cl.Sys().PutPolicy(policyName, string(policyRules))
-		if err != nil {
-			return errors.Wrapf(err, "error putting %s policy into vault", policyName)
 		}
 	}
 

--- a/internal/vault/policies.go
+++ b/internal/vault/policies.go
@@ -94,7 +94,7 @@ func (v *vault) configurePolicies() error {
 	}
 
 	// Remove unmanaged policies.
-	if extConfig.RemoveUnmanagedConfiguration {
+	if extConfig.PurgeUnmanagedConfig.Enabled && !extConfig.PurgeUnmanagedConfig.Exclude.Policies {
 		unmanagedPolicies := v.getUnmanagedPolicies(managedPolicies)
 		logrus.Debugf("remove unmanged policies %v", unmanagedPolicies)
 		for policyName := range unmanagedPolicies {

--- a/internal/vault/policies.go
+++ b/internal/vault/policies.go
@@ -1,0 +1,108 @@
+// Copyright © 2021 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vault
+
+import (
+	"emperror.dev/errors"
+	"github.com/hashicorp/hcl"
+	hclPrinter "github.com/hashicorp/hcl/hcl/printer"
+	"github.com/sirupsen/logrus"
+)
+
+type policy struct {
+	Name           string `json:"name"`
+	Rules          string `json:"rules"`
+	RulesFormatted string
+}
+
+func (p *policy) format() error {
+	// Try to format rules (HCL only)
+	policyRules, err := hclPrinter.Format([]byte(p.Rules))
+	if err != nil {
+		// Check if rules parse (HCL or JSON)
+		_, parseErr := hcl.Parse(p.Rules)
+		if parseErr != nil {
+			return errors.Wrapf(err, "error parsing %s policy rules", p.Name)
+		}
+
+		// Policies are parsable but couldn't be HCL formatted (most likely JSON)
+		policyRules = []byte(p.Rules)
+		logrus.Debugf("error HCL-formatting %s policy rules (ignore if rules are JSON-formatted): %s", p.Name, err.Error())
+	}
+
+	p.RulesFormatted = string(policyRules)
+
+	return nil
+}
+
+// getExistingPolicies gets all policies that are already in Vault.
+// The existing policies are in a map to make it easy to delete easily from it with "O(n)" complexity.
+func (v *vault) getExistingPolicies() (map[string]bool, error) {
+	existingPolicies := make(map[string]bool)
+
+	existingPoliciesList, err := v.cl.Sys().ListPolicies()
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to list existing policies")
+	}
+
+	for _, existingPolicy := range existingPoliciesList {
+		existingPolicies[existingPolicy] = true
+	}
+
+	return existingPolicies, nil
+}
+
+// getUnmanagedPolicies gets unmanaged policies by comparing what's already in Vault and what's in the externalConfig.
+func (v *vault) getUnmanagedPolicies(managedPolicies []policy) map[string]bool {
+	unmanagedPolicies, _ := v.getExistingPolicies()
+
+	// Vault doesn't allow to remove default or root policies.
+	delete(unmanagedPolicies, "root")
+	delete(unmanagedPolicies, "default")
+
+	// Remove managed polices form the items since the reset will be removed.
+	for _, mangedPolicy := range managedPolicies {
+		delete(unmanagedPolicies, mangedPolicy.Name)
+	}
+
+	return unmanagedPolicies
+}
+
+func (v *vault) configurePolicies() error {
+	// Add managed policies.
+	managedPolicies := extConfig.Policies
+	logrus.Debugf("add manged policies %v", managedPolicies)
+	for _, policy := range managedPolicies {
+		if err := policy.format(); err != nil {
+			return errors.Wrapf(err, "error formatting %s policy", policy.Name)
+		}
+		if err := v.cl.Sys().PutPolicy(policy.Name, policy.RulesFormatted); err != nil {
+			return errors.Wrapf(err, "error putting %s policy into vault", policy.Name)
+		}
+	}
+
+	// Remove unmanaged policies.
+	if extConfig.RemoveUnmanagedConfiguration {
+		unmanagedPolicies := v.getUnmanagedPolicies(managedPolicies)
+		logrus.Debugf("remove unmanged policies %v", unmanagedPolicies)
+		for policyName := range unmanagedPolicies {
+			if err := v.cl.Sys().DeletePolicy(policyName); err != nil {
+				return errors.Wrapf(err, "error deleting %s policy from vault", policyName)
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #605
| License         | Apache 2.0


### What's in this PR?
This feature allows purging unmanaged policies from Vault which simply with each sync it lists all policies and remove anything that is not in the `externalConfig`. That way no need to handle any state and it doesn't matter what was in the config previously.

Also, the purge option is disabled by default so there is no change in the behavior and anyone who wants to use it should enable it explicitly.

*How to configure it?*
If the user wants to remove any unmanaged config (just policies at the moment), they just need to add `purgeUnmanagedConfig` under `externalConfig`:

```
externalConfig:
  purgeUnmanagedConfig:
    enabled: true
    exclude:
      # Auth is not implemented yet, but just for demonstration.
      auth: true
```
Also as shown here, for more flexibility, some config could be excluded from the purge (for some use cases or if someone wants to apply the no-manual-changes gradually).

### Why?
This change is just the first of a series of changes where bank-vaults will be able to manage Vault in both ways (add and remove config).

So if this change is accepted, I will do it for the reset of config like `auth methods`, `audit`, and so on.
And those change allows following the Cloud-Native patterns where the apps are able to be fully declarative and automated.


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
- [ ] Add new a new acceptance test to make sure the feature works as expected.
- [ ] Update docs with example.