### PR TITLE
webhook: Add VAULT_TOKEN support

### DIFF
--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -83,6 +83,7 @@ type VaultConfig struct {
 	VaultServiceAccount         string
 	ObjectNamespace             string
 	MutateProbes                bool
+	Token                       string
 }
 
 func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig {
@@ -415,6 +416,8 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 	} else {
 		vaultConfig.TransitBatchSize = viper.GetInt("transit_batch_size")
 	}
+
+	vaultConfig.Token = viper.GetString("vault_token")
 
 	return vaultConfig
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
If VAULT_TOKEN env variable is defined for the webhook pod, forward it to all additional init and sidecar containers. Do not add Vault Agent container if the variable is defined because looks like it's impossible to reuse an existing token when using Vault agent.

It's possible to inject secrets into pod, secrets, configmaps and use Consul templates to generate configuration files when explicitly specifying VAULT_TOKEN, so you bypass kubernetes authentication method if using Minikube.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
