### PR TITLE
properly split template variables with multiple equal signs

### DIFF
--- a/internal/configuration/template.go
+++ b/internal/configuration/template.go
@@ -71,7 +71,7 @@ func (t Templater) EnvTemplate(templateText string) (*bytes.Buffer, error) {
 	env.Env = make(map[string]string, len(os.Environ()))
 
 	for _, v := range os.Environ() {
-		split := strings.Split(v, "=")
+		split := strings.SplitN(v, "=", 2)
 		env.Env[split[0]] = split[1]
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/bank-vaults/issues/1573
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Use `SplitN` instead of `Split` to split environment variables
