### PR TITLE
feat: Add configurable AWS KMS encryption context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /bin/
 /build/
 /tmp/
+/vendor/

--- a/cmd/bank-vaults/common.go
+++ b/cmd/bank-vaults/common.go
@@ -107,6 +107,7 @@ func kvStoreForConfig(cfg *viper.Viper) (kv.Service, error) {
 		s3SSEAlgos := cfg.GetStringSlice(cfgAWS3SSEAlgo)
 		kmsRegions := cfg.GetStringSlice(cfgAWSKMSRegion)
 		kmsKeyIDs := cfg.GetStringSlice(cfgAWSKMSKeyID)
+		kmsKeyEncryptionContext := cfg.GetStringMapString(cfgAWSKMSEncryptionContext)
 
 		// Try to use the standard AWS region
 		// setting if not provided for KMS/S3
@@ -164,7 +165,7 @@ func kvStoreForConfig(cfg *viper.Viper) (kv.Service, error) {
 				return nil, errors.Wrap(err, "error creating AWS S3 kv store")
 			}
 			if s3SSEAlgos[i] == "" {
-				kmsService, err := awskms.New(s3Service, kmsRegions[i], kmsKeyIDs[i])
+				kmsService, err := awskms.New(s3Service, kmsRegions[i], kmsKeyIDs[i], kmsKeyEncryptionContext)
 				if err != nil {
 					return nil, errors.Wrap(err, "error creating AWS KMS kv store")
 				}

--- a/cmd/bank-vaults/main.go
+++ b/cmd/bank-vaults/main.go
@@ -62,8 +62,9 @@ const (
 )
 
 const (
-	cfgAWSKMSRegion = "aws-kms-region"
-	cfgAWSKMSKeyID  = "aws-kms-key-id"
+	cfgAWSKMSRegion            = "aws-kms-region"
+	cfgAWSKMSKeyID             = "aws-kms-key-id"
+	cfgAWSKMSEncryptionContext = "aws-kms-encryption-context"
 )
 
 const (
@@ -118,6 +119,10 @@ const (
 // We need to pre-create a value and bind the the flag to this until
 // https://github.com/spf13/viper/issues/608 gets fixed.
 var k8sSecretLabels map[string]string
+
+var awsKmsEncryptionContext = map[string]string{
+	"Tool": "bank-vaults",
+}
 
 var rootCmd = &cobra.Command{
 	Use:   "bank-vaults",
@@ -222,6 +227,7 @@ func init() {
 	// AWS KMS flags
 	configStringSliceVar(rootCmd, cfgAWSKMSRegion, nil, "The region of the AWS KMS key to encrypt values")
 	configStringSliceVar(rootCmd, cfgAWSKMSKeyID, nil, "The ID or ARN of the AWS KMS key to encrypt values")
+	configStringMapVar(rootCmd, cfgAWSKMSEncryptionContext, &awsKmsEncryptionContext, "The encryption context that AWS KMS will use to encrypt values")
 
 	// AWS S3 Object Storage flags
 	configStringSliceVar(rootCmd, cfgAWSS3Region, []string{"us-east-1"}, "The region to use for storing values in AWS S3")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
This PR introduced a new feature allowing you to configure the AWS KMS encryption context

### Why?
In some cases, existing recovery/unseal keys may have been encrypted with a different encryption context

### Additional context
In our use case, we have an existing vault cluster that has existing unseal keys that are encrypted with a custom encryption context. This feature will allow us to migrate this vault cluster to be managed by bank-vaults.


### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

