### PR TITLE
Use well-known kubernetes name label

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-secrets-webhook
-version: 1.19.0
+version: 1.19.1
 appVersion: 1.19.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request secrets from Vault
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -146,7 +146,7 @@ webhooks:
     {{- if $podsNamespaceSelector.matchExpressions }}
 {{ toYaml $podsNamespaceSelector.matchExpressions | indent 4 }}
     {{- end }}
-    - key: name
+    - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
@@ -209,7 +209,7 @@ webhooks:
     {{- if $secretsNamespaceSelector.matchExpressions }}
 {{ toYaml $secretsNamespaceSelector.matchExpressions | indent 4 }}
     {{- end }}
-    - key: name
+    - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
@@ -277,7 +277,7 @@ webhooks:
   {{- if $configmapsNamespaceSelector.matchExpressions }}
 {{ toYaml $configmapsNamespaceSelector.matchExpressions | indent 4 }}
   {{- end }}
-    - key: name
+    - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
@@ -342,7 +342,7 @@ webhooks:
     {{- if $crNamespaceSelector.matchExpressions }}
 {{ toYaml $crNamespaceSelector.matchExpressions | indent 4 }}
     {{- end }}
-    - key: name
+    - key: kubernetes.io/metadata.name
       operator: NotIn
       values:
       - {{ .Release.Namespace }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -163,10 +163,6 @@ apiSideEffectValue: NoneOnDryRun
 
 namespaceSelector:
   matchExpressions:
-    - key: name
-      operator: NotIn
-      values:
-        - kube-system
     # https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name
     - key: kubernetes.io/metadata.name
       operator: NotIn


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | yes
| Related tickets | closes #1906
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Use the well-known `kubernetes.io/metadata.name` label in `namespaceSelector` instead of plain `name` which has caused issues in the [past](#1464) and [present](#1906) as well.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The latest problem it fixes is described in [this](#1906) issue.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)