### PR TITLE
webhook: remove obsolete mutate-configmap annotation

### DIFF
--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -58,7 +58,6 @@ type VaultConfig struct {
 	IgnoreMissingSecrets          string
 	VaultEnvPassThrough           string
 	ConfigfilePath                string
-	MutateConfigMap               bool
 	EnableJSONLog                 string
 	LogLevel                      string
 	AgentConfigMap                string
@@ -281,12 +280,6 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 		vaultConfig.RegistrySkipVerify, _ = strconv.ParseBool(val)
 	} else {
 		vaultConfig.RegistrySkipVerify, _ = strconv.ParseBool(viper.GetString("registry_skip_verify"))
-	}
-
-	if val, ok := annotations["vault.security.banzaicloud.io/mutate-configmap"]; ok {
-		vaultConfig.MutateConfigMap, _ = strconv.ParseBool(val)
-	} else {
-		vaultConfig.MutateConfigMap, _ = strconv.ParseBool(viper.GetString("mutate_configmap"))
 	}
 
 	if val, ok := annotations["vault.security.banzaicloud.io/log-level"]; ok {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Removed the remains of the annotation `vault.security.banzaicloud.io/mutate-configmap`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The logic for it has been already removed for some time, since the feature to mutate configmaps can be enabled on the webhook level in the chart (it is disabled by default).

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Removing the annotation from the docs is [on the way](https://github.com/bank-vaults/bank-vaults.dev/pull/106).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- ~Related Helm chart(s) updated (if needed)~