### PR TITLE
Webhook helm override namespace and object selector

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-secrets-webhook
-version: 1.15.9
+version: 1.15.10
 appVersion: 1.15.2
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request secrets from Vault
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -128,6 +128,14 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | volumeMounts                       | extra volume mounts                                                           | `[]`                                                     |
 | configMapMutation                  | enable injecting values from Vault to ConfigMaps                              | `false`                                                  |
 | secretsMutation                    | enable injecting values from Vault to Secrets                                 | `true`                                                   |
+| pods.objectSelector                | object selector to use - ( overrides root ObjectSelector )                    | `{}`                                                     |
+| pods.namespaceSelector             | namespace selector to use - ( overrides root namespaceSelector )              | `{}`                                                     |
+| secrets.objectSelector             | object selector to use - ( overrides root ObjectSelector )                    | `{}`                                                     |
+| secrets.namespaceSelector          | namespace selector to use - ( overrides root namespaceSelector )              | `{}`                                                     |
+| configMaps.objectSelector          | object selector to use - ( overrides root ObjectSelector )                    | `{}`                                                     |
+| configMaps.namespaceSelector       | namespace selector to use - ( overrides root namespaceSelector )              | `{}`                                                     |
+| customResources.objectSelector     | object selector to use - ( overrides root ObjectSelector )                    | `{}`                                                     |
+| customResources.namespaceSelector  | namespace selector to use - ( overrides root namespaceSelector )              | `{}`                                                     |
 | customResourceMutations            | list of CustomResources to inject values from Vault                           | `[]`                                                     |
 | podDisruptionBudget.enabled        | enable PodDisruptionBudget                                                    | `true`                                                   |
 | podDisruptionBudget.minAvailable   | represents the number of Pods that must be available (integer or percentage)  | `1`                                                      |

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -23,6 +23,61 @@
 {{- $caCrt = required "Required when certificate.generate is false" .Values.certificate.ca.crt }}
 {{- end }}
 
+
+{{- $secretsNamespaceSelector := default dict }}
+{{- $secretsObjectSelector := default dict }}
+{{- $configmapsNamespaceSelector := default dict }}
+{{- $configmapsObjectSelector := default dict }}
+{{- $podsNamespaceSelector := default dict }}
+{{- $podsObjectSelector := default dict }}
+{{- $crNamespaceSelector := default dict }}
+{{- $crObjectSelector := default dict }}
+
+{{- if .Values.secrets.namespaceSelector }}
+{{- $secretsNamespaceSelector = .Values.secrets.namespaceSelector }}
+{{- else }}
+{{- $secretsNamespaceSelector = .Values.namespaceSelector }}
+{{- end }}
+{{- if .Values.secrets.objectSelector }}
+{{- $secretsObjectSelector = .Values.secrets.objectSelector }}
+{{- else }}
+{{- $secretsObjectSelector = .Values.objectSelector }}
+{{- end }}
+
+{{- if .Values.configMaps.namespaceSelector }}
+{{- $configmapsNamespaceSelector = .Values.configMaps.namespaceSelector }}
+{{- else }}
+{{- $configmapsNamespaceSelector = .Values.namespaceSelector }}
+{{- end }}
+{{- if .Values.configMaps.objectSelector }}
+{{- $configmapsObjectSelector = .Values.configMaps.objectSelector }}
+{{- else }}
+{{- $configmapsObjectSelector = .Values.objectSelector }}
+{{- end }}
+
+{{- if .Values.pods.namespaceSelector }}
+{{- $podsNamespaceSelector = .Values.pods.namespaceSelector }}
+{{- else }}
+{{- $podsNamespaceSelector = .Values.namespaceSelector }}
+{{- end }}
+{{- if .Values.pods.objectSelector }}
+{{- $podsObjectSelector = .Values.pods.objectSelector }}
+{{- else }}
+{{- $podsObjectSelector = .Values.objectSelector }}
+{{- end }}
+
+{{- if .Values.customResources.namespaceSelector }}
+{{- $crNamespaceSelector = .Values.customResources.namespaceSelector }}
+{{- else }}
+{{- $crNamespaceSelector = .Values.namespaceSelector }}
+{{- end }}
+{{- if .Values.customResources.objectSelector }}
+{{- $crObjectSelector = .Values.customResources.objectSelector }}
+{{- else }}
+{{- $crObjectSelector = .Values.objectSelector }}
+{{- end }}
+
+
 {{- if $tlsCrt }}
 apiVersion: v1
 kind: Secret
