### PR TITLE
fix: log with warning level instead of error if missing secrets are allowed

### DIFF
--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -269,7 +269,7 @@ func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inj
 				return errors.Errorf("path not found: %s", valuePath)
 			}
 
-			i.logger.Errorf("path not found: %s", valuePath)
+			i.logger.Warnf("path not found: %s", valuePath)
 
 			continue
 		}
@@ -323,7 +323,7 @@ func (i SecretInjector) InjectSecretsFromVaultPath(paths string, inject SecretIn
 				return errors.Errorf("path not found: %s", valuePath)
 			}
 
-			i.logger.Errorln("path not found:", valuePath)
+			i.logger.Warnln("path not found:", valuePath)
 
 			continue
 		}

--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -274,9 +274,9 @@ func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inj
 			}
 
 			i.logger.Warnf(
-				"We couldn't find a secret path. This is not an error since missing secrets can be ignored according to the configuration you've set (annotation: %s). Path not found: %s",
-				MissingSecretsAnnotation,
+				"Path not found: %s - We couldn't find a secret path. This is not an error since missing secrets can be ignored according to the configuration you've set (annotation: %s).",
 				valuePath,
+				MissingSecretsAnnotation,
 			)
 
 			continue
@@ -332,9 +332,9 @@ func (i SecretInjector) InjectSecretsFromVaultPath(paths string, inject SecretIn
 			}
 
 			i.logger.Warnf(
-				"We couldn't find a secret path. This is not an error since missing secrets can be ignored according to the configuration you've set (annotation: %s). Path not found: %s",
-				MissingSecretsAnnotation,
+				"Path not found: %s - We couldn't find a secret path. This is not an error since missing secrets can be ignored according to the configuration you've set (annotation: %s).",
 				valuePath,
+				MissingSecretsAnnotation,
 			)
 
 			continue

--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -28,6 +28,10 @@ import (
 	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
 )
 
+const (
+	MissingSecretsAnnotation = "vault.security.banzaicloud.io/vault-ignore-missing-secrets"
+)
+
 type SecretInjectorFunc func(key, value string)
 
 type SecretRenewer interface {
@@ -269,7 +273,11 @@ func (i SecretInjector) InjectSecretsFromVault(references map[string]string, inj
 				return errors.Errorf("path not found: %s", valuePath)
 			}
 
-			i.logger.Warnf("path not found: %s", valuePath)
+			i.logger.Warnf(
+				"We couldn't find a secret path. This is not an error since missing secrets can be ignored according to the configuration you've set (annotation: %s). Path not found: %s",
+				MissingSecretsAnnotation,
+				valuePath,
+			)
 
 			continue
 		}
@@ -323,7 +331,11 @@ func (i SecretInjector) InjectSecretsFromVaultPath(paths string, inject SecretIn
 				return errors.Errorf("path not found: %s", valuePath)
 			}
 
-			i.logger.Warnln("path not found:", valuePath)
+			i.logger.Warnf(
+				"We couldn't find a secret path. This is not an error since missing secrets can be ignored according to the configuration you've set (annotation: %s). Path not found: %s",
+				MissingSecretsAnnotation,
+				valuePath,
+			)
 
 			continue
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | no
| License         | Apache 2.0


### What's in this PR?

This PR changes the log level from ERROR to WARNING when missing secrets are allowed.


### Why?

Currently, when using annotation `vault.security.banzaicloud.io/vault-ignore-missing-secrets`, an error is logged with message `path not found: %s`, but in the [documentation](https://banzaicloud.com/docs/bank-vaults/mutating-webhook/annotations/) of this annotation says: `When enabled will only log warnings when Vault secrets are missing` 


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
