### PR TITLE
webhook: Add skip registry verify functionality

### DIFF
--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -53,6 +53,7 @@ type VaultConfig struct {
 	RunAsUser                   int64
 	RunAsGroup                  int64
 	ReadOnlyRootFilesystem      bool
+	RegistrySkipVerify          bool
 	IgnoreMissingSecrets        string
 	VaultEnvPassThrough         string
 	ConfigfilePath              string
@@ -262,6 +263,12 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 		vaultConfig.ReadOnlyRootFilesystem, _ = strconv.ParseBool(val)
 	} else {
 		vaultConfig.ReadOnlyRootFilesystem, _ = strconv.ParseBool(viper.GetString("readonly_root_fs"))
+	}
+
+	if val, ok := annotations["vault.security.banzaicloud.io/registry-skip-verify"]; ok {
+		vaultConfig.RegistrySkipVerify, _ = strconv.ParseBool(val)
+	} else {
+		vaultConfig.RegistrySkipVerify, _ = strconv.ParseBool(viper.GetString("registry_skip_verify"))
 	}
 
 	if val, ok := annotations["vault.security.banzaicloud.io/mutate-configmap"]; ok {

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -263,7 +263,7 @@ func (mw *MutatingWebhook) mutateContainers(ctx context.Context, containers []co
 
 		// the container has no explicitly specified command
 		if len(args) == 0 {
-			imageConfig, err := mw.registry.GetImageConfig(ctx, mw.k8sClient, vaultConfig.ObjectNamespace, &container, podSpec) // nolint:gosec
+			imageConfig, err := mw.registry.GetImageConfig(ctx, mw.k8sClient, vaultConfig.ObjectNamespace, vaultConfig.RegistrySkipVerify, &container, podSpec) // nolint:gosec
 			if err != nil {
 				return false, err
 			}

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -44,7 +44,7 @@ type MockRegistry struct {
 	Image v1.Config
 }
 
-func (r *MockRegistry) GetImageConfig(_ context.Context, _ kubernetes.Interface, _ string, _ *corev1.Container, _ *corev1.PodSpec) (*v1.Config, error) {
+func (r *MockRegistry) GetImageConfig(_ context.Context, _ kubernetes.Interface, _ string, _ bool, _ *corev1.Container, _ *corev1.PodSpec) (*v1.Config, error) {
 	return &r.Image, nil
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | no
| License         | Apache 2.0


### What's in this PR?
Adding skipping tls check functionality for self-signed docker registry 

### Why?
When you have a self-signed certificate in your docker registry, you can face this error from the k8s job with consul temples config.
`time="2022-05-20T17:31:04Z" level=error msg="Admission review request failed" app=vault-secrets-webhook dry-run=false error="cannot fetch image descriptor: Get \"https://localhost:8443/v2/\": x509: certificate signed by unknown authority" kind=v1/Pod name=test`


### Additional context
None


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
