### PR TITLE
configurer: Startup secret support for v1 kv engine

### DIFF
--- a/internal/vault/startup_secrets.go
+++ b/internal/vault/startup_secrets.go
@@ -73,6 +73,15 @@ func getOrDefaultSecretData(m interface{}) (map[string]interface{}, error) {
 	return data, nil
 }
 
+func vaultKVVersion(secretPath string) string {
+	for _, v := range extConfig.Secrets {
+		if strings.HasPrefix(secretPath, v.Path) && v.Type == "kv" {
+			return v.Options["version"]
+		}
+	}
+	return ""
+}
+
 func readStartupSecret(startupSecret startupSecret) (string, map[string]interface{}, error) {
 	if len(startupSecret.Data.Data) > 0 && len(startupSecret.Data.SecretKeyRef) > 0 {
 		return "", nil, errors.New("the startup secret data source should be either 'data' or 'secretKeyRef'." +
@@ -81,6 +90,9 @@ func readStartupSecret(startupSecret startupSecret) (string, map[string]interfac
 
 	data := map[string]interface{}{
 		"data": startupSecret.Data.Data,
+	}
+	if vaultKVVersion(startupSecret.Path) == "1" {
+		data = startupSecret.Data.Data
 	}
 
 	if len(startupSecret.Data.SecretKeyRef) > 0 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1666 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added support for creating startup secrets in v1 KV Secrets engines by the Bank-Vaults operator. It only works if `version: 1` is specified in the secrets engine's options, otherwise still version 2 format is considered to be default, as this is the default for Vault as well.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Previously the way the operator handled startup secrets didn't work with Version 1 KV Secrets engines, the secrets were not created correctly (see issue #1666). Now if you use a similar config in the CRD, the startup secrets will be created correctly in the related Secrets engine:

```yaml
spec:
  externalConfig:
    secrets:
      - path: secret/v1
        type: kv
        description: General secrets.
        options:
          version: 1
      - path: secret/v2
        type: kv
        description: General secrets.
        options:
          version: 2

    startupSecrets:
      - type: kv
        path: secret/v1/accounts/aws
        data:
          data:
            AWS_ACCESS_KEY_ID: secretId
            AWS_SECRET_ACCESS_KEY: s3cr3t
      - type: kv
        path: secret/v2/data/mysql
        data:
          data:
            MYSQL_ROOT_PASSWORD: s3cr3t
            MYSQL_PASSWORD: 3xtr3ms3cr3t
```

```shell
vault kv get secret/v1/accounts/aws
============ Data ============
Key                      Value
---                      -----
AWS_ACCESS_KEY_ID        secretId
AWS_SECRET_ACCESS_KEY    s3cr3t
```

```shell
vault kv get secret/v2/mysql
==== Secret Path ====
secret/v2/data/mysql

====== Metadata ======
Key              Value
---              -----
created_time     2023-05-26T09:50:48.054560128Z
deletion_time    n/a
destroyed        false
version          1

=========== Data ===========
Key                    Value
---                    -----
MYSQL_PASSWORD         3xtr3ms3cr3t
MYSQL_ROOT_PASSWORD    s3cr3t
```
### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- ~ Related Helm chart(s) updated (if needed)~