### PR TITLE
Adding path to avoid error during reconciling

### DIFF
--- a/operator/deploy/cr-audit.yaml
+++ b/operator/deploy/cr-audit.yaml
@@ -109,6 +109,7 @@ spec:
             ttl: 1h
     audit:
       - type: file
+        path: file
         description: "File based audit logging device"
         options:
           file_path: /vault/logs/vault.log


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
I have added a missing syntax, which will make sure that you don't get any errors while applying an audit device using `bank-vaults` 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Current example is incorrect and leads to error.
```
vault-configurer-68cc75cc7d-bkqhs:bank-vaults {"level":"error","msg":"error configuring vault: error configuring audit devices for vault: error configuring managed audits: error enabling audit device  in vault: Error making API request.\n\nURL: PUT https://vault.vault-operator:8200/v1/sys/audit\nCode: 405. Errors:\n\n* 1 error occurred:\n\t* unsupported operation\n\n","time":"2022-07-29T10:42:45Z"}
vault-configurer-68cc75cc7d-bkqhs:bank-vaults {"level":"info","msg":"Failed applying configuration file: /config/vault-configurer/vault-config.yml , sleeping for 1m0s before trying again","time":"2022-07-29T10:42:45Z"}
```


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

https://github.com/banzaicloud/bank-vaults/issues/290
https://github.com/banzaicloud/bank-vaults/pull/311 (Thanks for the original contribution for cr-audit)

https://www.vaultproject.io/docs/audit/file#configuration-1
https://www.vaultproject.io/api-docs/system/audit#path

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
