### PR TITLE
Fixed typo for once flag description

### DIFF
--- a/cmd/bank-vaults/main.go
+++ b/cmd/bank-vaults/main.go
@@ -269,7 +269,7 @@ func init() {
 	configStringVar(rootCmd, cfgFilePath, "", "The path prefix of the files where to store values in")
 
 	// Misc common flags
-	configBoolVar(rootCmd, cfgOnce, false, "Run configure/unsela only once")
+	configBoolVar(rootCmd, cfgOnce, false, "Run configure/unseal only once")
 	configDurationVar(configureCmd, cfgUnsealPeriod, time.Second*5, "How often to attempt to unseal the Vault instance")
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | no
| License         | Apache 2.0

### What's in this PR?
This PR fixes typo for the --once flag description

### Why?
This PR fixes typo for the --once flag description

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
