### PR TITLE
chart/webhook: Add ClusterRole to create `serviceaccounts/token`

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-secrets-webhook
-version: 1.18.0
+version: 1.18.2
 appVersion: 1.18.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request secrets from Vault
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-secrets-webhook/templates/webhook-rbac.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-rbac.yaml
@@ -46,6 +46,12 @@ rules:
     verbs:
       - "create"
       - "update"
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - "create"
 {{- if .Values.rbac.psp.enabled }}
   - apiGroups:
       - extensions


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


Add ClusterRole to create `serviceaccounts/token` since the `1.18.0` release include the creation of serviceAccount tokens via apiserver.

Ref:
 - https://github.com/banzaicloud/bank-vaults/issues/1738
 - https://github.com/banzaicloud/bank-vaults/pull/1752

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)