### PR TITLE
webhook: enable vault-agent namespace for Vault Enterprise

### DIFF
--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -36,6 +36,7 @@ pid_file = "/tmp/pidfile"
 
 auto_auth {
         method "kubernetes" {
+                namespace = "%s"
                 mount_path = "auth/%s"
                 config = {
                         role = "%s"
@@ -869,7 +870,7 @@ func getConfigMapForVaultAgent(pod *corev1.Pod, vaultConfig VaultConfig) *corev1
 			OwnerReferences: ownerReferences,
 		},
 		Data: map[string]string{
-			"config.hcl": fmt.Sprintf(vaultAgentConfig, vaultConfig.Path, vaultConfig.Role),
+			"config.hcl": fmt.Sprintf(vaultAgentConfig, vaultConfig.VaultNamespace, vaultConfig.Path, vaultConfig.Role),
 		},
 	}
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | no
| License         | Apache 2.0

### What's in this PR?

Added the ability to set the Vault namespace in the vault agent configuration.

### Why?

Not functional with Vault Enterprise

### Additional context

Try to use the webhook with consul-template : 
* the vault-agent container cannot authenticate with Vault because the namespace is not defined.
* info : the namespace must be defined in the config.hcl file by the user, otherwise the consul-template container fails to authenticate

### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

