### PR TITLE
Create servicemonitor.yaml

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-operator
-version: 1.15.5
+version: 1.15.6
 appVersion: 1.15.2
 description: A Helm chart for banzaicloud/bank-vaults Vault operator
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-operator/templates/servicemonitor.yaml
+++ b/charts/vault-operator/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{ if .Values.monitoring.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "vault.fullname" . }}
+  namespace: {{ include "vault.namespace" . }}
+  labels:
+{{ include "vault.labels" . | indent 4 }}
+{{- with .Values.monitoring.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+{{ include "vault.labels" . | indent 6 }}
+  endpoints:
+  - port: http
+    path: /metrics
+    {{- with .Values.monitoring.serviceMonitor.metricsRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.monitoring.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  namespaceSelector:
+    matchNames:
+    - {{ include "vault.namespace" . }}
+{{- end }}

--- a/charts/vault-operator/values.yaml
+++ b/charts/vault-operator/values.yaml
@@ -86,4 +86,4 @@ monitoring:
     enabled: false
     additionalLabels: {}
     metricRelabelings: []
-    relabelings: []  
+    relabelings: []

--- a/charts/vault-operator/values.yaml
+++ b/charts/vault-operator/values.yaml
@@ -80,3 +80,10 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+monitoring:
+  # Create a Vault Operator ServiceMonitor object
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+    metricRelabelings: []
+    relabelings: []  


### PR DESCRIPTION
Creating service monitor for vault

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | NA
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR is raised to include a new 'service monitoring' feature for vault. A ServiceMonitor is used to define an application you wish to scrape metrics from within Kubernetes, the controller will action the ServiceMonitors we define and automatically build the required Prometheus configuration. Currently we do not have a service monitor for vault due to which we do not receive any metric related to vault

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
We can get vault related metrics post implementing a service monitor

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

