### PR TITLE
Fix: use the correct path var for audit and secrets engines

### DIFF
--- a/.github/workflows/ci-config-crud-e2e.yml
+++ b/.github/workflows/ci-config-crud-e2e.yml
@@ -73,37 +73,37 @@ jobs:
             --vault-config-file "${BANK_VAULTS_CONFIG_FILE}" \
             &> "${BANK_VAULTS_LOG_FILE}" & disown
 
-      - name: Audit tests
+      - name: Test group - Audit
         if: always()
         run: |
           bash scripts/validate-config-crud/validate-config-crud.sh "audit"
 
-      - name: Auth tests
+      - name: Test group - Auth
         if: always()
         run: |
           bash scripts/validate-config-crud/validate-config-crud.sh "auth"
 
-      - name: Groups tests
+      - name: Test group - Groups
         if: always()
         run: |
           bash scripts/validate-config-crud/validate-config-crud.sh "groups"
 
-      - name: Group-aliases tests
+      - name: Test group - Group-Aliases
         if: always()
         run: |
           bash scripts/validate-config-crud/validate-config-crud.sh "group-aliases"
 
-      - name: Policies tests
+      - name: Test group - Policies
         if: always()
         run: |
           bash scripts/validate-config-crud/validate-config-crud.sh "policies"
 
-      - name: StartupSecrets tests
+      - name: Test group - StartupSecrets
         if: always()
         run: |
           bash scripts/validate-config-crud/validate-config-crud.sh "startupSecrets"
 
-      - name: Secrets tests
+      - name: Test group - Secrets
         if: always()
         run: |
           bash scripts/validate-config-crud/validate-config-crud.sh "secrets"

--- a/internal/vault/audits.go
+++ b/internal/vault/audits.go
@@ -36,7 +36,7 @@ func initAuditConfig(configs []audit) []audit {
 			configs[index].Path = config.Type
 		}
 
-		configs[index].Path = strings.Trim(config.Path, "/")
+		configs[index].Path = strings.Trim(configs[index].Path, "/")
 	}
 
 	return configs

--- a/internal/vault/secrets_engines.go
+++ b/internal/vault/secrets_engines.go
@@ -62,7 +62,7 @@ func initSecretsEnginesConfig(configs []secretEngine) []secretEngine {
 			configs[index].Path = config.Type
 		}
 
-		configs[index].Path = strings.Trim(config.Path, "/")
+		configs[index].Path = strings.Trim(configs[index].Path, "/")
 	}
 
 	return configs

--- a/scripts/validate-config-crud/validate-config-crud.sh
+++ b/scripts/validate-config-crud/validate-config-crud.sh
@@ -54,9 +54,10 @@ test_case_passed () {
   echo "[PASSED] Test case successfully passed."
 }
 
-#
-# Tests.
 
+#
+# Test group - Audit
+#
 audit_test () {
   bank_vaults_config_copy "audit"
   local get_vault_values_json='vault audit list -format=json'
@@ -100,6 +101,10 @@ audit_test () {
   echo "All audit test cases have been passed."
 }
 
+
+#
+# Test group - Auth
+#
 auth_test () {
   bank_vaults_config_copy "auth"
   local get_vault_values_json='vault auth list -format=json'
@@ -143,6 +148,10 @@ auth_test () {
   echo "All auth test cases have been passed."
 }
 
+
+#
+# Test group - Groups
+#
 groups_test () {
   bank_vaults_config_copy 'groups'
   local get_vault_values_json='vault list -format=json identity/group/name'
@@ -184,6 +193,10 @@ groups_test () {
   echo "All groups test cases have been passed."
 }
 
+
+#
+# Test group - Group-Aliases
+#
 group_aliases_test () {
   # NOTE: group-aliases has a different test style because Vault exposes only group-aliases IDs not the names directly.
   bank_vaults_config_copy 'auth groups group-aliases'
@@ -243,6 +256,10 @@ group_aliases_test () {
   echo "All group-aliases test cases have been passed."
 }
 
+
+#
+# Test group - StartupSecrets
+#
 startup_secrets_test () {
   # Note: The "startupSecrets" doesn't have purge option; hence, we only check the values.
   bank_vaults_config_copy "secrets startupSecrets"
@@ -259,6 +276,10 @@ startup_secrets_test () {
   echo "All startupSecrets test cases have been passed."
 }
 
+
+#
+# Test group - Secrets
+#
 secrets_test () {
   bank_vaults_config_copy "secrets"
   local get_vault_values_json='vault secrets list -format=json'
@@ -302,6 +323,10 @@ secrets_test () {
   echo "All secrets test cases have been passed."
 }
 
+
+#
+# Test group - Policies
+#
 policies_test () {
   bank_vaults_config_copy 'policies'
   local get_vault_values_json='vault policy list -format=json'

--- a/scripts/validate-config-crud/validate-config-crud.sh
+++ b/scripts/validate-config-crud/validate-config-crud.sh
@@ -67,6 +67,8 @@ audit_test () {
 
   test "$(${get_vault_values_json} | jq -r '."audit_foo/".type')" == "file"; test_case_passed
   test "$(${get_vault_values_json} | jq -r '."audit_bar/".type')" == "file"; test_case_passed
+  # If the "path" key is not defined, then the "type" value should be used as "path".
+  test "$(${get_vault_values_json} | jq -r '."file/".type')" == "file"; test_case_passed
 
   #
   ## Case 2.
@@ -108,6 +110,8 @@ auth_test () {
 
   test "$(${get_vault_values_json} | jq -r '."auth_foo/".type')" == "approle"; test_case_passed
   test "$(${get_vault_values_json} | jq -r '."auth_bar/".type')" == "userpass"; test_case_passed
+  # If the "path" key is not defined, then the "type" value should be used as "path".
+  test "$(${get_vault_values_json} | jq -r '."userpass/".type')" == "userpass"; test_case_passed
 
   #
   ## Case 2.
@@ -265,6 +269,8 @@ secrets_test () {
 
   test "$(${get_vault_values_json} | jq -r '."secret_foo/".type')" == "kv"; test_case_passed
   test "$(${get_vault_values_json} | jq -r '."secret_bar/".type')" == "ssh"; test_case_passed
+  # If the "path" key is not defined, then the "type" value should be used as "path".
+  test "$(${get_vault_values_json} | jq -r '."ssh/".type')" == "ssh"; test_case_passed
 
   #
   ## Case 2.

--- a/scripts/validate-config-crud/vault-config.yml
+++ b/scripts/validate-config-crud/vault-config.yml
@@ -18,6 +18,10 @@ audit:
     type: file
     options:
       file_path: /tmp/foo.log
+  # The "path" would be defaulted to "type".
+  - type: file
+    options:
+      file_path: /tmp/file.log
 
 auth:
   # The auth "auth_approle" is used in group-aliases tests.
@@ -27,6 +31,8 @@ auth:
     type: approle
   - path: auth_bar
     type: userpass
+  # The "path" would be defaulted to "type".
+  - type: userpass
 
 groups:
   - name: group_foo
@@ -64,6 +70,8 @@ secrets:
     type: kv
   - path: secret_bar
     type: ssh
+  # The "path" would be defaulted to "type".
+  - type: ssh
 
 startupSecrets:
   - type: kv


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no/
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1612
| License         | Apache 2.0


### What's in this PR?
The Audit path default value was overwritten after it was set correctly because using the wrong var to trim.

In the trim process, the var `configs[index].Path` should be used because it was set by the previous if condition.

And to avoid a such issue in the future, I've also added that case (when the "path" would have defaulted to "type") to E2E tests. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
