### PR TITLE
Add startup probe to vault container

### DIFF
--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault
-version: 1.19.0
+version: 1.19.1
 appVersion: 1.19.0
 description: A Helm chart for Vault, a tool for managing secrets
 home: https://www.vaultproject.io/

--- a/charts/vault/templates/statefulset.yaml
+++ b/charts/vault/templates/statefulset.yaml
@@ -102,6 +102,19 @@ spec:
           name: vault
         - containerPort: {{ add .Values.service.port 1 }}
           name: cluster
+        # This probe allows Vault extra time to be responsive in a HTTPS manner during startup
+        # See: https://www.vaultproject.io/api/system/init.html
+        startupProbe:
+          httpGet:
+            {{ if .Values.vault.config.listener.tcp.tls_disable }}
+            scheme: HTTP
+            {{ else }}
+            scheme: HTTPS
+            {{ end }}
+            path: /v1/sys/init
+            port: vault
+          periodSeconds: 10
+          failureThreshold: 18
         # This probe makes sure Vault is responsive in a HTTPS manner
         # See: https://www.vaultproject.io/api/system/init.html
         livenessProbe:

--- a/operator/pkg/controller/vault/vault_controller.go
+++ b/operator/pkg/controller/vault/vault_controller.go
@@ -1185,6 +1185,18 @@ func statefulSetForVault(v *vaultv1alpha1.Vault, externalSecretsToWatchItems []c
 				},
 			}))),
 			SecurityContext: withContainerSecurityContext(v),
+			// This probe allows Vault extra time to be responsive in a HTTPS manner during startup
+			// See: https://www.vaultproject.io/api/system/init.html
+			StartupProbe: &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Scheme: getVaultURIScheme(v),
+						Port:   intstr.FromString(v.Spec.GetAPIPortName()),
+						Path:   "/v1/sys/init",
+					}},
+				PeriodSeconds: 10,
+				FailureThreshold: 18,
+			},
 			// This probe makes sure Vault is responsive in a HTTPS manner
 			// See: https://www.vaultproject.io/api/system/init.html
 			LivenessProbe: &corev1.Probe{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1813
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Adds a startup probe to the vault container, allowing it 3 minutes to start up instead of 30 seconds from the liveness probe

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Vault instances with large numbers of leases can take longer than 30 seconds to load the database

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
