### PR TITLE
vault-env: set TransitBatchSize in vault-env config

### DIFF
--- a/cmd/vault-env/main.go
+++ b/cmd/vault-env/main.go
@@ -75,6 +75,7 @@ var sanitizeEnvmap = map[string]envType{
 	"VAULT_AUTH_METHOD":            {login: false},
 	"VAULT_TRANSIT_KEY_ID":         {login: false},
 	"VAULT_TRANSIT_PATH":           {login: false},
+	"VAULT_TRANSIT_BATCH_SIZE":     {login: false},
 	"VAULT_IGNORE_MISSING_SECRETS": {login: false},
 	"VAULT_ENV_PASSTHROUGH":        {login: false},
 	"VAULT_JSON_LOG":               {login: false},
@@ -253,6 +254,7 @@ func main() {
 	config := injector.Config{
 		TransitKeyID:         os.Getenv("VAULT_TRANSIT_KEY_ID"),
 		TransitPath:          os.Getenv("VAULT_TRANSIT_PATH"),
+		TransitBatchSize:     cast.ToInt(os.Getenv("VAULT_TRANSIT_BATCH_SIZE")),
 		DaemonMode:           daemonMode,
 		IgnoreMissingSecrets: ignoreMissingSecrets,
 	}

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -375,20 +375,30 @@ func (mw *MutatingWebhook) mutateContainers(ctx context.Context, containers []co
 				},
 			}...)
 		}
-		if len(vaultConfig.VaultNamespace) > 0 {
-			container.Env = append(container.Env, []corev1.EnvVar{
-				{
-					Name:  "VAULT_NAMESPACE",
-					Value: vaultConfig.VaultNamespace,
-				},
-			}...)
-		}
 
 		if len(vaultConfig.TransitPath) > 0 {
 			container.Env = append(container.Env, []corev1.EnvVar{
 				{
 					Name:  "VAULT_TRANSIT_PATH",
 					Value: vaultConfig.TransitPath,
+				},
+			}...)
+		}
+
+		if vaultConfig.TransitBatchSize > 0 {
+			container.Env = append(container.Env, []corev1.EnvVar{
+				{
+					Name:  "VAULT_TRANSIT_BATCH_SIZE",
+					Value: strconv.Itoa(vaultConfig.TransitBatchSize),
+				},
+			}...)
+		}
+
+		if len(vaultConfig.VaultNamespace) > 0 {
+			container.Env = append(container.Env, []corev1.EnvVar{
+				{
+					Name:  "VAULT_NAMESPACE",
+					Value: vaultConfig.VaultNamespace,
 				},
 			}...)
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1788 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fix for `panic: runtime error: integer divide by zero` when using transit-encrypted secrets in deployments.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

TransitBatchSize was never set when entering from the vault-env main function.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested manually.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~