### PR TITLE
Operator: Fix metrics port name for ServiceMonitor in Helm chart

### DIFF
--- a/charts/vault-operator/Chart.yaml
+++ b/charts/vault-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-operator
-version: 1.16.1
+version: 1.16.2
 appVersion: 1.16.0
 description: A Helm chart for banzaicloud/bank-vaults Vault operator
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-operator/templates/servicemonitor.yaml
+++ b/charts/vault-operator/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "vault-operator.name" . }}
   endpoints:
-  - port: http
+  - port: http-metrics
     path: /metrics
     {{- with .Values.monitoring.serviceMonitor.metricRelabelings }}
     metricRelabelings:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1679
| License         | Apache 2.0


### What's in this PR?
#1679 Almost fixes the `ServiceMonitor` implementation for the operator, but the port name is not correct, this PR fixes that using the correct port defined in [the service](https://github.com/banzaicloud/bank-vaults/blob/ac9e73215916980e3217728de5d97d61d04be27b/charts/vault-operator/templates/service.yaml#L21L23)


### Why?
Fixes #1679 


### Additional context
Tested on a standalone  deployment, it works

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)


