### PR TITLE
webhook: create sa tokens via apiserver

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -241,7 +241,7 @@ func (mw *MutatingWebhook) newVaultClient(vaultConfig VaultConfig) (*vault.Clien
 			if err != nil {
 				return nil, errors.Wrap(err, "Failed to create a token for the specified service account "+vaultConfig.VaultServiceAccount+" on namespace "+vaultConfig.ObjectNamespace)
 			}
-			saToken = string(token.Status.Token)
+			saToken = token.Status.Token
 		}
 
 		return vault.NewClientFromConfig(

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -29,6 +29,7 @@ import (
 	"github.com/slok/kubewebhook/v2/pkg/webhook/mutating"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
@@ -213,10 +214,35 @@ func (mw *MutatingWebhook) newVaultClient(vaultConfig VaultConfig) (*vault.Clien
 			return nil, errors.Wrap(err, "Failed to retrieve specified service account on namespace "+vaultConfig.ObjectNamespace)
 		}
 
-		secret, err := mw.k8sClient.CoreV1().Secrets(vaultConfig.ObjectNamespace).Get(context.Background(), sa.Secrets[0].Name, metav1.GetOptions{})
-		if err != nil {
-			return nil, errors.Wrap(err, "Failed to retrieve secret for service account "+sa.Secrets[0].Name+" in namespace "+vaultConfig.ObjectNamespace)
-		}
+        saToken := ""
+        if len(sa.Secrets) > 0 {
+		    secret, err := mw.k8sClient.CoreV1().Secrets(vaultConfig.ObjectNamespace).Get(context.Background(), sa.Secrets[0].Name, metav1.GetOptions{})
+		    if err != nil {
+				return nil, errors.Wrap(err, "Failed to retrieve secret for service account "+sa.Secrets[0].Name+" in namespace "+vaultConfig.ObjectNamespace)
+		    }
+            saToken = string(secret.Data["token"])
+        }
+
+        if saToken == "" {
+            tokenTTL := int64(600) // min allowed duration is 10 mins
+	        tokenRequest := &authenticationv1.TokenRequest{
+				Spec: authenticationv1.TokenRequestSpec{
+					Audiences:         []string{"https://kubernetes.default.svc"},
+					ExpirationSeconds: &tokenTTL,
+				},
+	        }
+
+            token, err := mw.k8sClient.CoreV1().ServiceAccounts(vaultConfig.ObjectNamespace).CreateToken(
+                context.Background(),
+                vaultConfig.VaultServiceAccount,
+                tokenRequest,
+                metav1.CreateOptions{},
+            )
+            if err != nil {
+			    return nil, errors.Wrap(err, "Failed to create a token for the specified service account " +  vaultConfig.VaultServiceAccount + " on namespace "+vaultConfig.ObjectNamespace)
+		    }
+            saToken = string(token.Status.Token)
+        }
 
 		return vault.NewClientFromConfig(
 			clientConfig,
@@ -224,7 +250,7 @@ func (mw *MutatingWebhook) newVaultClient(vaultConfig VaultConfig) (*vault.Clien
 			vault.ClientAuthPath(vaultConfig.Path),
 			vault.NamespacedSecretAuthMethod,
 			vault.ClientLogger(logrusadapter.NewFromEntry(mw.logger)),
-			vault.ExistingSecret(secret.Data["token"]),
+			vault.ExistingSecret(saToken),
 			vault.VaultNamespace(vaultConfig.VaultNamespace),
 		)
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1738
| License         | Apache 2.0


### What's in this PR?
Currently the webhook tries to find sa.secrets[0]
and load its token. But this is no longer available from K8S 1.24 (unless users force creating legacy
tokens on each sa which is not best practice). This change allows creating tokens by calling the apiserver instead of expecting it to be available as a k8s
secret associated to the service account.
This change allows creating tokens by calling the apiserver if the service account does not have  an associated secret with a legacy token.

### Why?
From k8s 1.24 service account no longer have associated tokens stored in k8s secrets.

### Additional context
tested on EKS 1.24

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~

### To Do