@@ -80,13 +135,13 @@ webhooks:
     - pods
   failurePolicy: {{ .Values.podsFailurePolicy }}
   namespaceSelector:
-  {{- if .Values.namespaceSelector.matchLabels }}
+  {{- if $podsNamespaceSelector.matchLabels }}
     matchLabels:
-{{ toYaml .Values.namespaceSelector.matchLabels | indent 6 }}
+{{ toYaml $podsNamespaceSelector.matchLabels | indent 6 }}
   {{- end }}
     matchExpressions:
-    {{- if .Values.namespaceSelector.matchExpressions }}
-{{ toYaml .Values.namespaceSelector.matchExpressions | indent 4 }}
+    {{- if $podsNamespaceSelector.matchExpressions }}
+{{ toYaml $podsNamespaceSelector.matchExpressions | indent 4 }}
     {{- end }}
     - key: name
       operator: NotIn
@@ -94,13 +149,13 @@ webhooks:
       - {{ .Release.Namespace }}
 {{- if semverCompare ">=1.15-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   objectSelector:
-  {{- if .Values.objectSelector.matchLabels }}
+  {{- if $podsObjectSelector.matchLabels }}
     matchLabels:
-{{ toYaml .Values.objectSelector.matchLabels | indent 6 }}
+{{ toYaml $podsObjectSelector.matchLabels | indent 6 }}
   {{- end }}
     matchExpressions:
-    {{- if .Values.objectSelector.matchExpressions }}
-{{ toYaml .Values.objectSelector.matchExpressions | indent 4 }}
+    {{- if $podsObjectSelector.matchExpressions }}
+{{ toYaml $podsObjectSelector.matchExpressions | indent 4 }}
     {{- end }}
     - key: security.banzaicloud.io/mutate
       operator: NotIn
@@ -140,13 +195,13 @@ webhooks:
     - secrets
   failurePolicy: {{ .Values.secretsFailurePolicy }}
   namespaceSelector:
-  {{- if .Values.namespaceSelector.matchLabels }}
+  {{- if $secretsNamespaceSelector.matchLabels }}
     matchLabels:
-{{ toYaml .Values.namespaceSelector.matchLabels | indent 6 }}
+{{ toYaml $secretsNamespaceSelector.matchLabels | indent 6 }}
   {{- end }}
     matchExpressions:
-    {{- if .Values.namespaceSelector.matchExpressions }}
-{{ toYaml .Values.namespaceSelector.matchExpressions | indent 4 }}
+    {{- if $secretsNamespaceSelector.matchExpressions }}
+{{ toYaml $secretsNamespaceSelector.matchExpressions | indent 4 }}
     {{- end }}
     - key: name
       operator: NotIn
@@ -154,13 +209,13 @@ webhooks:
       - {{ .Release.Namespace }}
 {{- if semverCompare ">=1.15-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   objectSelector:
-  {{- if .Values.objectSelector.matchLabels }}
+  {{- if $secretsObjectSelector.matchLabels }}
     matchLabels:
-{{ toYaml .Values.objectSelector.matchLabels | indent 6 }}
+{{ toYaml $secretsObjectSelector.matchLabels | indent 6 }}
   {{- end }}
     matchExpressions:
-    {{- if .Values.objectSelector.matchExpressions }}
-{{ toYaml .Values.objectSelector.matchExpressions | indent 4 }}
+    {{- if $secretsObjectSelector.matchExpressions }}
+{{ toYaml $secretsObjectSelector.matchExpressions | indent 4 }}
     {{- end }}
     - key: owner
       operator: NotIn
@@ -205,13 +260,13 @@ webhooks:
         - configmaps
   failurePolicy: {{ .Values.configmapFailurePolicy | default .Values.configMapFailurePolicy }}
   namespaceSelector:
-  {{- if .Values.namespaceSelector.matchLabels }}
+  {{- if $configmapsNamespaceSelector.matchLabels }}
     matchLabels:
-{{ toYaml .Values.namespaceSelector.matchLabels | indent 6 }}
+{{ toYaml $configmapsNamespaceSelector.matchLabels | indent 6 }}
   {{- end }}
     matchExpressions:
-  {{- if .Values.namespaceSelector.matchExpressions }}
-{{ toYaml .Values.namespaceSelector.matchExpressions | indent 4 }}
+  {{- if $configmapsNamespaceSelector.matchExpressions }}
+{{ toYaml $configmapsNamespaceSelector.matchExpressions | indent 4 }}
   {{- end }}
     - key: name
       operator: NotIn
@@ -219,13 +274,13 @@ webhooks:
       - {{ .Release.Namespace }}
 {{- if semverCompare ">=1.15-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   objectSelector:
-  {{- if .Values.objectSelector.matchLabels }}
+  {{- if $configmapsObjectSelector.matchLabels }}
     matchLabels:
-{{ toYaml .Values.objectSelector.matchLabels | indent 6 }}
+{{ toYaml $configmapsObjectSelector.matchLabels | indent 6 }}
   {{- end }}
     matchExpressions:
-    {{- if .Values.objectSelector.matchExpressions }}
-{{ toYaml .Values.objectSelector.matchExpressions | indent 4 }}
+    {{- if $configmapsObjectSelector.matchExpressions }}
+{{ toYaml $configmapsObjectSelector.matchExpressions | indent 4 }}
     {{- end }}
     - key: owner
       operator: NotIn
@@ -270,13 +325,13 @@ webhooks:
 {{ toYaml .Values.customResourceMutations | indent 6 }}
   failurePolicy: {{ .Values.customResourcesFailurePolicy }}
   namespaceSelector:
-  {{- if .Values.namespaceSelector.matchLabels }}
+  {{- if $crNamespaceSelector.matchLabels }}
     matchLabels:
-{{ toYaml .Values.namespaceSelector.matchLabels | indent 6 }}
+{{ toYaml $crNamespaceSelector.matchLabels | indent 6 }}
   {{- end }}
     matchExpressions:
-    {{- if .Values.namespaceSelector.matchExpressions }}
-{{ toYaml .Values.namespaceSelector.matchExpressions | indent 4 }}
+    {{- if $crNamespaceSelector.matchExpressions }}
+{{ toYaml $crNamespaceSelector.matchExpressions | indent 4 }}
     {{- end }}
     - key: name
       operator: NotIn
@@ -284,13 +339,13 @@ webhooks:
       - {{ .Release.Namespace }}
 {{- if semverCompare ">=1.15-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
   objectSelector:
-  {{- if .Values.objectSelector.matchLabels }}
+  {{- if $crObjectSelector.matchLabels }}
     matchLabels:
-{{ toYaml .Values.objectSelector.matchLabels | indent 6 }}
+{{ toYaml $crObjectSelector.matchLabels | indent 6 }}
   {{- end }}
     matchExpressions:
-    {{- if .Values.objectSelector.matchExpressions }}
-{{ toYaml .Values.objectSelector.matchExpressions | indent 4 }}
+    {{- if $crObjectSelector.matchExpressions }}
+{{ toYaml $crObjectSelector.matchExpressions | indent 4 }}
     {{- end }}
     - key: security.banzaicloud.io/mutate
       operator: NotIn

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -180,6 +180,26 @@ objectSelector: {}
   # matchLabels:
   #   vault-injection: enabled
 
+# objectSelector & namespaceSelector for secrets resource (overrides `objectSelector`); Requires K8s 1.15+
+secrets:
+  objectSelector: {}
+  namespaceSelector: {}
+
+# objectSelector & namespaceSelector for pods resource (overrides `objectSelector`); Requires K8s 1.15+
+pods:
+  objectSelector: {}
+  namespaceSelector: {}
+
+# objectSelector & namespaceSelector for configmap resource (overrides `objectSelector`); Requires K8s 1.15+
+configMaps:
+  objectSelector: {}
+  namespaceSelector: {}
+
+# objectSelector & namespaceSelector for customResource resource (overrides `objectSelector`); Requires K8s 1.15+
+customResources:
+  objectSelector: {}
+  namespaceSelector: {}
+
 podDisruptionBudget:
   enabled: true
   minAvailable: 1


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Allows users to override objectSelectors and namespaceSelectors for a given resource

### Why?
I have a scenario where I'm mostly using the webhook to mutate secrets globally and not pods. So needed some finer grain controls to allow me to set different selectors for pod mutation vs secret mutation

### Additional context
Tested out different options manually


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
