### PR TITLE
operator: Fix setting fluentd config file name

### DIFF
--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1540,7 +1540,7 @@ func configMapForStatsD(v *vaultv1alpha1.Vault) *corev1.ConfigMap {
 func configMapForFluentD(v *vaultv1alpha1.Vault) *corev1.ConfigMap {
 	ls := v.LabelsForVault()
 	fluentdConfFile := v.Spec.FluentDConfFile
-	if fluentdConfFile != "" {
+	if fluentdConfFile == "" {
 		fluentdConfFile = "fluent.conf"
 	}
 	cm := &corev1.ConfigMap{

--- a/operator/pkg/controller/vault/vault_controller_test.go
+++ b/operator/pkg/controller/vault/vault_controller_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package vault
 
 import (

--- a/operator/pkg/controller/vault/vault_controller_test.go
+++ b/operator/pkg/controller/vault/vault_controller_test.go
@@ -1,0 +1,47 @@
+package vault
+
+import (
+	"testing"
+
+	vaultv1alpha1 "github.com/banzaicloud/bank-vaults/operator/pkg/apis/vault/v1alpha1"
+)
+
+func TestFluentDConfFile(t *testing.T) {
+	testFilename := "test.conf"
+
+	v := &vaultv1alpha1.Vault{
+		Spec: vaultv1alpha1.VaultSpec{
+			FluentDConfFile: testFilename,
+		},
+	}
+
+	configMap := configMapForFluentD(v)
+
+	if configMap == nil {
+		t.Errorf("no configmap returned")
+	}
+
+	if _, ok := configMap.Data[testFilename]; !ok {
+		t.Errorf("configmap did not contain a key matching %q", testFilename)
+		t.Logf("configmap: %+v", configMap)
+	}
+}
+
+func TestFluentDConfFileDefault(t *testing.T) {
+	defaultFilename := "fluent.conf"
+
+	v := &vaultv1alpha1.Vault{
+		Spec: vaultv1alpha1.VaultSpec{},
+	}
+
+	configMap := configMapForFluentD(v)
+
+	if configMap == nil {
+		t.Errorf("no configmap returned")
+	}
+
+	if _, ok := configMap.Data[defaultFilename]; !ok {
+		t.Errorf("configmap did not contain a key matching %q", defaultFilename)
+		t.Logf("configmap: %+v", configMap)
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1572
| License         | Apache 2.0

### What's in this PR?
A single character change to invert the check made on the `FluentdConfFile` field in the spec.

### Why?
Currently the code checks if the value from the spec is **not** empty making it impossible to override the default. 
If there is no value set it leaves the fluentd config file name as empty string ("").

This means we can only ever use `fluent.conf` or empty string `""` as the name of the config file and the latter causes the validation error seen in #1572 . 

We'd like to set it to `fluent-bit.conf` for use in the `aws-for-fluent` image. 
See: https://github.com/aws/aws-for-fluent-bit/blob/mainline/entrypoint.sh 

### Additional context
Added two quick unit tests to check the configMapForFluentd function to confirm the behaviour.

### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
