### PR TITLE
webhook: Add .Values.secretsMutation to control whether to mutate Secrets

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-secrets-webhook
-version: 1.15.8
+version: 1.15.9
 appVersion: 1.15.2
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request secrets from Vault
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -127,6 +127,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | volumes                            | extra volume definitions                                                      | `[]`                                                     |
 | volumeMounts                       | extra volume mounts                                                           | `[]`                                                     |
 | configMapMutation                  | enable injecting values from Vault to ConfigMaps                              | `false`                                                  |
+| secretsMutation                    | enable injecting values from Vault to Secrets                                 | `true`                                                   |
 | customResourceMutations            | list of CustomResources to inject values from Vault                           | `[]`                                                     |
 | podDisruptionBudget.enabled        | enable PodDisruptionBudget                                                    | `true`                                                   |
 | podDisruptionBudget.minAvailable   | represents the number of Pods that must be available (integer or percentage)  | `1`                                                      |

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -110,6 +110,7 @@ webhooks:
 {{- if semverCompare ">=1.12-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   sideEffects: {{ .Values.apiSideEffectValue }}
 {{- end }}
+{{- if .Values.secretsMutation }}
 - name: secrets.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
   {{- if semverCompare ">=1.14-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   admissionReviewVersions: ["v1beta1"]
@@ -172,6 +173,7 @@ webhooks:
 {{- end }}
 {{- if semverCompare ">=1.12-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   sideEffects: {{ .Values.apiSideEffectValue }}
+{{- end }}
 {{- end }}
 {{- if .Values.configMapMutation }}
 - name: configmaps.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -145,6 +145,9 @@ customResourcesFailurePolicy: Ignore
 # This can cause issues when used with Helm, so it is not enabled by default
 configMapMutation: false
 
+# Whether to mutate Secrets with values from Vault. Set to false in order to prevent secret values from being persisted in Kubernetes.
+secretsMutation: true
+
 configMapFailurePolicy: Ignore
 
 podsFailurePolicy: Ignore


### PR DESCRIPTION
In order to control if secret values should be persisted in K8s.

Sometimes this is undesired, as this sensitive data might not
be encrypted at rest and RBAC might not be sufficient to prevent
users from reading data they should not have access to.

Signed-off-by: Lucas Caparelli <lucas.caparelli@gympass.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1614
| License         | Apache 2.0


### What's in this PR?
A way to control whether to register the Secrets in the MutationWebhookConfiguration.


### Additional context
I've kept the default as `true` so it doesn't break current behavior for users that do not care about this.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)