### PR TITLE
Don't crash trying to rotate aws config/root.

### DIFF
--- a/internal/vault/secrets_engines.go
+++ b/internal/vault/secrets_engines.go
@@ -315,7 +315,7 @@ func (v *vault) addManagedSecretsEngines(managedSecretsEngines []secretEngine) e
 					}
 				}
 
-				// For secret engines where the root credentials are rotatable we don't wan't to reconfigure again
+				// For secret engines where the root credentials are rotatable we don't want to reconfigure again
 				// with the old credentials, because that would cause access denied issues. Currently these are:
 				// - AWS
 				// - Database
@@ -323,7 +323,11 @@ func (v *vault) addManagedSecretsEngines(managedSecretsEngines []secretEngine) e
 					((secretEngine.Type == "database" && configOption == "config") ||
 						(secretEngine.Type == "aws" && configOption == "config/root")) {
 					// TODO we need to find out if it was rotated or not
-					err = v.rotateSecretEngineCredentials(secretEngine.Type, secretEngine.Path, name.(string), configPath)
+					nameStr := ""
+					if name != nil {
+						nameStr = name.(string)
+					}
+					err = v.rotateSecretEngineCredentials(secretEngine.Type, secretEngine.Path, nameStr, configPath)
 					if err != nil {
 						return errors.Wrapf(err, "error rotating credentials for '%s' config in vault", configPath)
 					}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1481
| License         | Apache 2.0


### What's in this PR?
Check for nil.


### Why?
We can't cast `name` to `string` if it's nil. And the user can't work around the problem by providing a `name` to the config, because then we try to POST the config to the wrong path.


### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
