### PR TITLE
webhook: allow securityContext modification for injected containers

### DIFF
--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -49,6 +49,10 @@ type VaultConfig struct {
 	CtCPU                       resource.Quantity
 	CtMemory                    resource.Quantity
 	PspAllowPrivilegeEscalation bool
+	RunAsNonRoot                bool
+	RunAsUser                   int64
+	RunAsGroup                  int64
+	ReadOnlyRootFilesystem      bool
 	IgnoreMissingSecrets        string
 	VaultEnvPassThrough         string
 	ConfigfilePath              string
@@ -236,6 +240,30 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 		vaultConfig.PspAllowPrivilegeEscalation, _ = strconv.ParseBool(viper.GetString("psp_allow_privilege_escalation"))
 	}
 
+	if val, ok := annotations["vault.security.banzaicloud.io/run-as-non-root"]; ok {
+		vaultConfig.RunAsNonRoot, _ = strconv.ParseBool(val)
+	} else {
+		vaultConfig.RunAsNonRoot, _ = strconv.ParseBool(viper.GetString("run_as_non_root"))
+	}
+
+	if val, ok := annotations["vault.security.banzaicloud.io/run-as-user"]; ok {
+		vaultConfig.RunAsUser, _ = strconv.ParseInt(val, 10, 64)
+	} else {
+		vaultConfig.RunAsUser, _ = strconv.ParseInt(viper.GetString("run_as_user"), 0, 64)
+	}
+
+	if val, ok := annotations["vault.security.banzaicloud.io/run-as-group"]; ok {
+		vaultConfig.RunAsGroup, _ = strconv.ParseInt(val, 10, 64)
+	} else {
+		vaultConfig.RunAsGroup, _ = strconv.ParseInt(viper.GetString("run_as_group"), 0, 64)
+	}
+
+	if val, ok := annotations["vault.security.banzaicloud.io/readonly-root-fs"]; ok {
+		vaultConfig.ReadOnlyRootFilesystem, _ = strconv.ParseBool(val)
+	} else {
+		vaultConfig.ReadOnlyRootFilesystem, _ = strconv.ParseBool(viper.GetString("readonly_root_fs"))
+	}
+
 	if val, ok := annotations["vault.security.banzaicloud.io/mutate-configmap"]; ok {
 		vaultConfig.MutateConfigMap, _ = strconv.ParseBool(val)
 	} else {
@@ -403,6 +431,10 @@ func SetConfigDefaults() {
 	viper.SetDefault("vault_env_daemon", "false")
 	viper.SetDefault("vault_ct_share_process_namespace", "")
 	viper.SetDefault("psp_allow_privilege_escalation", "false")
+	viper.SetDefault("run_as_non_root", "false")
+	viper.SetDefault("run_as_user", "0")
+	viper.SetDefault("run_as_group", "0")
+	viper.SetDefault("readonly_root_fs", "false")
 	viper.SetDefault("vault_ignore_missing_secrets", "false")
 	viper.SetDefault("vault_env_passthrough", "")
 	viper.SetDefault("mutate_configmap", "false")

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -501,11 +501,46 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 		pod         *corev1.Pod
 		vaultConfig VaultConfig
 	}
+
 	defaultMode := int32(420)
-	runAsUser := int64(100)
-	initContainerSecurityContext := &corev1.SecurityContext{
-		RunAsUser:                &runAsUser,
+	agentRunAsUser := vaultAgentUID
+
+	baseSecurityContext := &corev1.SecurityContext{
+		RunAsNonRoot:             &vaultConfig.RunAsNonRoot,
+		ReadOnlyRootFilesystem:   &vaultConfig.ReadOnlyRootFilesystem,
 		AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+	}
+
+	agentInitContainerSecurityContext := &corev1.SecurityContext{
+		RunAsUser:                &agentRunAsUser,
+		RunAsNonRoot:             &vaultConfig.RunAsNonRoot,
+		ReadOnlyRootFilesystem:   &vaultConfig.ReadOnlyRootFilesystem,
+		AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+	}
+
+	agentContainerSecurityContext := &corev1.SecurityContext{
+		RunAsUser:                &agentRunAsUser,
+		RunAsNonRoot:             &vaultConfig.RunAsNonRoot,
+		ReadOnlyRootFilesystem:   &vaultConfig.ReadOnlyRootFilesystem,
+		AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+			Add: []corev1.Capability{
+				"IPC_LOCK",
+			},
+		},
 	}
 
 	tests := []struct {
@@ -584,7 +619,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 									corev1.ResourceMemory: resource.MustParse("64Mi"),
 								},
 							},
