### PR TITLE
webhook: set conditional around unused verb when not using secrets mutation

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-secrets-webhook
-version: 1.17.0
+version: 1.17.1
 appVersion: 1.17.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request secrets from Vault
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-secrets-webhook/templates/webhook-rbac.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-rbac.yaml
@@ -30,7 +30,9 @@ rules:
       - configmaps
     verbs:
       - "get"
+    {{- if .Values.secretsMutation }}
       - "update"
+    {{- end }}
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | yes
| Related tickets |  fixes #1759 
| License         | Apache 2.0


### What's in this PR?
Disables the ability for the webhook to modify secrets if the secret webhook is not enabled as the service no longer needs permissions once it is disabled.


### Why?
Having the webhook overly permissible is a concern within my organization.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] Related Helm chart(s) updated (if needed)
