### PR TITLE
Allow env to be set in vault init container 

### DIFF
--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -69,6 +69,7 @@ type VaultConfig struct {
 	AgentMemory                   resource.Quantity
 	AgentImage                    string
 	AgentImagePullPolicy          corev1.PullPolicy
+	AgentEnvVariables             string
 	ServiceAccountTokenVolumeName string
 	EnvImage                      string
 	EnvImagePullPolicy            corev1.PullPolicy
@@ -375,6 +376,10 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 		vaultConfig.AgentImagePullPolicy = getPullPolicy(val)
 	} else {
 		vaultConfig.AgentImagePullPolicy = getPullPolicy(viper.GetString("vault_image_pull_policy"))
+	}
+
+	if val, ok := annotations["vault.security.banzaicloud.io/vault-agent-env-variables"]; ok {
+		vaultConfig.AgentEnvVariables = val
 	}
 
 	if val, ok := annotations["vault.security.banzaicloud.io/vault-namespace"]; ok {

--- a/pkg/webhook/configmap_test.go
+++ b/pkg/webhook/configmap_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
 // +build integration
 
 package webhook

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -16,16 +16,16 @@ package webhook
 
 import (
 	"context"
-	"fmt"
-	"strconv"
-	"strings"
-
 	"emperror.dev/errors"
+	"encoding/json"
+	"fmt"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeVer "k8s.io/apimachinery/pkg/version"
+	"strconv"
+	"strings"
 
 	"github.com/banzaicloud/bank-vaults/internal/injector"
 )
@@ -811,6 +811,16 @@ func getAgentContainers(originalContainers []corev1.Container, podSecurityContex
 		agentCommandString = []string{"agent", "-config", "/vault/config/config.hcl", "-exit-after-auth"}
 	} else {
 		agentCommandString = []string{"agent", "-config", "/vault/config/config.hcl"}
+	}
+
+	if vaultConfig.AgentEnvVariables != "" {
+
+		var envVars []corev1.EnvVar
+		err := json.Unmarshal([]byte(vaultConfig.AgentEnvVariables), &envVars)
+		if err != nil {
+			envVars = []corev1.EnvVar{}
+		}
+		containerEnvVars = append(containerEnvVars, envVars...)
 	}
 
 	containers = append(containers, corev1.Container{

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -814,7 +814,6 @@ func getAgentContainers(originalContainers []corev1.Container, podSecurityContex
 	}
 
 	if vaultConfig.AgentEnvVariables != "" {
-
 		var envVars []corev1.EnvVar
 		err := json.Unmarshal([]byte(vaultConfig.AgentEnvVariables), &envVars)
 		if err != nil {

--- a/pkg/webhook/pod_test.go
+++ b/pkg/webhook/pod_test.go
@@ -957,7 +957,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Will mutate pod with agent-configmap annotations",
+			name: "Will mutate pod with agent-configmap annotations and envVariables",
 			fields: fields{
 				k8sClient: fake.NewSimpleClientset(),
 				registry: &MockRegistry{
@@ -992,6 +992,7 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 					AgentImage:                    "vault:latest",
 					AgentImagePullPolicy:          "IfNotPresent",
 					ServiceAccountTokenVolumeName: "/var/run/secrets/kubernetes.io/serviceaccount",
+					AgentEnvVariables:             "[{\"Name\": \"SKIP_SETCAP\",\"Value\": \"1\"}]",
 				},
 			},
 			wantedPod: &corev1.Pod{
@@ -1017,6 +1018,10 @@ func Test_mutatingWebhook_mutatePod(t *testing.T) {
 								{
 									Name:  "VAULT_SKIP_VERIFY",
 									Value: "false",
+								},
+								{
+									Name:  "SKIP_SETCAP",
+									Value: "1",
 								},
 							},
 							SecurityContext: agentContainerSecurityContext,


### PR DESCRIPTION
**This is a resubmission of [this PR](https://github.com/banzaicloud/bank-vaults/pull/1810) so the CI could run again and it could be merged for the next release.**

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1782 
| License         | Apache 2.0


### What's in this PR?
This feature enables environment variables to be set In the vault init container



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)