### PR TITLE
Fix panic when secret is empty

### DIFF
--- a/pkg/kv/k8s/k8s.go
+++ b/pkg/kv/k8s/k8s.go
@@ -99,6 +99,9 @@ func (k *k8sStorage) Set(key string, val []byte) error {
 		}
 		_, err = k.client.CoreV1().Secrets(k.namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 	} else if err == nil {
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
 		secret.Data[key] = val
 		_, err = k.client.CoreV1().Secrets(k.namespace).Update(context.Background(), secret, metav1.UpdateOptions{})
 	} else {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1814 
| License         | Apache 2.0


### What's in this PR?
Simple fix to allow the code to populate an empty Kubernetes secret.


### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

