### PR TITLE
injector: fix embedded template parsing

### DIFF
--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -62,7 +62,7 @@ func NewSecretInjector(config Config, client *vault.Client, renewer SecretRenewe
 	}
 }
 
-var inlineMutationRegex = regexp.MustCompile(`\${([>]{0,2}vault:.*?)}`)
+var inlineMutationRegex = regexp.MustCompile(`\${([>]{0,2}vault:.*?#*}?)}`)
 
 func (i SecretInjector) FetchTransitSecrets(secrets []string) (map[string][]byte, error) {
 	if len(i.config.TransitKeyID) == 0 {

--- a/internal/injector/injector_test.go
+++ b/internal/injector/injector_test.go
@@ -82,12 +82,13 @@ func TestSecretInjector(t *testing.T) {
 		t.Parallel()
 
 		references := map[string]string{
-			"ACCOUNT_PASSWORD":      "vault:secret/data/account#password",
-			"TRANSIT_SECRET":        `>>vault:transit/decrypt/mykey#${.plaintext | b64dec}#{"ciphertext":"` + ciphertext + `"}`,
-			"ROOT_CERT":             ">>vault:pki/root/generate/internal#certificate",
-			"ROOT_CERT_CACHED":      ">>vault:pki/root/generate/internal#certificate",
-			"INLINE_SECRET":         "scheme://${vault:secret/data/account#username}:${vault:secret/data/account#password}@127.0.0.1:8080",
-			"INLINE_DYNAMIC_SECRET": "${>>vault:pki/root/generate/internal#certificate}__${>>vault:pki/root/generate/internal#certificate}",
+			"ACCOUNT_PASSWORD":                "vault:secret/data/account#password",
+			"TRANSIT_SECRET":                  `>>vault:transit/decrypt/mykey#${.plaintext | b64dec}#{"ciphertext":"` + ciphertext + `"}`,
+			"ROOT_CERT":                       ">>vault:pki/root/generate/internal#certificate",
+			"ROOT_CERT_CACHED":                ">>vault:pki/root/generate/internal#certificate",
+			"INLINE_SECRET":                   "scheme://${vault:secret/data/account#username}:${vault:secret/data/account#password}@127.0.0.1:8080",
+			"INLINE_SECRET_EMBEDDED_TEMPLATE": "scheme://${vault:secret/data/account#username}:${vault:secret/data/account#${.password | urlquery}}@127.0.0.1:8080",
+			"INLINE_DYNAMIC_SECRET":           "${>>vault:pki/root/generate/internal#certificate}__${>>vault:pki/root/generate/internal#certificate}",
 		}
 
 		results := map[string]string{}
@@ -111,9 +112,10 @@ func TestSecretInjector(t *testing.T) {
 		delete(results, "INLINE_DYNAMIC_SECRET")
 
 		assert.Equal(t, map[string]string{
-			"ACCOUNT_PASSWORD": "secret",
-			"TRANSIT_SECRET":   "secret",
-			"INLINE_SECRET":    "scheme://superusername:secret@127.0.0.1:8080",
+			"ACCOUNT_PASSWORD":                "secret",
+			"TRANSIT_SECRET":                  "secret",
+			"INLINE_SECRET":                   "scheme://superusername:secret@127.0.0.1:8080",
+			"INLINE_SECRET_EMBEDDED_TEMPLATE": "scheme://superusername:secret@127.0.0.1:8080",
 		}, results)
 	})
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1728
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Support embedded templates inside templates as well.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Let's take this example into account, where you need to craft a database url from a secret and encode the password, since it contains some special chars:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test-db-configmap
  annotations:
    # vault.security.banzaicloud.io settings
data:
  jdbc: postgresql://foo.bar.svc:5432/mydb?user=${vault:secret/data/account#username}&password=${vault:secret/data/account#${.password | urlquery}}
```

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
