### PR TITLE
templating support for vault-role setting

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -20,6 +20,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
+	"text/template"
 
 	"emperror.dev/errors"
 	vaultapi "github.com/hashicorp/vault/api"
@@ -52,6 +54,24 @@ func (mw *MutatingWebhook) VaultSecretsMutator(ctx context.Context, ar *model.Ad
 	if vaultConfig.Skip {
 		return &mutating.MutatorResult{}, nil
 	}
+
+	// parse resulting vaultConfig.Role as potential template with fields of vaultConfig
+	tmpl, err := template.New("vaultRole").Option("missingkey=error").Parse(vaultConfig.Role)
+	if err != nil {
+		return &mutating.MutatorResult{}, errors.Wrap(err, "error parsing vault_role")
+	}
+	var vRoleBuf strings.Builder
+	if err = tmpl.Execute(&vRoleBuf, map[string]string{
+		"authmethod":     vaultConfig.AuthMethod,
+		"name":           obj.GetName(),
+		"namespace":      vaultConfig.ObjectNamespace,
+		"path":           vaultConfig.Path,
+		"serviceaccount": vaultConfig.VaultServiceAccount,
+	}); err != nil {
+		return &mutating.MutatorResult{}, errors.Wrap(err, "error templating vault_role")
+	}
+	vaultConfig.Role = vRoleBuf.String()
+	mw.logger.Debugf("vaultConfig.Role = '%s'", vaultConfig.Role)
 
 	switch v := obj.(type) {
 	case *corev1.Pod:


### PR DESCRIPTION
As described in the mentioned issues, there is a need to define a role based on variables such as the Namespace or ServiceAccount involved.

Instead of manually training developers to set the right annotation, we could define a default using templating to ensure the right role for the right namespace or other concepts.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1160 #954
| License         | Apache 2.0


### What's in this PR?
We want to be able to define the vault role setting with a default of the form _"k8s.\<namespace\>"_, where namespace is the namespace of the pod. Being able to supply a template for the vault role in the settings for the webhook would grant sufficient flexibility.

Hence a very handy **default** configuration could be set so that every deployment has its namespaced role automatically:

```yaml
      containers:
      - env:
        - name: VAULT_ROLE
          value: 'k8s.{{.namespace}}'
```

Or at deployment level:
```yaml
      annotations:
        vault.security.banzaicloud.io/vault-role: '{{ .namespace }}-{{ serviceaccount }}'
```

### Why?
Our users currently need to set the vault role for their pod explicitly even though it should always be _k8s.\<namespace\>_ in our scenarios. We have been able to define defaults for all of the other settings we need so that our users do not need to worry about them, but not this one since the default is simply the serviceaccount name at this time. 

We need to ensure uniqueness of role names across namespaces and serviceaccounts!

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

For now this is a naive approach, to get feedback from the stakeholders @bonifaido how the implementation is expected. 
