### PR TITLE
webhook: transit engine use batch api calls for better performance

### DIFF
--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -39,6 +39,7 @@ type VaultConfig struct {
 	VaultEnvDelay               time.Duration
 	TransitKeyID                string
 	TransitPath                 string
+	TransitBatchSize            int
 	CtConfigMap                 string
 	CtImage                     string
 	CtInjectInInitcontainers    bool
@@ -408,6 +409,13 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 		vaultConfig.MutateProbes = false
 	}
 
+	if val, ok := annotations["vault.security.banzaicloud.io/transit-batch-size"]; ok {
+		batchSize, _ := strconv.ParseInt(val, 10, 32)
+		vaultConfig.TransitBatchSize = int(batchSize)
+	} else {
+		vaultConfig.TransitBatchSize = viper.GetInt("transit_batch_size")
+	}
+
 	return vaultConfig
 }
 
@@ -455,6 +463,7 @@ func SetConfigDefaults() {
 	viper.SetDefault("telemetry_listen_address", "")
 	viper.SetDefault("transit_key_id", "")
 	viper.SetDefault("transit_path", "")
+	viper.SetDefault("transit_batch_size", 25)
 	viper.SetDefault("default_image_pull_secret", "")
 	viper.SetDefault("default_image_pull_secret_namespace", "")
 	viper.SetDefault("registry_skip_verify", "false")
@@ -467,5 +476,6 @@ func SetConfigDefaults() {
 	viper.SetDefault("VAULT_ENV_MEMORY_LIMIT", "")
 	viper.SetDefault("VAULT_ENV_LOG_SERVER", "")
 	viper.SetDefault("VAULT_NAMESPACE", "")
+
 	viper.AutomaticEnv()
 }

--- a/pkg/webhook/configmap.go
+++ b/pkg/webhook/configmap.go
@@ -52,8 +52,9 @@ func (mw *MutatingWebhook) MutateConfigMap(configMap *corev1.ConfigMap, vaultCon
 	defer vaultClient.Close()
 
 	config := injector.Config{
-		TransitKeyID: vaultConfig.TransitKeyID,
-		TransitPath:  vaultConfig.TransitPath,
+		TransitKeyID:     vaultConfig.TransitKeyID,
+		TransitPath:      vaultConfig.TransitPath,
+		TransitBatchSize: vaultConfig.TransitBatchSize,
 	}
 	secretInjector := injector.NewSecretInjector(config, vaultClient, nil, logger)
 

--- a/pkg/webhook/object.go
+++ b/pkg/webhook/object.go
@@ -129,8 +129,9 @@ func (mw *MutatingWebhook) MutateObject(object *unstructured.Unstructured, vault
 	defer vaultClient.Close()
 
 	config := injector.Config{
-		TransitKeyID: vaultConfig.TransitKeyID,
-		TransitPath:  vaultConfig.TransitPath,
+		TransitKeyID:     vaultConfig.TransitKeyID,
+		TransitPath:      vaultConfig.TransitPath,
+		TransitBatchSize: vaultConfig.TransitBatchSize,
 	}
 	secretInjector := injector.NewSecretInjector(config, vaultClient, nil, logger)
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
This PR improves performance when using the transit engine with lots of secrets coming in from vault;

### Why?
When you have lots of secrets that use the transit engine, the webhook is really slow to respond; This is because it's making N number of API calls to vault; We can leverage batch_input to send multiple secrets at once, reducing the overhead and improving the response time of the webhook.

For example - If I have a secret with 20 Values coming from vault... previously this would take about 1.5-2 seconds for the webhook to respond; After this PR since it's only making 1 API call, it takes < 250 ms

### Additional context
I've tested it extensively with ConfigMaps, and Secrets; The code for secret mutation was simplified in order to share the logic for prefetching transit secrets;  

Mutating Custom Resources or Pods still has the old behavior


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
