### PR TITLE
Added template binary to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN apk add --update --no-cache ca-certificates tzdata
 # RUN pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so --keypairgen --key-type rsa:2048 --pin banzai --token-label bank-vaults --label bank-vaults
 
 COPY --from=builder /usr/local/bin/bank-vaults /usr/local/bin/bank-vaults
+COPY --from=builder /usr/local/bin/template /usr/local/bin/template
 
 USER 65534
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added template binary to the docker image

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The template binary was left out from the Dockerfile when it was refactored, causing an error in the `config-templating` initContainer when started a Vault with the operator:

```
failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "template": executable file not found in $PATH: unknown         
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~