### PR TITLE
Secret-cleanup pre-delete hook in vault Helm chart

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault
-version: 1.17.0
+version: 1.17.1
 appVersion: 1.17.0
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/

--- a/charts/vault/templates/secret-cleanup.yaml
+++ b/charts/vault/templates/secret-cleanup.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "vault.fullname" . }}-secret-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+  labels:
+    app.kubernetes.io/name: {{ template "vault.name" . }}
+spec:
+  template:
+    metadata:
+      name: {{ template "vault.fullname" . }}-secret-cleanup
+      labels:
+        app.kubernetes.io/name: {{ template "vault.name" . }}
+    spec:
+      serviceAccountName: {{ template "vault.serviceAccountName" . }}
+      containers:
+        - name: {{ template "vault.fullname" . }}-secret-cleanup
+          image: "k8s.gcr.io/hyperkube:v1.12.1"
+          imagePullPolicy: "IfNotPresent"
+          command:
+          - /bin/sh
+          - -c
+          - >
+              kubectl delete secret bank-vaults --ignore-not-found=true;
+              kubectl delete secret vault-unseal-keys --ignore-not-found=true;
+      restartPolicy: OnFailure
+{{- end }}

--- a/hack/acceptance-test.sh
+++ b/hack/acceptance-test.sh
@@ -37,7 +37,6 @@ trap finish EXIT
 # Smoke test the pure Vault Helm chart first
 helm upgrade --install --wait vault ./charts/vault --set unsealer.image.tag=latest --set ingress.enabled=true --set "ingress.hosts[0]=localhost"
 helm delete vault
-kubectl delete secret bank-vaults
 
 # Create a resource quota in the default namespace
 kubectl create quota bank-vaults --hard=cpu=4,memory=8G,pods=10,services=10,replicationcontrollers=10,secrets=15,persistentvolumeclaims=10


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #1760
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added a pre-delete Helm chart hook to cleanup secret used to unseal Vault.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

So if Vault is installed, then deleted and installed again with Helm, it won't complain that this secret already exists.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- [X] Related Helm chart(s) updated (if needed)