### PR TITLE
webhook: local dev environment facilitation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,13 +170,12 @@ operator-down:
 webhook-forward: ## Install the webhook chart and kurun to port-forward the local webhook into Kubernetes
 	kubectl create namespace vault-infra --dry-run -o yaml | kubectl apply -f -
 	kubectl label namespaces vault-infra name=vault-infra --overwrite
-	helm upgrade --install vault-secrets-webhook charts/vault-secrets-webhook --namespace vault-infra --set replicaCount=0 --set podsFailurePolicy=Fail --set secretsFailurePolicy=Fail
+	helm upgrade --install vault-secrets-webhook charts/vault-secrets-webhook --namespace vault-infra --set replicaCount=0 --set podsFailurePolicy=Fail --set secretsFailurePolicy=Fail --set configMapMutation=true --set configMapFailurePolicy=Fail
 	kurun port-forward localhost:8443 --namespace vault-infra --servicename vault-secrets-webhook --tlssecret vault-secrets-webhook-webhook-tls
 
 .PHONY: webhook-run ## Run run the webhook locally
 webhook-run:
 	KUBERNETES_NAMESPACE=vault-infra go run ./cmd/vault-secrets-webhook
 
-
-.PHONY: webhook-up ## Run the webhook and `kurun port-forward` in foreground. Use with make -j.
+.PHONY: webhook-up ## Run the webhook and `kurun port-forward` in foreground. Use with make -j webhook-up
 webhook-up: webhook-run webhook-forward

--- a/deploy/test-configmap-dev.yaml
+++ b/deploy/test-configmap-dev.yaml
@@ -1,0 +1,20 @@
+# Useful for local development with a Vault dev server:
+#
+# vault server -dev
+# export VAULT_ADDR='http://127.0.0.1:8200'
+# vault kv put secret/database/test username=joska
+#
+# make -j webhook-up
+#
+# kubectl apply -f deploy/test-configmap-dev.yaml
+# kubectl get configmap configmap-dev -o yaml
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-dev
+  annotations:
+    vault.security.banzaicloud.io/vault-addr: "http://localhost:8200"
+data:
+  plain: vault:secret/data/database/test#username
+  template: user=${vault:secret/data/database/test#username}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #1737 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
A useful sample, to enable configmap mutation locally during webhook development, steps are included inline

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
It is hard and error prone to do tricks with Docker images, tags and chart versions.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
[kurun](https://github.com/banzaicloud/kurun) is required for running the webhook locally against a cluster.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
