### PR TITLE
Fix typo Vault CRD spec field 'FleuntDConfLocation' to 'FluentDConfLocation'

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-operator
-version: 1.15.8
+version: 1.15.9
 appVersion: 1.15.3
 description: A Helm chart for banzaicloud/bank-vaults Vault operator
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-operator/crds/crd.yaml
+++ b/charts/vault-operator/crds/crd.yaml
@@ -491,7 +491,7 @@ spec:
                 type: string
               externalConfig:
                 x-kubernetes-preserve-unknown-fields: true
-              fleuntdConfLocation:
+              fluentdConfLocation:
                 type: string
               fluentdConfFile:
                 type: string

--- a/operator/deploy/cr-audit.yaml
+++ b/operator/deploy/cr-audit.yaml
@@ -24,7 +24,7 @@ spec:
 
   fluentdEnabled: true
   fluentdImage: banzaicloud/fluentd-s3:latest
-  fleuntdConfLocation: "/fluentd/etc"
+  fluentdConfLocation: "/fluentd/etc"
   #fluentdConfFile: "fluent.conf" # default value
   fluentdConfig: |
     <source>

--- a/operator/deploy/crd.yaml
+++ b/operator/deploy/crd.yaml
@@ -491,7 +491,7 @@ spec:
                 type: string
               externalConfig:
                 x-kubernetes-preserve-unknown-fields: true
-              fleuntdConfLocation:
+              fluentdConfLocation:
                 type: string
               fluentdConfFile:
                 type: string

--- a/operator/pkg/apis/vault/v1alpha1/vault_types.go
+++ b/operator/pkg/apis/vault/v1alpha1/vault_types.go
@@ -110,9 +110,9 @@ type VaultSpec struct {
 	// default: fluent/fluentd:edge
 	FluentDImage string `json:"fluentdImage,omitempty"`
 
-	// FleuntDConfLocation is the location of the fluent.conf file
+	// FluentDConfLocation is the location of the fluent.conf file
 	// default: "/fluentd/etc"
-	FleuntDConfLocation string `json:"fleuntdConfLocation,omitempty"`
+	FluentDConfLocation string `json:"fluentdConfLocation,omitempty"`
 
 	// FluentDConfFile specifices the FluentD configuration file name to use for Vault log exportation
 	// default:
@@ -601,10 +601,10 @@ func (spec *VaultSpec) GetFluentDImage() string {
 
 // GetFluentDConfMountPath returns the mount path for the fluent.conf
 func (spec *VaultSpec) GetFluentDConfMountPath() string {
-	if spec.FleuntDConfLocation == "" {
+	if spec.FluentDConfLocation == "" {
 		return "/fluentd/etc"
 	}
-	return spec.FleuntDConfLocation
+	return spec.FluentDConfLocation
 }
 
 // IsFluentDEnabled returns true if fluentd sidecar is to be deployed


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1652
| License         | Apache 2.0


### What's in this PR?
Fixes typo and spelling in Vault CRD spec field `fleuntdConfLocation` -> `fluentdConfLocation`.

### Why?
First it's a typo and more importantly as per issue #1652 if full CRD spec not applied to enable validation user can use the correct spelling leading to hidden misconfiguration.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)