### PR TITLE
chart/webhook: allow to customise the deployment strategy

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-secrets-webhook
-version: 1.18.0
+version: 1.18.1
 appVersion: 1.18.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request secrets from Vault
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-secrets-webhook/README.md
+++ b/charts/vault-secrets-webhook/README.md
@@ -94,7 +94,7 @@ You can read more information on how to add firewall rules for the GKE control p
 The following tables lists configurable parameters of the vault-secrets-webhook chart and their default values:
 
 | Parameter                          | Description                                                                   | Default                                                  |
-| ---------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------- |
+|------------------------------------|-------------------------------------------------------------------------------|----------------------------------------------------------|
 | affinity                           | affinities to use                                                             | `{}`                                                     |
 | debug                              | debug logs for webhook                                                        | `false`                                                  |
 | image.pullPolicy                   | image pull policy                                                             | `IfNotPresent`                                           |
@@ -122,12 +122,13 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | env.VAULT_ENV_MEMORY_REQUEST       | memory requests for init-containers vault-env and copy-vault-env              | `64Mi`                                                   |
 | env.VAULT_ENV_CPU_LIMIT            | cpu limits for init-containers vault-env and copy-vault-env                   | `250m`                                                   |
 | env.VAULT_ENV_MEMORY_LIMIT         | memory limits for init-containers vault-env and copy-vault-env                | `64Mi`                                                   |
-| env.VAULT_ENV_LOG_SERVER           | define remote log server for vault-env                                        | ``                                                   |
-| initContainers                     | containers, which are run before the app containers are started               | `[]`                                                  |
+| env.VAULT_ENV_LOG_SERVER           | define remote log server for vault-env                                        | ``                                                       |
+| initContainers                     | containers, which are run before the app containers are started               | `[]`                                                     |
 | volumes                            | extra volume definitions                                                      | `[]`                                                     |
 | volumeMounts                       | extra volume mounts                                                           | `[]`                                                     |
 | configMapMutation                  | enable injecting values from Vault to ConfigMaps                              | `false`                                                  |
 | secretsMutation                    | enable injecting values from Vault to Secrets                                 | `true`                                                   |
+| deployment.strategy                | rolling strategy for webhook deployment                                       | `{}`                                                     |
 | pods.objectSelector                | object selector to use - ( overrides root ObjectSelector )                    | `{}`                                                     |
 | pods.namespaceSelector             | namespace selector to use - ( overrides root namespaceSelector )              | `{}`                                                     |
 | secrets.objectSelector             | object selector to use - ( overrides root ObjectSelector )                    | `{}`                                                     |
@@ -151,7 +152,7 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | podSecurityContext                 | Pod security context for webhook deployment                                   | `{}`                                                     |
 | timeoutSeconds                     | Webhook timeoutSeconds value                                                  | ``                                                       |
 | hostNetwork                        | allow pod to use the node network namespace                                   | `false`                                                  |
-| dnsPolicy                          | The dns policy desired for the deployment                                     | ``                                                |
+| dnsPolicy                          | The dns policy desired for the deployment                                     | ``                                                       |
 | kubeVersion                        | Override cluster version                                                      | ``                                                       |
 
 ### Certificate options

--- a/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-deployment.yaml
@@ -18,6 +18,12 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ template "vault-secrets-webhook.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.deployment }}
+  {{- if .Values.deployment.strategy }}
+  strategy:
+{{ toYaml .Values.deployment.strategy | indent 4 }}
+  {{- end }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -137,6 +137,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+deployment:
+  # Strategy for the deployment
+  strategy: {}
+
 # A list of Kubernetes resource types to mutate as well:
 # Example: ["ingresses", "servicemonitors"]
 customResourceMutations: []


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?

This PR adds an option in the chart to configure the deployment strategy. 

### Why?

I've recently looked for a way to change the deployment strategy of the webhook pods without using kustomize. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
