### PR TITLE
webhook: Fix broken capabilities (#1531)

### DIFF
--- a/deploy/test-deploy-templating.yaml
+++ b/deploy/test-deploy-templating.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: my-app
+    my-app.kubernetes.io/name: my-app-vault-agent
+    branches: "true"
+  name: my-app-vault-agent
+  namespace: default
+data:
+  config.hcl: |
+    vault {
+      // This is needed until https://github.com/hashicorp/vault/issues/7889
+      // gets fixed, otherwise it is automated by the webhook.
+      ca_cert = "/vault/tls/ca.crt"
+    }
+    auto_auth {
+      method "kubernetes" {
+        mount_path = "auth/kubernetes"
+        config = {
+          role = "default"
+        }
+      }
+      sink "file" {
+        config = {
+          path = "/vault/.vault-token"
+        }
+      }
+    }
+    template {
+      contents = <<EOH
+        {{- with secret "secret/accounts/aws" }}
+        {
+          "id": "{{ .Data.data.AWS_ACCESS_KEY_ID }}",
+          "key": "{{ .Data.data.AWS_SECRET_ACCESS_KEY }}"
+        }
+        {{ end }}
+      EOH
+      destination = "/vault/secrets/config.yaml"
+      command     = "/bin/sh -c \"kill -HUP $(pidof vault-demo-app) || true\""
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vault-test
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-templating
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: test-templating
+      annotations:
+        vault.security.banzaicloud.io/vault-addr: "https://vault:8200" # optional, the address of the Vault service, default values is https://vault:8200
+        vault.security.banzaicloud.io/vault-role: "default" # optional, the default value is the name of the ServiceAccount the Pod runs in, in case of Secrets and ConfigMaps it is "default"
+        vault.security.banzaicloud.io/vault-skip-verify: "false" # optional, skip TLS verification of the Vault server certificate
+        vault.security.banzaicloud.io/vault-tls-secret: "vault-tls" # optional, the name of the Secret where the Vault CA cert is, if not defined it is not mounted
+        vault.security.banzaicloud.io/vault-agent: "false" # optional, if true, a Vault Agent will be started to do Vault authentication, by default not needed and vault-env will do Kubernetes Service Account based Vault authentication
+        vault.security.banzaicloud.io/vault-path: "kubernetes" # optional, the Kubernetes Auth mount path in Vault the default value is "kubernetes"
+        vault.security.banzaicloud.io/vault-agent-configmap: "my-app-vault-agent"
+    spec:
+      serviceAccountName: default
+      containers:
+      - name: alpine
+        image: alpine
+        command: ["sh", "-c", "cat /vault/secrets/config.yaml && echo going to sleep... && sleep 1000"]
+        resources:
+          limits:
+            cpu: 20m
+            memory: 10Mi
+          requests:
+            cpu: 20m
+            memory: 10Mi

--- a/operator/deploy/cr-raft-1.yaml
+++ b/operator/deploy/cr-raft-1.yaml
@@ -1,0 +1,205 @@
+apiVersion: "vault.banzaicloud.com/v1alpha1"
+kind: "Vault"
+metadata:
+  name: "vault"
+  labels:
+    app.kubernetes.io/name: vault
+    vault_cr: vault
+spec:
+  size: 1
+  image: vault:1.6.2
+
+  # Common annotations for all created resources
+  annotations:
+    common/annotation: "true"
+
+  # Vault Pods , Services and TLS Secret annotations
+  vaultAnnotations:
+    type/instance: "vault"
+
+  # Vault Configurer Pods and Services annotations
+  vaultConfigurerAnnotations:
+    type/instance: "vaultconfigurer"
+
+  # Vault Pods , Services and TLS Secret labels
+  vaultLabels:
+    example.com/log-format: "json"
+
+  # Vault Configurer Pods and Services labels
+  vaultConfigurerLabels:
+    example.com/log-format: "string"
+
+  # Support for affinity Rules
+  # affinity:
+  #   nodeAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #       nodeSelectorTerms:
+  #       - matchExpressions:
+  #         - key : "node-role.kubernetes.io/your_role"
+  #           operator: In
+  #           values: ["true"]
+
+  # Support for pod nodeSelector rules to control which nodes can be chosen to run
+  # the given pods
+  # nodeSelector:
+  #   "node-role.kubernetes.io/your_role": "true"
+
+  # Support for node tolerations that work together with node taints to control
+  # the pods that can like on a node
+  # tolerations:
+  # - effect: NoSchedule
+  #   key: node-role.kubernetes.io/your_role
+  #   operator: Equal
+  #   value: "true"
+
+  # Specify the ServiceAccount where the Vault Pod and the Bank-Vaults configurer/unsealer is running
+  serviceAccount: vault
+
+  # Specify the Service's type where the Vault Service is exposed
+  # Please note that some Ingress controllers like https://github.com/kubernetes/ingress-gce
+  # forces you to expose your Service on a NodePort
+  serviceType: ClusterIP
+
+  # Request an Ingress controller with the default configuration
+  ingress:
+    # Specify Ingress object annotations here, if TLS is enabled (which is by default)
+    # the operator will add NGINX, Traefik and HAProxy Ingress compatible annotations
+    # to support TLS backends
+    annotations: {}
+    # Override the default Ingress specification here
+    # This follows the same format as the standard Kubernetes Ingress
+    # See: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#ingressspec-v1beta1-extensions
+    spec: {}
+
+  # In some cases, you have to set permissions for the raft directory.
+  # For example in the case of using a local kind cluster, uncomment the lines below.
+  # vaultInitContainers:
+  #   - name: raft-permission
+  #     image: busybox
+  #     command:
+  #       - /bin/sh
+  #       - -c
+  #       - |
+  #         chown -R 100:1000 /vault/file
+  #     volumeMounts:
+  #       - name: vault-raft
+  #         mountPath: /vault/file
+
+  # Use local disk to store Vault raft data, see config section.
+  volumeClaimTemplates:
+    - metadata:
+        name: vault-raft
+      spec:
+        # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
+        # storageClassName: ""
+        accessModes:
+          - ReadWriteOnce
+        volumeMode: Filesystem
+        resources:
+          requests:
+            storage: 1Gi
+
+  volumeMounts:
+    - name: vault-raft
+      mountPath: /vault/file
+
+  # Add Velero fsfreeze sidecar container and supporting hook annotations to Vault Pods:
+  # https://velero.io/docs/v1.2.0/hooks/
+  veleroEnabled: true
+
+  # Support for distributing the generated CA certificate Secret to other namespaces.
+  # Define a list of namespaces or use ["*"] for all namespaces.
+  caNamespaces:
+    - "vswh"
+
+  # Describe where you would like to store the Vault unseal keys and root token.
+  unsealConfig:
+    options:
+      # The preFlightChecks flag enables unseal and root token storage tests
+      # This is true by default
+      preFlightChecks: true
+      # The storeRootToken flag enables storing of root token in chosen storage
+      # This is true by default
+      storeRootToken: true
+    kubernetes:
+      secretNamespace: default
+
+  # A YAML representation of a final vault config file.
+  # See https://www.vaultproject.io/docs/configuration/ for more information.
+  config:
+    storage:
+      raft:
+        path: "/vault/file"
+    listener:
+      tcp:
+        address: "0.0.0.0:8200"
+        tls_cert_file: /vault/tls/server.crt
+        tls_key_file: /vault/tls/server.key
+    api_addr: https://vault.default:8200
+    cluster_addr: "https://${.Env.POD_NAME}:8201"
+    ui: true
+
+  statsdDisabled: true
+
+  serviceRegistrationEnabled: true
+
+  resources:
+    # A YAML representation of resource ResourceRequirements for vault container
+    # Detail can reference: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container
+    vault:
+      limits:
+        memory: "512Mi"
+        cpu: "200m"
+      requests:
+        memory: "256Mi"
+        cpu: "100m"
+
+  # See: https://banzaicloud.com/docs/bank-vaults/cli-tool/#example-external-vault-configuration
+  # The repository also contains a lot examples in the deploy/ and operator/deploy directories.
+  externalConfig:
+    policies:
+      - name: allow_secrets
+        rules: path "secret/*" {
+          capabilities = ["create", "read", "update", "delete", "list"]
+          }
+    auth:
+      - type: kubernetes
+        roles:
+          # Allow every pod in the default namespace to use the secret kv store
+          - name: default
+            bound_service_account_names: ["default", "vault-secrets-webhook"]
+            bound_service_account_namespaces: ["default", "vswh"]
+            policies: allow_secrets
+            ttl: 1h
+
+    secrets:
+      - path: secret
+        type: kv
+        description: General secrets.
+        options:
+          version: 2
+
+    # Allows writing some secrets to Vault (useful for development purposes).
+    # See https://www.vaultproject.io/docs/secrets/kv/index.html for more information.
+    startupSecrets:
+      - type: kv
+        path: secret/data/accounts/aws
+        data:
+          data:
+            AWS_ACCESS_KEY_ID: secretId
+            AWS_SECRET_ACCESS_KEY: s3cr3t
+      - type: kv
+        path: secret/data/dockerrepo
+        data:
+          data:
+            DOCKER_REPO_USER: dockerrepouser
+            DOCKER_REPO_PASSWORD: dockerrepopassword
+      - type: kv
+        path: secret/data/mysql
+        data:
+          data:
+            MYSQL_ROOT_PASSWORD: s3cr3t
+
+  vaultEnvsConfig:
+    - name: VAULT_LOG_LEVEL
+      value: debug

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -48,7 +48,7 @@ auto_auth {
                 }
         }
 }`
-	vaultAgentUID int64 = 100
+	vaultAgentUID int64 = 0
 
 	VaultEnvVolumeName = "vault-env"
 )
@@ -817,8 +817,16 @@ func getBaseSecurityContext(podSecurityContext *corev1.PodSecurityContext, vault
 	context := &corev1.SecurityContext{
 		AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
 		RunAsNonRoot:             &vaultConfig.RunAsNonRoot,
+		RunAsUser:                &vaultConfig.RunAsUser,
 		ReadOnlyRootFilesystem:   &vaultConfig.ReadOnlyRootFilesystem,
 		Capabilities: &corev1.Capabilities{
+			Add: []corev1.Capability{
+				"CHOWN",
+				"SETFCAP",
+				"SETGID",
+				"SETPCAP",
+				"SETUID",
+			},
 			Drop: []corev1.Capability{
 				"ALL",
 			},

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -506,10 +506,18 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 	agentRunAsUser := vaultAgentUID
 
 	baseSecurityContext := &corev1.SecurityContext{
+		RunAsUser:                &agentRunAsUser,
 		RunAsNonRoot:             &vaultConfig.RunAsNonRoot,
 		ReadOnlyRootFilesystem:   &vaultConfig.ReadOnlyRootFilesystem,
 		AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
 		Capabilities: &corev1.Capabilities{
+			Add: []corev1.Capability{
+				"CHOWN",
+				"SETFCAP",
+				"SETGID",
+				"SETPCAP",
+				"SETUID",
+			},
 			Drop: []corev1.Capability{
 				"ALL",
 			},
@@ -522,6 +530,13 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 		ReadOnlyRootFilesystem:   &vaultConfig.ReadOnlyRootFilesystem,
 		AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
 		Capabilities: &corev1.Capabilities{
+			Add: []corev1.Capability{
+				"CHOWN",
+				"SETFCAP",
+				"SETGID",
+				"SETPCAP",
+				"SETUID",
+			},
 			Drop: []corev1.Capability{
 				"ALL",
 			},
@@ -538,6 +553,11 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 				"ALL",
 			},
 			Add: []corev1.Capability{
+				"CHOWN",
+				"SETFCAP",
+				"SETGID",
+				"SETPCAP",
+				"SETUID",
 				"IPC_LOCK",
 			},
 		},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1531, fixes #1540
| License         | Apache 2.0


### What's in this PR?
* Fix for capabilities regression introduced in 1.15.0
* Additional acceptance test

### Why?
1.15.0 introduced a regression in dropping all capabilities necessary for Vault Agent Templating. The PR fixes that by keeping the capabilities drop while adding the bare minimum that is necessary for proper functionality of templating.
In addition to that, the PR adds a new acceptance test that goes through the process of templating. This test will fail the build in case same or similar regression happens in the future.

### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)