### PR TITLE
webhook: fix webhook servingCertificate helm issue

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-secrets-webhook
-version: 1.19.1
+version: 1.19.2
 appVersion: 1.19.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request secrets from Vault
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-secrets-webhook/templates/_helpers.tpl
+++ b/charts/vault-secrets-webhook/templates/_helpers.tpl
@@ -44,7 +44,11 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{- define "vault-secrets-webhook.servingCertificate" -}}
+{{- if .Values.certificate.servingCertificate -}}
+{{ .Values.certificate.servingCertificate }}
+{{- else -}}
 {{ printf "%s-webhook-tls" (include "vault-secrets-webhook.fullname" .) }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-cert-manager.yaml
@@ -53,6 +53,8 @@ spec:
   ca:
     secretName: {{ include "vault-secrets-webhook.rootCACertificate" . }}
 
+{{- end }}
+{{- if or .Values.certificate.useCertManager .Values.certificate.servingCertificate }}
 ---
 
 # Finally, generate a serving certificate for the webhook to use


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1844 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed using a pre-existing serving certificate provided in the webhook helm cart. Previously the name of the given cert did not got to all places it needed to be because the `vault-secrets-webhook.servingCertificate` helper function always returned the same string.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

So the chart could be used with an existing cert using the following config:

```shell
helm install vault-secrets-webhook banzaicloud-stable/vault-secrets-webhook \
    --set certificate.generate=false \
    --set certificate.servingCertificate=<certificateName> \
    --namespace <namespaceName>
```

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested locally.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [X] Related Helm chart(s) updated (if needed)