### PR TITLE
Add Wildlife Studios as an adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -12,3 +12,4 @@ This is a list of production adopters of Bank-Vaults (in alphabetical order):
 - [Vase.ai](https://vase.ai) is using Bank-vaults with the Vault Secrets Webhook to pull secrets from vault in to be used in their CI/CD pipelines.
 - [ViaBill](https://viabill.com/) is using Bank-Vaults to provision and configure Vault, providing secrets for multiple services and applications.
 - [Vonage](https://www.vonage.com/business/) is using Bank-Vaults to provision and configure Vault to provide secrets to application that are on cloud(k8s) and on premise(approle) and also as a transit engine. Uses AWS KMS, S3 and DynamoDB and will be migrated to use raft backend.
+- [Wildlife Studios](https://wildlifestudios.com/) is using the Vault Secrets Webhook on more than a dozen Kubernetes clusters to provide both static secrets injected with vault-env, as well as dynamic secrets with vault-agent.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?

Adding Wildlifestudios as an Adopter

### Why?

We have been using vault-secrets-webhook for some years now and I saw the slack message asking for users to add themselves to the adopters list.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)