### PR TITLE
configurer: Allow to specify options on kv2 writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Start kind cluster
       run: |
         kind version
-        kind create cluster --config hack/kind.yaml
+        kind create cluster --config hack/kind.yaml --wait 1m
 
     - name: Build Docker images
       run: |

--- a/hack/kind.yaml
+++ b/hack/kind.yaml
@@ -1,7 +1,5 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  ServiceAccountIssuerDiscovery: true
 networking:
   apiServerPort: 6443
 kubeadmConfigPatches:

--- a/internal/vault/startup_secrets.go
+++ b/internal/vault/startup_secrets.go
@@ -31,6 +31,7 @@ type startupSecret struct {
 	Path string `mapstructure:"path"`
 	Data struct {
 		Data         map[string]interface{}   `mapstructure:"data"`
+		Options      map[string]interface{}   `mapstructure:"options,omitempty"`
 		SecretKeyRef []map[string]interface{} `mapstructure:"secretKeyRef"`
 	} `mapstructure:"data"`
 }
@@ -119,6 +120,10 @@ func (v *vault) configureStartupSecrets() error {
 			path, data, err := readStartupSecret(startupSecret)
 			if err != nil {
 				return errors.Wrap(err, "unable to read 'kv' startup secret")
+			}
+
+			if len(startupSecret.Data.Options) > 0 {
+				data["options"] = startupSecret.Data.Options
 			}
 
 			_, err = v.writeWithWarningCheck(path, data)

--- a/operator/deploy/cr-kvv2.yaml
+++ b/operator/deploy/cr-kvv2.yaml
@@ -1,0 +1,105 @@
+apiVersion: vault.banzaicloud.com/v1alpha1
+kind: Vault
+metadata:
+  name: vault
+spec:
+  size: 1
+  image: vault:1.6.2
+
+  # Specify the Service's type where the Vault Service is exposed
+  serviceType: ClusterIP
+
+  # Service account name of Vault pod
+  serviceAccount: vault
+
+  # Disable statsd side-car container
+  statsdDisabled: true
+
+  # Describe where you would like to store the Vault unseal keys and root token.
+  unsealConfig:
+    options:
+      # The preFlightChecks flag enables unseal and root token storage tests
+      # This is true by default
+      preFlightChecks: true
+      # The storeRootToken flag enables storing of root token in chosen storage
+      # This is true by default
+      storeRootToken: true
+    kubernetes:
+      # Namespace for Secret used to store root token and unseal keys
+      secretNamespace: default
+      # Secret name to store root token and unseal keys
+      secretName: vault-unseal-keys
+
+  # A YAML representation of a final vault config file.
+  # See https://www.vaultproject.io/docs/configuration/ for more information.
+  config:
+    storage:
+      file:
+        path: /vault/file
+    listener:
+      tcp:
+        address: 0.0.0.0:8200
+        tls_disable: true
+    api_addr: http://vault.default:8200
+    disable_clustering: true
+    ui: true
+
+  # See: https://banzaicloud.com/docs/bank-vaults/cli-tool/#example-external-vault-configuration
+  # The repository also contains a lot examples in the deploy/ and operator/deploy directories.
+  externalConfig:
+    policies:
+      - name: allow_secrets
+        rules: |
+          path "secret/*" {
+            capabilities = ["create", "read", "update", "delete", "list"]
+          }
+
+    auth:
+      - type: kubernetes
+        roles:
+          # Allow every pod in the default namespace to use the secret kv store
+          - name: default
+            bound_service_account_names: ["default"]
+            bound_service_account_namespaces: ["default"]
+            policies: ["allow_secrets"]
+            ttl: 1h
+
+    secrets:
+      - type: kv
+        path: secret
+        description: General secrets backend with cas constraint.
+        options:
+          version: 2
+        configuration:
+          config:
+            - max_versions: 3
+              cas_required: true
+      - type: kv
+        path: kv
+        description: General secrets backend.
+        options:
+          version: 2
+
+    startupSecrets:
+      - type: kv
+        path: secret/data/info
+        data:
+          data:
+            APP_LOGIN: user
+            APP_PASSWORD: password
+          options:
+            cas: 0
+      - type: kv
+        path: kv/data/info
+        data:
+          data:
+            APP_LOGIN: user
+            APP_PASSWORD: password
+
+  volumes:
+    - name: vault-file
+      emptyDir: {}
+
+  volumeMounts:
+    - name: vault-file
+      mountPath: /vault/file


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/banzaicloud/bank-vaults/issues/1576
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

That's my attempt to enable extra CAS options on writes to KVv2 backend, such as

```
    startupSecrets:
      - type: kv
        path: secret/data/info
        data:
          data:
            APP_LOGIN: user
            APP_PASSWORD: password
          options:
            cas: 0
```

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

https://github.com/banzaicloud/bank-vaults/issues/1576

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] let's run CI and see how it goes
