### PR TITLE
add default pull secret service account

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-secrets-webhook
-version: 1.16.0
+version: 1.16.1
 appVersion: 1.16.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request secrets from Vault
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -58,6 +58,7 @@ env:
   # # specify an imagePullSecret
   # DEFAULT_IMAGE_PULL_SECRET:
   # DEFAULT_IMAGE_PULL_SECRET_NAMESPACE:
+  # DEFAULT_IMAGE_PULL_SECRET_SERVICE_ACCOUNT
   # VAULT_CLIENT_TIMEOUT: 10s
   # # define the webhook's role in Vault used for authentication,
   # # if not defined individually in resources by annotations.

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -456,6 +456,7 @@ func SetConfigDefaults() {
 	viper.SetDefault("transit_key_id", "")
 	viper.SetDefault("transit_path", "")
 	viper.SetDefault("default_image_pull_secret", "")
+	viper.SetDefault("default_image_pull_secret_service_account", "")
 	viper.SetDefault("default_image_pull_secret_namespace", "")
 	viper.SetDefault("registry_skip_verify", "false")
 	viper.SetDefault("enable_json_log", "false")

--- a/pkg/webhook/registry.go
+++ b/pkg/webhook/registry.go
@@ -108,10 +108,12 @@ func (r *Registry) GetImageConfig(
 	// Try to find matching registry credentials in the default imagePullSecret if one was provided.
 	// Otherwise, cloud credential providers will be tried.
 	defaultImagePullSecretNamespace := viper.GetString("default_image_pull_secret_namespace")
+	defaultImagePullSecretServiceAccount := viper.GetString("default_image_pull_secret_service_account")
 	defaultImagePullSecret := viper.GetString("default_image_pull_secret")
 	if len(containerInfo.ImagePullSecrets) == 0 &&
-		defaultImagePullSecretNamespace != "" && defaultImagePullSecret != "" {
+		defaultImagePullSecretNamespace != "" && defaultImagePullSecret != "" && defaultImagePullSecretServiceAccount != "" {
 		containerInfo.Namespace = defaultImagePullSecretNamespace
+		containerInfo.ServiceAccountName = defaultImagePullSecretServiceAccount
 		containerInfo.ImagePullSecrets = []string{defaultImagePullSecret}
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1659
| License         | Apache 2.0


### What's in this PR?
Adds the option to specify a default image pull secret service account name.

### Why?
To solve issue #1659 


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] Related Helm chart(s) updated (if needed)
