### PR TITLE
ci: dependabot to ignore viper and gocloud.dev

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,9 @@ updates:
       - "area/dependencies"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "github.com/spf13/viper"
+      - dependency-name: "gocloud.dev"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #1990
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Dependabot to ignore upgrading viper and gocloud.dev until we figure out how to solve the related lowercasing issue.