### PR TITLE
Add sample tlsAdditionalHosts setting to cr.yaml

### DIFF
--- a/operator/deploy/cr.yaml
+++ b/operator/deploy/cr.yaml
@@ -91,6 +91,11 @@ spec:
   # Define a list of namespaces or use ["*"] for all namespaces.
   caNamespaces:
     - "vswh"
+    
+  # Support for adding hostnames and IPs to the generated CA certificate.
+  # tlsAdditionalHosts:
+  #   - vault2.example.com
+  #   - 192.168.20.20
 
   # Describe where you would like to store the Vault unseal keys and root token.
   unsealConfig:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | None
| License         | Apache 2.0


### What's in this PR?
Adds a commented `tlsAdditionalHosts` section to `cr.yaml` to demonstrate how to add extra hosts to the generated CA certificate. I discovered that section by looking at the operator's Go code, it'll be easier for others to discover in the future if it's in one of the CR YAML files.

### Why?
At present, this option isn't documented anywhere.

### Checklist
- [ x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
