### PR TITLE
vault-env: fix vault-env generated env which may contain duplicates

### DIFF
--- a/internal/injector/injector_test.go
+++ b/internal/injector/injector_test.go
@@ -32,6 +32,11 @@ import (
 	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
 )
 
+func assertKeyDoesNotExist(t *testing.T, m map[string]string, k string) {
+	_, hasKey := m[k]
+	assert.False(t, hasKey)
+}
+
 func TestSecretInjector(t *testing.T) {
 	t.Parallel()
 
@@ -93,6 +98,7 @@ func TestSecretInjector(t *testing.T) {
 
 		results := map[string]string{}
 		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
 			results[key] = value
 		}
 
@@ -128,6 +134,7 @@ func TestSecretInjector(t *testing.T) {
 
 		results := map[string]string{}
 		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
 			results[key] = value
 		}
 
@@ -144,6 +151,7 @@ func TestSecretInjector(t *testing.T) {
 
 		results := map[string]string{}
 		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
 			results[key] = value
 		}
 
@@ -189,6 +197,7 @@ func TestSecretInjectorFromPath(t *testing.T) {
 		results := map[string]string{}
 
 		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
 			results[key] = value
 		}
 
@@ -208,6 +217,7 @@ func TestSecretInjectorFromPath(t *testing.T) {
 		results := map[string]string{}
 
 		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
 			results[key] = value
 		}
 
@@ -229,6 +239,7 @@ func TestSecretInjectorFromPath(t *testing.T) {
 
 		results := map[string]string{}
 		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
 			results[key] = value
 		}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?

I have noticed that the new `preprocessTransitSecrets` is calling `inject` even if nothing has been replaced with values from the transit cache. 

In case you are working with "maps" (ConfigMap, Secret) this does not matter as the "old" code will still overwrite the key with the secret. But in the case of `vault-env` you will have the same env var set twice and most the the time only the first occurence (without the secret) is taken into account.

### Why?

Since https://github.com/banzaicloud/bank-vaults/pull/1697 we are experimenting issues with `vault-env`: the generated environment has all the env vars containing `vault:` tokens duplicated, one version in its original version and a second one with the secret instead of the token.

```
root@pod:/# /vault/vault-env printenv
{"addr":"","app":"vault-env","level":"info","msg":"received new Vault token","path":"...","role":"...","time":"2023-01-27T15:25:12Z"}
{"app":"vault-env","level":"info","msg":"initial Vault token arrived","time":"2023-01-27T15:25:12Z"}
{"app":"vault-env","level":"info","msg":"spawning process: [printenv]","time":"2023-01-27T15:25:12Z"}
RMQ_PASSWORD=${vault:secret/data/rmqpassword#password}
OTHER=VAL
BLA=BLA
......
RMQ_PASSWORD=suPeRSecrEt
......
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