-							SecurityContext: initContainerSecurityContext,
+							SecurityContext: agentInitContainerSecurityContext,
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "vault-env",
@@ -620,9 +655,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 									Value: "false",
 								},
 							},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
-							},
+							SecurityContext: baseSecurityContext,
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "vault-env",
@@ -779,7 +812,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 									corev1.ResourceMemory: resource.MustParse("64Mi"),
 								},
 							},
-							SecurityContext: initContainerSecurityContext,
+							SecurityContext: agentInitContainerSecurityContext,
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "vault-env",
@@ -813,9 +846,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 									Value: "false",
 								},
 							},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
-							},
+							SecurityContext: baseSecurityContext,
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "vault-env",
@@ -966,14 +997,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 									Value: "false",
 								},
 							},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
-								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{
-										"IPC_LOCK",
-									},
-								},
-							},
+							SecurityContext: agentContainerSecurityContext,
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "vault-env",
@@ -1133,7 +1157,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 									corev1.ResourceMemory: resource.MustParse("64Mi"),
 								},
 							},
-							SecurityContext: initContainerSecurityContext,
+							SecurityContext: agentInitContainerSecurityContext,
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "vault-env",
@@ -1167,9 +1191,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 									Value: "false",
 								},
 							},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
-							},
+							SecurityContext: baseSecurityContext,
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "vault-env",
@@ -1353,7 +1375,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 									corev1.ResourceMemory: resource.MustParse("64Mi"),
 								},
 							},
-							SecurityContext: initContainerSecurityContext,
+							SecurityContext: agentInitContainerSecurityContext,
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "vault-env",
@@ -1400,9 +1422,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 									Value: "false",
 								},
 							},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
-							},
+							SecurityContext: baseSecurityContext,
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "vault-env",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
This PR makes it possible to lock down the `securityContext` of containers that get injected into pods by the webhook.
This is achieved by:
1. Implementing a base `securityContext` shared by all injected containers.
2. Dropping all Linux capabilities by default and adding them back as needed.
3. Adding 4 new pod annotations recognized by the webhook that allow setting the `runAsNonRoot`, `readOnlyRootFilesystem`, `runAsUser` and `runAsGroup` parameters for injected containers.

Added pod annotations:
| Annotation                                       | Default | Explanation
| ------------------------------------------------ | ------- | -----------
| `vault.security.banzaicloud.io/run-as-non-root`  | `false` | Set this to `true` to indicate that all injected containers must run as a non-root user. 
| `vault.security.banzaicloud.io/run-as-user`      | `0`     | Set the UID for all injected containers. The default value means that no modifications will be made to the `securityContext` of injected containers.
| `vault.security.banzaicloud.io/run-as-group`     | `0`     | Set the GID for all injected containers. The default value means that no modifications will be made to the `securityContext` of injected containers.
| `vault.security.banzaicloud.io/readonly-root-fs` | `false` | Set this to `true` to indicate that all injected containers must have a read-only root filesystem. 

Changes in default behaviour:
1. All Linux capabilities are dropped by default.
2. All injected containers now start with a base `securityContext` that then gets extended as needed.

Everything else is disabled by default. This should allow existing users to keep their old webhook configuration.

### Why?
Some Kubernetes environments may use third-party policy engines (such as OPA or Kyverno) that enforce various security policies. Some of these security policies may impose additional requirements on containers or init containers such as dropping all capabilities by default or running with a read-only root FS. This may in turn make it hard to use the mutating webhook implemented in Bank Vaults because it injects containers that run with a very basic `securityContext` that can not currently be modified by the user.

### Additional context
This has been tested in a 1.23.1 Kubernetes cluster with the Kyverno policy engine in a scenario where environment variables get injected into a pod that adheres to a strict set of security policies.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
