### PR TITLE
Add VAULT_TOKEN support for non-production environments

### DIFF
--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -83,6 +83,7 @@ type VaultConfig struct {
 	VaultServiceAccount         string
 	ObjectNamespace             string
 	MutateProbes                bool
+	Token                       string
 }
 
 func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig {
@@ -415,6 +416,8 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 	} else {
 		vaultConfig.TransitBatchSize = viper.GetInt("transit_batch_size")
 	}
+
+	vaultConfig.Token = viper.GetString("vault_token")
 
 	return vaultConfig
 }


### PR DESCRIPTION
Sometimes it's convinient (though quite insecure) to use preexisting Vault token when deploying webhook.

For example, it's rather impossible to use kubernetes or jwt auth method with Minikibe and external Vault server, because the Vault server can not connect to the Minikube cluster to validate a token.

At the moment, it's already possible to authorize with a preexisting token using the VAULT_TOKEN environment variable set for the webhook container when injecting Vault secrets into k8s Secret resources, but other use cases (e.g. vault-env) do not work this way.

So the following patch is proposed.

- if VAULT_TOKEN environment variable is defined in the webhook's pod environment, a token value defined by the variable is used directly so other Vault authorization methods are bypassed.
- the variable is applied to all inject methods, excluding vault agent;
- when using VAULT_TOKEN, the vault agent injection method is useless. Vault agent is the source of token on its own and can not use the predefined token. As a result we can not use vault agent templating support to render configuration files when using VAULT_TOKEN.

| Q               | A
| --------------- | ---
| Bug fix?        | no/yes
| New feature?    | no/yes
| API breaks?     | no/yes
| Deprecations?   | no/yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
