### PR TITLE
🔨 Add rbac.yaml to instructions

### DIFF
--- a/charts/vault-operator/README.md
+++ b/charts/vault-operator/README.md
@@ -86,6 +86,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 To deploy different Vault configurations (single node, HA, with AWS unsealing, with etcd backend, ...) see: https://github.com/banzaicloud/bank-vaults/tree/main/operator/deploy for more examples.
 
 ```bash
+kubectl apply -f https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/operator/deploy/rbac.yaml
 kubectl apply -f https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/operator/deploy/cr-raft.yaml
 ```
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | mentioned in #1529
| License         | Apache 2.0


### What's in this PR?
Adds the step to create the rbca.yaml on the docs.

### Why?
If this step is not done the `statefulset.apps/vault` show this events. 
```
Events:
  Type     Reason        Age                From                    Message
  ----     ------        ----               ----                    -------
  Warning  FailedCreate  5s (x11 over 10s)  statefulset-controller  create Pod vault-0 in StatefulSet vault failed error: pods "vault-0" is forbidden: error looking up service account default/vault: serviceaccount "vault" not found
```


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] User guide and development docs updated (if needed)
