### PR TITLE
webhook: for run-as-user use whatever is definied in config or the de…

### DIFF
--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -49,8 +49,6 @@ auto_auth {
                 }
         }
 }`
-	vaultAgentUID int64 = 0
-
 	VaultEnvVolumeName = "vault-env"
 )
 
@@ -674,8 +672,6 @@ func getInitContainers(originalContainers []corev1.Container, podSecurityContext
 		})
 
 		securityContext := getBaseSecurityContext(podSecurityContext, vaultConfig)
-		runAsUser := vaultAgentUID
-		securityContext.RunAsUser = &runAsUser
 
 		containers = append(containers, corev1.Container{
 			Name:            "vault-agent",
@@ -786,9 +782,6 @@ func getAgentContainers(originalContainers []corev1.Container, podSecurityContex
 	if vaultConfig.AgentShareProcess {
 		securityContext.Capabilities.Add = append(securityContext.Capabilities.Add, "SYS_PTRACE")
 	}
-
-	runAsUser := vaultAgentUID
-	securityContext.RunAsUser = &runAsUser
 
 	serviceAccountMount := getServiceAccountMount(originalContainers)
 

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -503,10 +503,9 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 	}
 
 	defaultMode := int32(420)
-	agentRunAsUser := vaultAgentUID
 
 	baseSecurityContext := &corev1.SecurityContext{
-		RunAsUser:                &agentRunAsUser,
+		RunAsUser:                &vaultConfig.RunAsUser,
 		RunAsNonRoot:             &vaultConfig.RunAsNonRoot,
 		ReadOnlyRootFilesystem:   &vaultConfig.ReadOnlyRootFilesystem,
 		AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
@@ -525,7 +524,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 	}
 
 	agentInitContainerSecurityContext := &corev1.SecurityContext{
-		RunAsUser:                &agentRunAsUser,
+		RunAsUser:                &vaultConfig.RunAsUser,
 		RunAsNonRoot:             &vaultConfig.RunAsNonRoot,
 		ReadOnlyRootFilesystem:   &vaultConfig.ReadOnlyRootFilesystem,
 		AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,
@@ -544,7 +543,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 	}
 
 	agentContainerSecurityContext := &corev1.SecurityContext{
-		RunAsUser:                &agentRunAsUser,
+		RunAsUser:                &vaultConfig.RunAsUser,
 		RunAsNonRoot:             &vaultConfig.RunAsNonRoot,
 		ReadOnlyRootFilesystem:   &vaultConfig.ReadOnlyRootFilesystem,
 		AllowPrivilegeEscalation: &vaultConfig.PspAllowPrivilegeEscalation,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/banzaicloud/bank-vaults/issues/1761
| License         | Apache 2.0


### What's in this PR?
Removed the code section for the vault-agent use that overwrites the runAsUser value in the securityContext always with 0. Instead now the value from the config (if annotation run-as-user specified this will be used or the default which is 0) will be used

### Checklist

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
