### PR TITLE
Adding vault-operator sm

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-operator
-version: 1.15.8
+version: 1.15.9
 appVersion: 1.15.3
 description: A Helm chart for banzaicloud/bank-vaults Vault operator
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-operator/templates/servicemonitor.yaml
+++ b/charts/vault-operator/templates/servicemonitor.yaml
@@ -2,17 +2,17 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "vault.fullname" . }}
-  namespace: {{ include "vault.namespace" . }}
+  name: {{ include "vault-operator.fullname" . }}
+  namespace: {{ include "vault-operator.namespace" . }}
   labels:
-{{ include "vault.labels" . | indent 4 }}
+{{ include "vault-operator.labels" . | indent 4 }}
 {{- with .Values.monitoring.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
 {{- end }}
 spec:
   selector:
     matchLabels:
-{{ include "vault.labels" . | indent 6 }}
+{{ include "vault-operator.labels" . | indent 6 }}
   endpoints:
   - port: http
     path: /metrics
@@ -26,5 +26,5 @@ spec:
     {{- end }}
   namespaceSelector:
     matchNames:
-    - {{ include "vault.namespace" . }}
+    - {{ include "vault-operator.namespace" . }}
 {{- end }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | NA
| License         | Apache 2.0


### What's in this PR?
A ServiceMonitor is used to define an application you wish to scrape metrics from within Kubernetes, the controller will action the ServiceMonitors we define and automatically build the required Prometheus configuration. Currently we do not have a service monitor for vault due to which we do not receive any metric related to vault. This PR is raised to fix a small bug in servicemonitor.yaml file


### Why?
We can get vault related metrics post implementing a service monitor


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

