### PR TITLE
fix: Honor vault operator init parameter validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/google/go-containerregistry v0.8.0
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20220105220605-d9bfbcb99e52
 	github.com/hashicorp/go-uuid v1.0.2
-	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/vault/api v1.8.2
 	github.com/hashicorp/vault/sdk v0.6.0
@@ -129,6 +128,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1808 
| License         | Apache 2.0


### What's in this PR?
This PR checks the seal recovery key support and uses the according parameters in the init API call.


### Why?
This PR fixes the initialization of vaults that use a seal type that supports only recovery keys and vice versa.

### Additional context
Vault 1.12.0 introduced parameter validation in the operator init request. In the cases where the unseal type does not support recovery keys and recovery keys are provided, the initialization will fail. The same case applies to unseal types that do support recovery keys and secret keys are provided. The related Vault change can be found [here](https://github.com/hashicorp/vault/blob/main/http/sys_init.go#L170).

### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do
- [x] Test it with all unseal methods (tested with shamir and awskms)
